### PR TITLE
Rename to chaosbringer and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 chaos-report.json
 *.log
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @luna_ui/playwright-chaos
+# chaosbringer
 
 Playwright-based chaos testing library for web applications. Uses accessibility-aware weighted random actions to discover errors.
 
@@ -15,7 +15,7 @@ Playwright-based chaos testing library for web applications. Uses accessibility-
 ## Installation
 
 ```bash
-pnpm add @luna_ui/playwright-chaos playwright @playwright/test
+pnpm add chaosbringer playwright @playwright/test
 ```
 
 ## Playwright Test Integration
@@ -24,7 +24,7 @@ pnpm add @luna_ui/playwright-chaos playwright @playwright/test
 
 ```typescript
 import { test, expect } from '@playwright/test';
-import { chaosTest, chaosExpect } from '@luna_ui/playwright-chaos';
+import { chaosTest, chaosExpect } from 'chaosbringer';
 
 // Use the pre-configured chaosTest
 chaosTest('chaos test homepage', async ({ page, chaos }) => {
@@ -43,7 +43,7 @@ chaosTest('chaos test homepage', async ({ page, chaos }) => {
 
 ```typescript
 import { test as base } from '@playwright/test';
-import { withChaos, type ChaosFixtures } from '@luna_ui/playwright-chaos';
+import { withChaos, type ChaosFixtures } from 'chaosbringer';
 
 const test = base.extend<ChaosFixtures>(withChaos({
   maxActionsPerPage: 10,
@@ -77,16 +77,16 @@ chaosTest('crawl entire site', async ({ chaos }) => {
 
 ```bash
 # Basic crawl
-chaos-crawler --url http://localhost:3000
+chaosbringer --url http://localhost:3000
 
 # With analytics errors ignored (recommended for dev mode)
-chaos-crawler --url http://localhost:3000 --ignore-analytics
+chaosbringer --url http://localhost:3000 --ignore-analytics
 
 # CI mode with strict checking
-chaos-crawler --url http://localhost:3000 --strict --compact --ignore-analytics
+chaosbringer --url http://localhost:3000 --strict --compact --ignore-analytics
 
 # With screenshots
-chaos-crawler --url https://docs.example.com --max-pages 20 --screenshots
+chaosbringer --url https://docs.example.com --max-pages 20 --screenshots
 ```
 
 ### CLI Options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1093 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.59.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      playwright:
+        specifier: ^1.52.0
+        version: 1.59.1
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.7
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 /**
- * Chaos Crawler CLI
+ * Chaosbringer CLI
  *
  * Usage:
  *   pnpm tsx src/cli.ts [options]
- *   chaos-crawler [options]  (when installed globally)
+ *   chaosbringer [options]  (when installed globally)
  *
  * Options:
  *   --url <url>           Base URL to crawl (required)
@@ -55,10 +55,10 @@ const { values, positionals } = parseArgs({
 
 if (values.help) {
   console.log(`
-Chaos Crawler - Playwright-based chaos testing tool
+Chaosbringer - Playwright-based chaos testing tool
 
 USAGE:
-  chaos-crawler --url <url> [options]
+  chaosbringer --url <url> [options]
 
 OPTIONS:
   --url <url>           Base URL to crawl (required)
@@ -84,19 +84,19 @@ OPTIONS:
 
 EXAMPLES:
   # Basic crawl
-  chaos-crawler --url http://localhost:3000
+  chaosbringer --url http://localhost:3000
 
   # With screenshots and limited pages
-  chaos-crawler --url https://docs.example.com --max-pages 20 --screenshots
+  chaosbringer --url https://docs.example.com --max-pages 20 --screenshots
 
   # CI mode with strict checking (ignore analytics errors)
-  chaos-crawler --url http://localhost:3000 --strict --compact --ignore-analytics
+  chaosbringer --url http://localhost:3000 --strict --compact --ignore-analytics
 
   # With detailed logging to file
-  chaos-crawler --url http://localhost:3000 --log-file crawl.log --log-level debug
+  chaosbringer --url http://localhost:3000 --log-file crawl.log --log-level debug
 
   # Exclude patterns and ignore specific errors
-  chaos-crawler --url http://localhost:3000 --exclude "/api/" --ignore-error "third-party"
+  chaosbringer --url http://localhost:3000 --exclude "/api/" --ignore-error "third-party"
 `);
   process.exit(0);
 }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -25,6 +25,13 @@ import type {
   SpaIssueInfo,
 } from "./types.js";
 import { Logger, createNullLogger } from "./logger.js";
+import {
+  matchesAnyPattern,
+  matchesSpaPattern as matchesSpaPatternPure,
+  isExternalUrl as isExternalUrlPure,
+  escapeSelector as escapeSelectorPure,
+  summarizePages,
+} from "./filters.js";
 
 const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl">> = {
   maxPages: 50,
@@ -273,49 +280,20 @@ export class ChaosCrawler {
   }
 
   private shouldExclude(url: string): boolean {
-    const patterns = this.options.excludePatterns || [];
-    return patterns.some((pattern) => {
-      try {
-        return new RegExp(pattern).test(url);
-      } catch {
-        return false;
-      }
-    });
+    return matchesAnyPattern(url, this.options.excludePatterns);
   }
 
   /** Check if URL matches SPA patterns */
   private matchesSpaPattern(url: string): string | null {
-    const patterns = this.options.spaPatterns || [];
-    for (const pattern of patterns) {
-      try {
-        if (new RegExp(pattern).test(url)) {
-          return pattern;
-        }
-      } catch {
-        // Invalid regex, skip
-      }
-    }
-    return null;
+    return matchesSpaPatternPure(url, this.options.spaPatterns);
   }
 
   private shouldIgnoreError(message: string): boolean {
-    const patterns = this.options.ignoreErrorPatterns || [];
-    return patterns.some((pattern) => {
-      try {
-        return new RegExp(pattern, "i").test(message);
-      } catch {
-        return false;
-      }
-    });
+    return matchesAnyPattern(message, this.options.ignoreErrorPatterns, "i");
   }
 
   private isExternalUrl(url: string): boolean {
-    try {
-      const urlOrigin = new URL(url).origin;
-      return urlOrigin !== this.baseOrigin;
-    } catch {
-      return false;
-    }
+    return isExternalUrlPure(url, this.baseOrigin);
   }
 
   private async setupNavigationBlocking(page: Page): Promise<void> {
@@ -846,7 +824,7 @@ export class ChaosCrawler {
   }
 
   private escapeSelector(text: string): string {
-    return text.replace(/"/g, '\\"').replace(/\n/g, " ").slice(0, 50);
+    return escapeSelectorPure(text);
   }
 
   /**
@@ -1026,50 +1004,6 @@ export class ChaosCrawler {
   }
 
   private calculateSummary(): CrawlSummary {
-    const successPages = this.results.filter((r) => r.status === "success").length;
-    const errorPages = this.results.filter((r) => r.status === "error").length;
-    const timeoutPages = this.results.filter((r) => r.status === "timeout").length;
-    const recoveredPages = this.results.filter((r) => r.status === "recovered").length;
-
-    const allErrors = this.results.flatMap((r) => r.errors);
-    const consoleErrors = allErrors.filter((e) => e.type === "console").length;
-    const networkErrors = allErrors.filter((e) => e.type === "network").length;
-    const jsExceptions = allErrors.filter((e) => e.type === "exception").length;
-    const unhandledRejections = allErrors.filter((e) => e.type === "unhandled-rejection").length;
-
-    const loadTimes = this.results.map((r) => r.loadTime);
-    const avgLoadTime = loadTimes.length > 0 ? loadTimes.reduce((a, b) => a + b, 0) / loadTimes.length : 0;
-
-    // Calculate average metrics
-    const metricsResults = this.results.filter((r) => r.metrics);
-    let avgMetrics: CrawlSummary["avgMetrics"] = undefined;
-
-    if (metricsResults.length > 0) {
-      const ttfbs = metricsResults.map((r) => r.metrics!.ttfb).filter((v): v is number => v !== undefined);
-      const fcps = metricsResults.map((r) => r.metrics!.fcp).filter((v): v is number => v !== undefined);
-      const lcps = metricsResults.map((r) => r.metrics!.lcp).filter((v): v is number => v !== undefined);
-
-      if (ttfbs.length > 0 || fcps.length > 0 || lcps.length > 0) {
-        avgMetrics = {
-          ttfb: ttfbs.length > 0 ? ttfbs.reduce((a, b) => a + b, 0) / ttfbs.length : 0,
-          fcp: fcps.length > 0 ? fcps.reduce((a, b) => a + b, 0) / fcps.length : 0,
-          lcp: lcps.length > 0 ? lcps.reduce((a, b) => a + b, 0) / lcps.length : 0,
-        };
-      }
-    }
-
-    return {
-      successPages,
-      errorPages,
-      timeoutPages,
-      recoveredPages,
-      consoleErrors,
-      networkErrors,
-      jsExceptions,
-      unhandledRejections,
-      avgLoadTime,
-      avgMetrics,
-      discovery: this.discoveryMetrics,
-    };
+    return summarizePages(this.results, this.discoveryMetrics);
   }
 }

--- a/src/filters.test.ts
+++ b/src/filters.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchesAnyPattern,
+  matchesSpaPattern,
+  isExternalUrl,
+  escapeSelector,
+  summarizePages,
+} from "./filters.js";
+import type { PageResult } from "./types.js";
+
+describe("matchesAnyPattern", () => {
+  it("returns false when no patterns given", () => {
+    expect(matchesAnyPattern("anything", undefined)).toBe(false);
+    expect(matchesAnyPattern("anything", [])).toBe(false);
+  });
+
+  it("matches when any pattern hits", () => {
+    expect(matchesAnyPattern("/api/users", ["\\bapi\\b", "nope"])).toBe(true);
+  });
+
+  it("returns false when no pattern hits", () => {
+    expect(matchesAnyPattern("/home", ["\\bapi\\b"])).toBe(false);
+  });
+
+  it("respects regex flags (case insensitive)", () => {
+    expect(matchesAnyPattern("Analytics failed", ["analytics"], "i")).toBe(true);
+    expect(matchesAnyPattern("Analytics failed", ["analytics"])).toBe(false);
+  });
+
+  it("skips invalid regex patterns without throwing", () => {
+    expect(matchesAnyPattern("/home", ["(unterminated", "home"])).toBe(true);
+    expect(matchesAnyPattern("/home", ["(unterminated"])).toBe(false);
+  });
+});
+
+describe("matchesSpaPattern", () => {
+  it("returns the first matching pattern string", () => {
+    expect(matchesSpaPattern("/browser_router/deep", ["browser_router", "hash"])).toBe(
+      "browser_router"
+    );
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(matchesSpaPattern("/static", ["browser_router"])).toBeNull();
+  });
+
+  it("returns null for empty / undefined patterns", () => {
+    expect(matchesSpaPattern("/x", undefined)).toBeNull();
+    expect(matchesSpaPattern("/x", [])).toBeNull();
+  });
+
+  it("skips invalid regex patterns", () => {
+    expect(matchesSpaPattern("/spa", ["(bad", "spa"])).toBe("spa");
+  });
+});
+
+describe("isExternalUrl", () => {
+  const base = "http://localhost:3000";
+
+  it("returns false for same origin", () => {
+    expect(isExternalUrl("http://localhost:3000/path", base)).toBe(false);
+  });
+
+  it("returns true for different host", () => {
+    expect(isExternalUrl("http://example.com/", base)).toBe(true);
+  });
+
+  it("returns true for different port", () => {
+    expect(isExternalUrl("http://localhost:4000/", base)).toBe(true);
+  });
+
+  it("returns true for different scheme", () => {
+    expect(isExternalUrl("https://localhost:3000/", base)).toBe(true);
+  });
+
+  it("returns false for invalid URLs", () => {
+    expect(isExternalUrl("not a url", base)).toBe(false);
+  });
+});
+
+describe("escapeSelector", () => {
+  it("escapes double quotes", () => {
+    expect(escapeSelector('say "hi"')).toBe('say \\"hi\\"');
+  });
+
+  it("replaces newlines with spaces", () => {
+    expect(escapeSelector("line1\nline2")).toBe("line1 line2");
+  });
+
+  it("truncates to 50 chars", () => {
+    const input = "x".repeat(60);
+    expect(escapeSelector(input)).toHaveLength(50);
+  });
+});
+
+function makeResult(overrides: Partial<PageResult> = {}): PageResult {
+  return {
+    url: "http://localhost/p",
+    status: "success",
+    loadTime: 100,
+    errors: [],
+    warnings: [],
+    links: [],
+    ...overrides,
+  };
+}
+
+describe("summarizePages", () => {
+  it("returns zeros for empty input", () => {
+    const s = summarizePages([]);
+    expect(s.successPages).toBe(0);
+    expect(s.errorPages).toBe(0);
+    expect(s.avgLoadTime).toBe(0);
+    expect(s.avgMetrics).toBeUndefined();
+  });
+
+  it("counts pages by status", () => {
+    const s = summarizePages([
+      makeResult({ status: "success" }),
+      makeResult({ status: "success" }),
+      makeResult({ status: "error" }),
+      makeResult({ status: "timeout" }),
+      makeResult({ status: "recovered" }),
+    ]);
+    expect(s.successPages).toBe(2);
+    expect(s.errorPages).toBe(1);
+    expect(s.timeoutPages).toBe(1);
+    expect(s.recoveredPages).toBe(1);
+  });
+
+  it("counts errors by type across all pages", () => {
+    const s = summarizePages([
+      makeResult({
+        errors: [
+          { type: "console", message: "a", timestamp: 0 },
+          { type: "network", message: "b", timestamp: 0 },
+        ],
+      }),
+      makeResult({
+        errors: [
+          { type: "exception", message: "c", timestamp: 0 },
+          { type: "unhandled-rejection", message: "d", timestamp: 0 },
+          { type: "console", message: "e", timestamp: 0 },
+        ],
+      }),
+    ]);
+    expect(s.consoleErrors).toBe(2);
+    expect(s.networkErrors).toBe(1);
+    expect(s.jsExceptions).toBe(1);
+    expect(s.unhandledRejections).toBe(1);
+  });
+
+  it("averages load times", () => {
+    const s = summarizePages([
+      makeResult({ loadTime: 100 }),
+      makeResult({ loadTime: 200 }),
+      makeResult({ loadTime: 300 }),
+    ]);
+    expect(s.avgLoadTime).toBe(200);
+  });
+
+  it("averages performance metrics, ignoring missing values", () => {
+    const s = summarizePages([
+      makeResult({ metrics: { ttfb: 10, fcp: 100, lcp: 200 } }),
+      makeResult({ metrics: { ttfb: 30, fcp: 300 } }),
+    ]);
+    expect(s.avgMetrics).toEqual({ ttfb: 20, fcp: 200, lcp: 200 });
+  });
+
+  it("leaves avgMetrics undefined when no page has metrics", () => {
+    const s = summarizePages([makeResult({}), makeResult({})]);
+    expect(s.avgMetrics).toBeUndefined();
+  });
+
+  it("passes discovery through unchanged", () => {
+    const discovery = {
+      extractedLinks: 5,
+      clickedLinks: 2,
+      uniquePages: 3,
+      deadLinks: [],
+      spaIssues: [],
+    };
+    const s = summarizePages([], discovery);
+    expect(s.discovery).toBe(discovery);
+  });
+});

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure helpers for URL / error filtering and summary calculation.
+ * Extracted from ChaosCrawler so they can be tested without Playwright.
+ */
+
+import type { CrawlSummary, PageResult, DiscoveryMetrics } from "./types.js";
+
+/** True if any pattern (regex string) matches `value`. Invalid regex is skipped. */
+export function matchesAnyPattern(
+  value: string,
+  patterns: readonly string[] | undefined,
+  flags?: string
+): boolean {
+  if (!patterns || patterns.length === 0) return false;
+  for (const pattern of patterns) {
+    try {
+      if (new RegExp(pattern, flags).test(value)) return true;
+    } catch {
+      // Invalid regex, skip
+    }
+  }
+  return false;
+}
+
+/** Return the first SPA pattern that matches the URL, or null. */
+export function matchesSpaPattern(
+  url: string,
+  patterns: readonly string[] | undefined
+): string | null {
+  if (!patterns) return null;
+  for (const pattern of patterns) {
+    try {
+      if (new RegExp(pattern).test(url)) return pattern;
+    } catch {
+      // Invalid regex, skip
+    }
+  }
+  return null;
+}
+
+/** True if `url` has a different origin from `baseOrigin`. Invalid URL → false. */
+export function isExternalUrl(url: string, baseOrigin: string): boolean {
+  try {
+    return new URL(url).origin !== baseOrigin;
+  } catch {
+    return false;
+  }
+}
+
+/** Escape text for use in a Playwright selector string. */
+export function escapeSelector(text: string): string {
+  return text.replace(/"/g, '\\"').replace(/\n/g, " ").slice(0, 50);
+}
+
+/** Compute summary statistics from a list of page results. */
+export function summarizePages(
+  results: readonly PageResult[],
+  discovery?: DiscoveryMetrics
+): CrawlSummary {
+  const successPages = results.filter((r) => r.status === "success").length;
+  const errorPages = results.filter((r) => r.status === "error").length;
+  const timeoutPages = results.filter((r) => r.status === "timeout").length;
+  const recoveredPages = results.filter((r) => r.status === "recovered").length;
+
+  const allErrors = results.flatMap((r) => r.errors);
+  const consoleErrors = allErrors.filter((e) => e.type === "console").length;
+  const networkErrors = allErrors.filter((e) => e.type === "network").length;
+  const jsExceptions = allErrors.filter((e) => e.type === "exception").length;
+  const unhandledRejections = allErrors.filter((e) => e.type === "unhandled-rejection").length;
+
+  const loadTimes = results.map((r) => r.loadTime);
+  const avgLoadTime =
+    loadTimes.length > 0 ? loadTimes.reduce((a, b) => a + b, 0) / loadTimes.length : 0;
+
+  let avgMetrics: CrawlSummary["avgMetrics"] = undefined;
+  const metricsResults = results.filter((r) => r.metrics);
+  if (metricsResults.length > 0) {
+    const ttfbs = metricsResults
+      .map((r) => r.metrics!.ttfb)
+      .filter((v): v is number => v !== undefined);
+    const fcps = metricsResults
+      .map((r) => r.metrics!.fcp)
+      .filter((v): v is number => v !== undefined);
+    const lcps = metricsResults
+      .map((r) => r.metrics!.lcp)
+      .filter((v): v is number => v !== undefined);
+
+    if (ttfbs.length > 0 || fcps.length > 0 || lcps.length > 0) {
+      avgMetrics = {
+        ttfb: ttfbs.length > 0 ? ttfbs.reduce((a, b) => a + b, 0) / ttfbs.length : 0,
+        fcp: fcps.length > 0 ? fcps.reduce((a, b) => a + b, 0) / fcps.length : 0,
+        lcp: lcps.length > 0 ? lcps.reduce((a, b) => a + b, 0) / lcps.length : 0,
+      };
+    }
+  }
+
+  return {
+    successPages,
+    errorPages,
+    timeoutPages,
+    recoveredPages,
+    consoleErrors,
+    networkErrors,
+    jsExceptions,
+    unhandledRejections,
+    avgLoadTime,
+    avgMetrics,
+    discovery,
+  };
+}

--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -4,7 +4,7 @@
  * Usage:
  * ```typescript
  * import { test, expect } from '@playwright/test';
- * import { chaosTest, withChaos } from '@luna_ui/playwright-chaos/fixture';
+ * import { chaosTest, withChaos } from 'chaosbringer/fixture';
  *
  * // Option 1: Use chaosTest directly
  * chaosTest('chaos test homepage', async ({ page, chaos }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @luna_ui/playwright-chaos
+ * chaosbringer
  *
  * Playwright-based chaos testing library for web applications.
  * Inspired by monkey testing with additional features for error detection and reporting.

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFileSync, existsSync, unlinkSync } from "node:fs";
+import { Logger, createNullLogger } from "./logger.js";
+
+describe("Logger level filtering", () => {
+  it("skips entries below the configured level", () => {
+    const logger = new Logger({ level: "warn" });
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+    const levels = logger.getEntries().map((e) => e.level);
+    expect(levels).toEqual(["warn", "error"]);
+  });
+
+  it("default level is info (debug filtered)", () => {
+    const logger = new Logger();
+    logger.debug("d");
+    logger.info("i");
+    const levels = logger.getEntries().map((e) => e.level);
+    expect(levels).toEqual(["info"]);
+  });
+
+  it("records event name and data payload", () => {
+    const logger = new Logger();
+    logger.info("page_start", { url: "http://x/" });
+    const [entry] = logger.getEntries();
+    expect(entry.event).toBe("page_start");
+    expect(entry.data).toEqual({ url: "http://x/" });
+    expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("Logger file output", () => {
+  it("writes one JSON entry per line", async () => {
+    const path = join(tmpdir(), `chaos-log-${Date.now()}.log`);
+    try {
+      const logger = new Logger({ logFile: path, level: "debug" });
+      logger.info("a", { n: 1 });
+      logger.warn("b");
+      await logger.close();
+
+      expect(existsSync(path)).toBe(true);
+      const lines = readFileSync(path, "utf-8").trim().split("\n");
+      expect(lines).toHaveLength(2);
+      const first = JSON.parse(lines[0]);
+      expect(first.event).toBe("a");
+      expect(first.data).toEqual({ n: 1 });
+      expect(first.level).toBe("info");
+    } finally {
+      if (existsSync(path)) unlinkSync(path);
+    }
+  });
+
+  it("creates missing parent directories", async () => {
+    const dir = join(tmpdir(), `chaos-nested-${Date.now()}`, "deep");
+    const path = join(dir, "out.log");
+    try {
+      const logger = new Logger({ logFile: path });
+      logger.info("hi");
+      await logger.close();
+      expect(existsSync(path)).toBe(true);
+    } finally {
+      if (existsSync(path)) unlinkSync(path);
+    }
+  });
+});
+
+describe("createNullLogger", () => {
+  it("buffers only errors", () => {
+    const logger = createNullLogger();
+    logger.info("skipped");
+    logger.error("kept");
+    const levels = logger.getEntries().map((e) => e.level);
+    expect(levels).toEqual(["error"]);
+  });
+});
+
+describe("crawler-specific helpers", () => {
+  it("logPageComplete emits a summarised payload", () => {
+    const logger = new Logger();
+    logger.logPageComplete({
+      url: "http://x/",
+      status: "success",
+      statusCode: 200,
+      loadTime: 42,
+      errors: [],
+      warnings: [],
+      links: ["a", "b"],
+    });
+    const [entry] = logger.getEntries();
+    expect(entry.event).toBe("page_complete");
+    expect(entry.data).toMatchObject({
+      url: "http://x/",
+      status: "success",
+      statusCode: 200,
+      loadTime: 42,
+      errorCount: 0,
+      linkCount: 2,
+    });
+  });
+
+  it("logBlockedNavigation uses warn level", () => {
+    const logger = new Logger({ level: "debug" });
+    logger.logBlockedNavigation("http://evil/");
+    const [entry] = logger.getEntries();
+    expect(entry.level).toBe("warn");
+    expect(entry.event).toBe("blocked_navigation");
+    expect(entry.data).toEqual({ url: "http://evil/" });
+  });
+});

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFileSync, existsSync, unlinkSync } from "node:fs";
+import { formatCompactReport, getExitCode, saveReport } from "./reporter.js";
+import type { CrawlReport, CrawlSummary } from "./types.js";
+
+function makeSummary(overrides: Partial<CrawlSummary> = {}): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    avgLoadTime: 0,
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://localhost:3000",
+    startTime: 0,
+    endTime: 1000,
+    duration: 1000,
+    pagesVisited: 1,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: makeSummary(),
+    ...overrides,
+  };
+}
+
+describe("getExitCode", () => {
+  it("returns 0 for a clean report", () => {
+    expect(getExitCode(makeReport())).toBe(0);
+  });
+
+  it("returns 1 when there are error pages", () => {
+    expect(getExitCode(makeReport({ summary: makeSummary({ errorPages: 1 }) }))).toBe(1);
+  });
+
+  it("returns 1 when there are timeout pages", () => {
+    expect(getExitCode(makeReport({ summary: makeSummary({ timeoutPages: 1 }) }))).toBe(1);
+  });
+
+  it("returns 0 for console-only errors in non-strict mode", () => {
+    expect(getExitCode(makeReport({ summary: makeSummary({ consoleErrors: 5 }) }))).toBe(0);
+  });
+
+  it("returns 1 for console errors in strict mode", () => {
+    expect(
+      getExitCode(makeReport({ summary: makeSummary({ consoleErrors: 1 }) }), true)
+    ).toBe(1);
+  });
+
+  it("returns 1 for JS exceptions in strict mode", () => {
+    expect(
+      getExitCode(makeReport({ summary: makeSummary({ jsExceptions: 1 }) }), true)
+    ).toBe(1);
+  });
+
+  it("returns 0 for clean report in strict mode", () => {
+    expect(getExitCode(makeReport(), true)).toBe(0);
+  });
+});
+
+describe("formatCompactReport", () => {
+  it("shows PASS for clean report", () => {
+    const out = formatCompactReport(makeReport({ pagesVisited: 10 }));
+    expect(out).toContain("[PASS]");
+    expect(out).toContain("10 pages");
+  });
+
+  it("shows FAIL when there are error pages", () => {
+    const report = makeReport({
+      summary: makeSummary({ errorPages: 2, consoleErrors: 3 }),
+    });
+    const out = formatCompactReport(report);
+    expect(out).toContain("[FAIL]");
+  });
+
+  it("aggregates error counts", () => {
+    const report = makeReport({
+      summary: makeSummary({ consoleErrors: 2, networkErrors: 1, jsExceptions: 3 }),
+    });
+    const out = formatCompactReport(report);
+    expect(out).toContain("6 errors");
+  });
+
+  it("includes metrics when present", () => {
+    const report = makeReport({
+      summary: makeSummary({ avgMetrics: { ttfb: 50, fcp: 120, lcp: 200 } }),
+    });
+    const out = formatCompactReport(report);
+    expect(out).toContain("TTFB=50ms");
+    expect(out).toContain("FCP=120ms");
+  });
+
+  it("omits metrics line when not present", () => {
+    const out = formatCompactReport(makeReport());
+    expect(out).not.toContain("Metrics");
+  });
+});
+
+describe("saveReport", () => {
+  it("writes a readable JSON file", () => {
+    const path = join(tmpdir(), `chaos-test-${Date.now()}.json`);
+    try {
+      const report = makeReport({ pagesVisited: 7 });
+      saveReport(report, path);
+      expect(existsSync(path)).toBe(true);
+      const parsed = JSON.parse(readFileSync(path, "utf-8"));
+      expect(parsed.pagesVisited).toBe(7);
+      expect(parsed.baseUrl).toBe("http://localhost:3000");
+    } finally {
+      if (existsSync(path)) unlinkSync(path);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Remove lingering `@luna_ui/playwright-chaos` references and rename the CLI from `chaos-crawler` to `chaosbringer` in docs and help text.
- Ignore build artifacts (`dist/`, `node_modules/`) and commit `pnpm-lock.yaml`.
- Extract pure URL/error filtering and summary helpers from `ChaosCrawler` into `src/filters.ts`, and add 45 vitest cases covering filters, reporter exit codes / compact output, and logger level/file behaviour. Exclude `*.test.ts` from the published build.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` (45 passed)
- [x] `node dist/cli.js --help` shows new `chaosbringer` name

https://claude.ai/code/session_01GGegJKyzEqkq4yTn2py43e