### PR TITLE
Fix error attribution, recovery status, and fault body defaults

### DIFF
--- a/fixtures/runner/diag-actions.ts
+++ b/fixtures/runner/diag-actions.ts
@@ -1,0 +1,30 @@
+/**
+ * Count what kinds of chaos actions happen on each page, seeded.
+ * If interactive pages produce >70% scrolls we're wasting budget.
+ */
+
+import { ChaosCrawler } from "../../src/crawler.js";
+import { startFixtureServer } from "../site/server.js";
+
+const { url, close } = await startFixtureServer(0);
+
+const seeds = [1, 2, 3, 4, 5];
+for (const seed of seeds) {
+  const crawler = new ChaosCrawler({
+    baseUrl: url,
+    maxPages: 3,
+    maxActionsPerPage: 10,
+    headless: true,
+    seed,
+  });
+  const report = await crawler.start();
+  const byType = new Map<string, number>();
+  for (const a of report.actions) {
+    byType.set(a.type, (byType.get(a.type) ?? 0) + 1);
+  }
+  const total = report.actions.length;
+  const entries = [...byType.entries()].map(([t, n]) => `${t}=${n} (${Math.round((n / total) * 100)}%)`);
+  console.log(`seed=${seed}  total=${total}  ${entries.join(", ")}`);
+}
+
+await close();

--- a/fixtures/runner/diag-attribution.ts
+++ b/fixtures/runner/diag-attribution.ts
@@ -1,0 +1,36 @@
+/**
+ * Confirm that errors fired after a chaos-action navigation record the
+ * navigated URL in `error.url`, even though they end up in the originating
+ * page's PageResult.
+ */
+
+import { ChaosCrawler } from "../../src/crawler.js";
+import { startFixtureServer } from "../site/server.js";
+
+const { url, close } = await startFixtureServer(0);
+
+const crawler = new ChaosCrawler({
+  baseUrl: url,
+  maxPages: 6,
+  maxActionsPerPage: 1,
+  headless: true,
+  seed: 123,
+  faultInjection: [
+    { name: "api-500", urlPattern: "/api/data", fault: { kind: "status", status: 500 } },
+  ],
+});
+
+try {
+  const report = await crawler.start();
+  for (const page of report.pages) {
+    for (const err of page.errors) {
+      if (err.url !== page.url) {
+        console.log(`  [drifted] page=${page.url} error.url=${err.url} type=${err.type} msg=${err.message.slice(0, 60)}`);
+      } else {
+        console.log(`  [ok     ] page=${page.url} type=${err.type}`);
+      }
+    }
+  }
+} finally {
+  await close();
+}

--- a/fixtures/runner/diag-delay.ts
+++ b/fixtures/runner/diag-delay.ts
@@ -1,0 +1,28 @@
+/**
+ * Sanity-check the "delay" fault kind: inject 500ms latency on /api/data
+ * and confirm the /api-consumer page still resolves the fetch (i.e. the
+ * request continues, it's just slow).
+ */
+
+import { ChaosCrawler } from "../../src/crawler.js";
+import { startFixtureServer } from "../site/server.js";
+
+const { url, close } = await startFixtureServer(0);
+
+const t0 = Date.now();
+const crawler = new ChaosCrawler({
+  baseUrl: `${url}/api-consumer`,
+  maxPages: 1,
+  maxActionsPerPage: 0,
+  headless: true,
+  seed: 1,
+  faultInjection: [
+    { name: "slow-api", urlPattern: "/api/data", fault: { kind: "delay", ms: 500 } },
+  ],
+});
+const report = await crawler.start();
+const elapsed = Date.now() - t0;
+console.log("pages:", report.pages.map((p) => `${p.url} status=${p.status}`));
+console.log("faultInjections:", report.faultInjections);
+console.log("elapsed:", elapsed, "ms (should be >= 500 due to delay)");
+await close();

--- a/fixtures/runner/diag-fault-recovery.ts
+++ b/fixtures/runner/diag-fault-recovery.ts
@@ -1,0 +1,45 @@
+/**
+ * If we inject a 500 on a page's HTML (not just an API), does the crawler's
+ * dead-link / recovery path engage? It should: status >= 500 is a recovery
+ * trigger in crawler.ts.
+ */
+
+import { ChaosCrawler } from "../../src/crawler.js";
+import { startFixtureServer } from "../site/server.js";
+
+const { url, close } = await startFixtureServer(0);
+
+const crawler = new ChaosCrawler(
+  {
+    baseUrl: url,
+    maxPages: 4,
+    maxActionsPerPage: 1,
+    headless: true,
+    seed: 7,
+    faultInjection: [
+      {
+        name: "kill-about",
+        urlPattern: "/about$",
+        fault: { kind: "status", status: 500, body: "<h1>500</h1>", contentType: "text/html" },
+      },
+    ],
+  },
+  {
+    onPageComplete: (r) =>
+      console.log(
+        `${r.status.padEnd(9)} statusCode=${r.statusCode} ${r.url}  recovery=${r.recovery ? "yes" : "no"}`
+      ),
+  }
+);
+
+try {
+  const report = await crawler.start();
+  console.log("\nrecoveryCount:", report.recoveryCount);
+  console.log("faultInjections:", report.faultInjections);
+  console.log(
+    "deadLinks:",
+    report.summary.discovery?.deadLinks?.map((d) => `${d.url} (${d.statusCode})`),
+  );
+} finally {
+  await close();
+}

--- a/fixtures/runner/diag-routes.ts
+++ b/fixtures/runner/diag-routes.ts
@@ -1,0 +1,65 @@
+/**
+ * Diagnostic run: log every request and who initiated it, to investigate
+ * why /api/data matched twice in the earlier fault-demo run.
+ *
+ * `page.on("request")` is passive — it does not interfere with the route
+ * handler, so we get a faithful transcript.
+ */
+
+import { ChaosCrawler } from "../../src/crawler.js";
+import { startFixtureServer } from "../site/server.js";
+
+const { url, close } = await startFixtureServer(0);
+console.log(`[fixture] ${url}`);
+
+const crawler = new ChaosCrawler(
+  {
+    baseUrl: url,
+    maxPages: 6,
+    maxActionsPerPage: 1,
+    headless: true,
+    seed: 123,
+    faultInjection: [
+      {
+        name: "api-500",
+        urlPattern: "/api/data",
+        fault: { kind: "status", status: 500, body: "boom" },
+      },
+    ],
+  },
+  {
+    onPageStart: (u) => console.log(`\n[page-start] ${u}`),
+    onPageComplete: (r) => console.log(`[page-done ] ${r.status} ${r.url} errors=${r.errors.length}`),
+  }
+);
+
+// Patch newPage so every new Playwright page logs its requests.
+const origStart = crawler.start.bind(crawler);
+(crawler as any).start = async function () {
+  const ctxPromise = (async () => {
+    // Wait for context to be created by polling.
+    while (!(crawler as any).context) await new Promise((r) => setTimeout(r, 10));
+    const ctx = (crawler as any).context;
+    ctx.on("page", (page: any) => {
+      page.on("request", (req: any) => {
+        const rurl = req.url();
+        if (rurl.includes("/api/")) {
+          const frame = req.frame();
+          console.log(
+            `  [req] ${req.method()} ${rurl} type=${req.resourceType()} frame=${frame.url()} isNav=${req.isNavigationRequest()}`
+          );
+        }
+      });
+    });
+  })();
+  const result = await origStart();
+  await ctxPromise;
+  return result;
+};
+
+try {
+  const report = await crawler.start();
+  console.log("\n[faultInjections]", report.faultInjections);
+} finally {
+  await close();
+}

--- a/fixtures/runner/e2e.test.ts
+++ b/fixtures/runner/e2e.test.ts
@@ -71,6 +71,74 @@ describe("ChaosCrawler against fixture site", () => {
     expect(report.blockedExternalNavigations).toBeGreaterThanOrEqual(0);
   }, 120000);
 
+  it("marks a 500-injected page as recovered and fires onPageComplete with the final status", async () => {
+    const seen: Array<{ url: string; status: string }> = [];
+    const crawler = new ChaosCrawler(
+      {
+        baseUrl: server.url,
+        maxPages: 3,
+        maxActionsPerPage: 1,
+        headless: true,
+        seed: 7,
+        faultInjection: [
+          {
+            name: "kill-about",
+            urlPattern: "/about$",
+            fault: { kind: "status", status: 500, body: "<h1>500</h1>", contentType: "text/html" },
+          },
+        ],
+      },
+      {
+        onPageComplete: (r) => seen.push({ url: r.url, status: r.status }),
+      }
+    );
+    const report = await crawler.start();
+    const aboutEvent = seen.find((s) => s.url.endsWith("/about"));
+    expect(aboutEvent?.status).toBe("recovered");
+
+    const aboutPage = report.pages.find((p) => p.url.endsWith("/about"));
+    expect(aboutPage?.status).toBe("recovered");
+    expect(aboutPage?.recovery).toBeDefined();
+    expect(report.recoveryCount).toBeGreaterThanOrEqual(1);
+  }, 120000);
+
+  it("attributes errors fired after chaos-action navigation to the real URL", async () => {
+    // Seed 123 + home's chaos action reliably clicks into /api-consumer.
+    // The /api/data console error should then record error.url = /api-consumer,
+    // not the home URL, even if it lives in home's PageResult.
+    const crawler = new ChaosCrawler({
+      baseUrl: server.url,
+      maxPages: 2,
+      maxActionsPerPage: 1,
+      headless: true,
+      seed: 123,
+      faultInjection: [
+        {
+          name: "api-500",
+          urlPattern: "/api/data$",
+          fault: { kind: "status", status: 500, body: '{"error":500}' },
+        },
+      ],
+    });
+    const report = await crawler.start();
+
+    const apiErrors = report.pages.flatMap((p) =>
+      p.errors.filter((e) => e.url?.endsWith("/api-consumer") || e.message.includes("/api/data"))
+    );
+    // Each error we attribute via /api/data should carry the real URL.
+    for (const err of apiErrors) {
+      expect(err.url).toMatch(/api-consumer/);
+    }
+
+    // Fault should never produce a spurious ERR_ABORTED network error
+    // alongside the 500 console error (requires non-empty body, which we now
+    // default).
+    const networkAborts = report.pages
+      .flatMap((p) => p.errors)
+      .filter((e) => e.type === "network" && e.message.includes("ERR_ABORTED"));
+    expect(networkAborts).toHaveLength(0);
+  }, 120000);
+
   it("injects faults into matching API requests and tracks per-rule stats", async () => {
     const crawler = new ChaosCrawler({
       baseUrl: `${server.url}/api-consumer`,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -399,6 +399,8 @@ export class ChaosCrawler {
     }
 
     const result = await this.crawlPageWithExistingPage(page, url);
+    this.events.onPageComplete?.(result);
+    this.logger.logPageComplete(result);
     this.results.push(result);
 
     return result;
@@ -529,6 +531,8 @@ export class ChaosCrawler {
         this.lastSuccessfulUrl = url;
       }
 
+      this.events.onPageComplete?.(result);
+      this.logger.logPageComplete(result);
       return result;
     } finally {
       await page.close();
@@ -540,12 +544,19 @@ export class ChaosCrawler {
     const warnings: string[] = [];
     const blockedNavigations: string[] = [];
     const startTime = Date.now();
+    // Set to false once collection is done so spurious events fired during
+    // page.close() (in-flight requests getting cancelled as ERR_ABORTED, etc.)
+    // don't pollute the PageResult.
+    let collecting = true;
 
     this.events.onPageStart?.(url);
     this.logger.logPageStart(url);
 
-    // Set up error listeners
+    // Set up error listeners. Each error records `page.url()` at fire time
+    // so that errors triggered after a chaos-action navigation are attributed
+    // to the URL actually in the address bar, not the original crawlPage URL.
     page.on("console", (msg) => {
+      if (!collecting) return;
       const type = msg.type();
       const text = msg.text();
       if (type === "error") {
@@ -553,7 +564,7 @@ export class ChaosCrawler {
         const error: PageError = {
           type: "console",
           message: text,
-          url,
+          url: page.url(),
           timestamp: Date.now(),
         };
         errors.push(error);
@@ -566,12 +577,13 @@ export class ChaosCrawler {
 
     // Capture unhandled exceptions
     page.on("pageerror", (err) => {
+      if (!collecting) return;
       if (this.shouldIgnoreError(err.message)) return;
       const error: PageError = {
         type: "exception",
         message: err.message,
         stack: err.stack,
-        url,
+        url: page.url(),
         timestamp: Date.now(),
       };
       errors.push(error);
@@ -594,6 +606,7 @@ export class ChaosCrawler {
     });
 
     page.on("requestfailed", (request) => {
+      if (!collecting) return;
       const requestUrl = request.url();
       if (this.shouldIgnoreError(requestUrl)) return;
 
@@ -614,7 +627,7 @@ export class ChaosCrawler {
       const error: PageError = {
         type: "network",
         message: `${requestUrl} - ${failure?.errorText || "Unknown error"}`,
-        url,
+        url: page.url(),
         timestamp: Date.now(),
       };
       errors.push(error);
@@ -693,8 +706,13 @@ export class ChaosCrawler {
       };
     }
 
-    this.events.onPageComplete?.(result);
-    this.logger.logPageComplete(result);
+    // Stop collecting before the caller closes the page — any ERR_ABORTED
+    // for in-flight requests cancelled by close() would otherwise be logged
+    // against this result.
+    collecting = false;
+
+    // onPageComplete fires from the caller (crawlPage / testPage) after any
+    // recovery reclassification so the callback sees the final status.
     return result;
   }
 
@@ -1159,13 +1177,19 @@ async function applyFault(route: Route, fault: Fault): Promise<void> {
     case "abort":
       await route.abort(fault.errorCode ?? "failed");
       return;
-    case "status":
+    case "status": {
+      // Chromium emits a spurious ERR_ABORTED alongside the response when the
+      // body is empty, so synthesise a minimal JSON body by default. Callers
+      // can still opt into an empty body by passing `body: ""` explicitly.
+      const body =
+        fault.body !== undefined ? fault.body : JSON.stringify({ error: fault.status });
       await route.fulfill({
         status: fault.status,
-        body: fault.body ?? "",
-        contentType: fault.contentType ?? "text/plain",
+        body,
+        contentType: fault.contentType ?? "application/json",
       });
       return;
+    }
     case "delay":
       await new Promise((r) => setTimeout(r, fault.ms));
       await route.continue();


### PR DESCRIPTION
## Summary

Dogfooding chaosbringer against its own fixture surfaced four correctness bugs. This PR fixes them and leaves the investigation tools in place.

- **Stale error attribution** — click during chaos actions causes in-page navigation, but errors were tagged with the original closure URL. Now captures `page.url()` at fire time in the console / pageerror / requestfailed handlers.
- **Spurious `ERR_ABORTED` on `page.close()`** — in-flight requests cancelled by close leaked into the PageResult. A `collecting` flag flips false before close so listeners stop recording.
- **`onPageComplete` fired with stale status** — showed `success` for pages that the recovery path later reclassified as `recovered`. Event firing moved to after reclassification in both `crawlPage` and `testPage`.
- **`route.fulfill` with empty body triggered Chromium `ERR_ABORTED`** — produced a phantom network error alongside the intended HTTP response. Default body changed to `{"error":<status>}` JSON; callers can still opt into empty body by passing `body: ""`.

Regression e2e tests added for the error-attribution, recovery-status, and no-ERR_ABORTED paths.

Investigation scripts kept as dogfood tools under `fixtures/runner/diag-*.ts`:
- `diag-routes` — request tracer
- `diag-attribution` — error-URL drift detector
- `diag-actions` — action-type distribution across seeds
- `diag-fault-recovery` — 500 injection → recovery path
- `diag-delay` — delay fault timing

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — 64 passed
- [x] `pnpm tsx fixtures/runner/diag-attribution.ts` — no more ERR_ABORTED; drifted errors carry the correct URL
- [x] `pnpm tsx fixtures/runner/diag-fault-recovery.ts` — 500-injected `/about` shows `recovered` status, recovery info attached
- [x] `pnpm tsx fixtures/runner/diag-delay.ts` — 500ms delay fault → end-to-end elapsed ≈1.6s

https://claude.ai/code/session_01GGegJKyzEqkq4yTn2py43e