### PR TITLE
DX review follow-up: validation, URL normalization, faults helpers, reproCommand, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,173 +1,318 @@
 # chaosbringer
 
-Playwright-based chaos testing library for web applications. Uses accessibility-aware weighted random actions to discover errors.
+Playwright-based chaos testing for web apps. Crawls the pages you point it at, performs weighted random actions, injects network faults, evaluates invariants, and reports what broke — with a seed you can replay.
 
 ## Features
 
-- **Accessibility-based targeting**: Uses ARIA roles and visible text to prioritize interactive elements
-- **Weighted random actions**: Navigation links > buttons > inputs > scroll
-- **External navigation blocking**: Prevents leaving the test domain
-- **Error detection**: Console errors, network errors, JS exceptions, unhandled promise rejections
-- **Performance metrics**: TTFB, FCP, LCP
-- **Playwright Test integration**: Use as a fixture in your existing tests
-- **CLI tool**: Standalone crawler for CI/CD pipelines
+- **Weighted random actions** targeted by ARIA role and visible text (nav links > buttons > inputs > scroll).
+- **Seeded reproducibility** — same seed, same action order. Every report prints a `Repro:` line you can paste into CI logs.
+- **Network fault injection** via Playwright's route API: serve a 500, abort, or add latency to any URL pattern.
+- **Declarative invariants** evaluated on every page. A violation fails the run regardless of `--strict`.
+- **Error detection**: console errors, failed requests, JS exceptions, unhandled rejections, invariant violations.
+- **Recovery from 404 / 5xx** — records what actions preceded the failure.
+- **Playwright Test integration** for when you'd rather run chaos inside an existing test file.
+- **CLI** for running from a shell or CI.
 
-## Installation
+## Install
 
 ```bash
 pnpm add chaosbringer playwright @playwright/test
+npx playwright install chromium
 ```
 
-## Playwright Test Integration
+`chaosbringer` targets ESM. Programmatic consumers need `"type": "module"` (or `.mts` files) and `playwright` as a peer dependency.
 
-### Basic Usage
+## Quick start — CLI
 
-```typescript
-import { test, expect } from '@playwright/test';
-import { chaosTest, chaosExpect } from 'chaosbringer';
+```bash
+# Crawl, then exit 0 / 1 based on navigation outcomes
+chaosbringer --url http://localhost:3000
 
-// Use the pre-configured chaosTest
-chaosTest('chaos test homepage', async ({ page, chaos }) => {
-  await page.goto('http://localhost:3000');
+# Dev mode: ignore third-party analytics noise
+chaosbringer --url http://localhost:3000 --ignore-analytics
+
+# CI mode: console errors and JS exceptions also fail the run
+chaosbringer --url http://localhost:3000 --strict --compact --ignore-analytics
+
+# Reproduce a failing run by pasting its Repro: line
+chaosbringer --url http://localhost:3000 --seed 1234567 --max-pages 20
+```
+
+## Quick start — programmatic
+
+The shortest path, using the `chaos()` convenience and the `faults` helpers:
+
+```ts
+// chaos-test.ts
+import { chaos, faults } from "chaosbringer";
+
+async function main() {
+  const { report, passed } = await chaos({
+    baseUrl: "http://localhost:3000",
+    seed: 42,
+    maxPages: 20,
+    strict: true,
+    faultInjection: [
+      faults.status(500, { urlPattern: /\/api\// }),
+      faults.delay(2000, { urlPattern: /\/slow\// }),
+    ],
+    invariants: [
+      {
+        name: "cart-count-non-negative",
+        when: "afterActions",
+        async check({ page }) {
+          const n = Number(await page.locator("[data-cart-count]").textContent());
+          return n >= 0 || `cart count was ${n}`;
+        },
+      },
+    ],
+  });
+
+  console.log(report.reproCommand);
+  process.exit(passed ? 0 : 1);
+}
+main();
+```
+
+The examples wrap in `async function main()` because a plain `.ts` file under an unconfigured project can't use top-level `await`.
+
+### Lower-level API
+
+If you need more control than `chaos()` exposes:
+
+```ts
+import { ChaosCrawler, getExitCode } from "chaosbringer";
+
+async function main() {
+  const crawler = new ChaosCrawler({
+    baseUrl: "http://localhost:3000",
+    seed: 42,
+  });
+  const report = await crawler.start();
+  process.exit(getExitCode(report, /* strict */ true));
+}
+main();
+```
+
+## Reproducible runs
+
+Every report includes:
+- `report.seed` — the seed actually used (random if you didn't pass one).
+- `report.reproCommand` — a shell-safe invocation that rebuilds the same run.
+
+Both are printed in the compact header (`[PASS] … (seed=42)`) and the full report (`Seed: 42` / `Repro: chaosbringer --url … --seed 42`).
+
+To rerun an exact failure locally, copy the `Repro:` line from CI.
+
+## Fault injection
+
+Fault rules let you force specific network requests to fail, delay, or return a canned response. Use the `faults` helpers to build rules without the discriminated-union noise:
+
+```ts
+import { chaos, faults } from "chaosbringer";
+
+await chaos({
+  baseUrl: "http://localhost:3000",
+  faultInjection: [
+    // Always 500 on /api/*
+    faults.status(500, { urlPattern: /\/api\// }),
+
+    // 30% of the time, return a 429 with a Retry-After body
+    faults.status(429, {
+      urlPattern: /\/api\/orders$/,
+      methods: ["POST"],
+      probability: 0.3,
+      body: "Retry-After: 5",
+      contentType: "text/plain",
+    }),
+
+    // Abort tracking pixels
+    faults.abort({ urlPattern: /tracking/ }),
+
+    // Add 2s of latency to one endpoint
+    faults.delay(2000, { urlPattern: /\/api\/search/ }),
+  ],
+});
+```
+
+`probability` is evaluated against the seeded RNG — same seed, same pattern of injections.
+
+Per-rule `matched` / `injected` counters end up in `report.faultInjections`.
+
+## Invariants
+
+Invariants are assertions that must hold on every page. They run either `afterLoad` (right after navigation) or `afterActions` (default — after chaos clicks/inputs). Returning `false`, throwing, or returning a string all count as a failure; returning `true` or `void` means the invariant held.
+
+```ts
+import { chaos, type Invariant } from "chaosbringer";
+
+const invariants: Invariant[] = [
+  {
+    name: "has-h1",
+    when: "afterLoad",
+    async check({ page }) {
+      return (await page.locator("h1").count()) > 0 || "no <h1>";
+    },
+  },
+  {
+    name: "no-loading-spinner-after-actions",
+    urlPattern: /\/spa\//,
+    async check({ page }) {
+      const t = (await page.locator("#app").textContent()) ?? "";
+      return !/loading/i.test(t) || `app still shows loading: "${t}"`;
+    },
+  },
+];
+
+const { passed } = await chaos({ baseUrl: "http://localhost:3000", invariants });
+```
+
+Violations always fail the run (exit 1), whether or not `strict` is set — a declared invariant is a stronger signal than console noise.
+
+## Exit codes
+
+| Condition | Exit |
+| --- | --- |
+| No navigation errors, no invariant violations | **0** |
+| At least one page with `status: "error"` or `"timeout"` | **1** |
+| At least one invariant violation (any mode) | **1** |
+| `--strict` and any console error / JS exception | **1** |
+
+`chaos()` returns `{ passed, exitCode }`; the CLI applies the same rule via `getExitCode`.
+
+## Playwright Test integration
+
+Use the pre-configured `chaosTest`:
+
+```ts
+import { chaosTest, chaosExpect } from "chaosbringer";
+
+chaosTest("chaos-test homepage", async ({ page, chaos }) => {
+  await page.goto("http://localhost:3000");
   const result = await chaos.testPage(page, page.url());
-
-  // Assert no errors
-  chaos.expectNoErrors(result);
-  // Or use chaosExpect helpers
   chaosExpect.toHaveNoExceptions(result);
   chaosExpect.toLoadWithin(result, 3000);
 });
 ```
 
-### Extend Your Existing Tests
+Or extend your existing test:
 
-```typescript
-import { test as base } from '@playwright/test';
-import { withChaos, type ChaosFixtures } from 'chaosbringer';
+```ts
+import { test as base } from "@playwright/test";
+import { withChaos, type ChaosFixtures } from "chaosbringer";
 
-const test = base.extend<ChaosFixtures>(withChaos({
-  maxActionsPerPage: 10,
-  ignoreErrorPatterns: ['analytics', 'tracking'],
-}));
+const test = base.extend<ChaosFixtures>(
+  withChaos({ maxActionsPerPage: 10, ignoreErrorPatterns: ["analytics"] }),
+);
 
-test('my feature test', async ({ page, chaos }) => {
-  await page.goto('/dashboard');
-  // ... your test logic ...
-
-  // Run chaos testing at the end
+test("my feature", async ({ page, chaos }) => {
+  await page.goto("/dashboard");
   const result = await chaos.testPage(page, page.url());
-  expect(result.errors).toHaveLength(0);
+  chaos.expectNoErrors(result);
 });
 ```
 
-### Crawl Multiple Pages
+Or crawl from within a fixture-based test:
 
-```typescript
-chaosTest('crawl entire site', async ({ chaos }) => {
-  const report = await chaos.crawl('http://localhost:3000');
-
-  console.log(`Visited ${report.pagesVisited} pages`);
-  console.log(`Found ${report.totalErrors} errors`);
-
+```ts
+chaosTest("crawl entire site", async ({ chaos }) => {
+  const report = await chaos.crawl("http://localhost:3000");
   chaos.expectNoErrors(report);
 });
 ```
 
-## CLI Usage
-
-```bash
-# Basic crawl
-chaosbringer --url http://localhost:3000
-
-# With analytics errors ignored (recommended for dev mode)
-chaosbringer --url http://localhost:3000 --ignore-analytics
-
-# CI mode with strict checking
-chaosbringer --url http://localhost:3000 --strict --compact --ignore-analytics
-
-# With screenshots
-chaosbringer --url https://docs.example.com --max-pages 20 --screenshots
-```
-
-### CLI Options
+## CLI reference
 
 | Option | Description | Default |
-|--------|-------------|---------|
-| `--url <url>` | Base URL to crawl (required) | - |
-| `--max-pages <n>` | Max pages to visit | 50 |
+| --- | --- | --- |
+| `--url <url>` | Base URL (required) | — |
+| `--max-pages <n>` | Max pages visited | 50 |
 | `--max-actions <n>` | Max random actions per page | 5 |
 | `--timeout <ms>` | Page load timeout | 30000 |
-| `--headless` | Run in headless mode | true |
-| `--no-headless` | Show browser window | - |
+| `--no-headless` | Show the browser window | headless |
 | `--screenshots` | Take screenshots | false |
-| `--output <path>` | Output report path | chaos-report.json |
-| `--exclude <pattern>` | Exclude URL patterns (regex) | - |
-| `--ignore-error <pattern>` | Ignore error patterns (regex) | - |
-| `--ignore-analytics` | Ignore common analytics errors | false |
-| `--compact` | Compact output format | false |
-| `--strict` | Exit with error on console errors | false |
+| `--screenshot-dir <path>` | Screenshot directory | `./screenshots` |
+| `--output <path>` | Report path | `chaos-report.json` |
+| `--exclude <pattern>` | Skip URLs matching regex (repeatable) | — |
+| `--ignore-error <pattern>` | Suppress errors matching regex (repeatable) | — |
+| `--ignore-analytics` | Suppress common analytics noise† | false |
+| `--spa <pattern>` | Mark matching URLs as SPA (errors bucketed separately, repeatable) | — |
+| `--log-file <path>` | JSON execution log | — |
+| `--log-level <level>` | `debug` / `info` / `warn` / `error` | info |
+| `--log-console` | Also log to console | false |
+| `--seed <n>` | Seed for deterministic action selection | random |
+| `--compact` | Compact output | false |
+| `--strict` | Fail on console errors + JS exceptions | false |
+| `--quiet` | Minimal output | false |
+| `--help` | Show help | — |
 
-## Action Weighting
+† `--ignore-analytics` suppresses matches for `googletagmanager`, `google-analytics`, `analytics.google`, `hotjar`, `clarity.ms`, `segment.io`, `amplitude`, `cloudflareinsights`, `facebook.net`, and generic `net::ERR_FAILED` from blocked resources. See `COMMON_IGNORE_PATTERNS` in `src/crawler.ts`.
 
-Elements are selected with weighted probability based on:
+Fault injection and invariants are programmatic-only — they can't be expressed in a shell command and are intentionally absent from the CLI.
 
-| Element Type | Default Weight |
-|--------------|----------------|
-| Navigation links (in nav/header) | 4.5 (3 × 1.5) |
+## Action weighting
+
+| Element type | Default weight |
+| --- | --- |
+| Navigation links (in `<nav>` / `<header>`) | 4.5 (3 × 1.5) |
 | Regular links | 3.0 |
 | Buttons | 2.0 |
 | ARIA interactive roles | 2.0 |
 | Input fields | 1.0 |
 | Scroll | 0.5 |
 
-Elements with visible text get a 1.5x multiplier.
+Elements with visible text get a 1.5× multiplier.
 
-### Customize Weights
-
-```typescript
-const crawler = new ChaosCrawler({
-  baseUrl: 'http://localhost:3000',
-  actionWeights: {
-    navigationLinks: 5,  // Prioritize nav links
-    buttons: 3,
-    inputs: 0.5,         // De-prioritize inputs
-    scroll: 0.1,
-  },
+```ts
+new ChaosCrawler({
+  baseUrl: "http://localhost:3000",
+  actionWeights: { navigationLinks: 5, buttons: 3, inputs: 0.5, scroll: 0.1 },
 });
 ```
 
-## Error Types Detected
+## Error types
 
-- `console`: Console.error() calls
-- `network`: Failed network requests
-- `exception`: Uncaught JavaScript errors
-- `unhandled-rejection`: Unhandled Promise rejections
-- `crash`: Page crashes
+- `console` — `console.error(...)` calls
+- `network` — failed requests
+- `exception` — uncaught JS errors
+- `unhandled-rejection` — unhandled promise rejections
+- `invariant-violation` — a declared invariant failed
+- `crash` — the page crashed
 
-## Report Format
+`PageResult.status` reports the navigation outcome (`success` / `error` / `timeout` / `recovered`), not whether the page was healthy. A page can be `success` with exceptions on it — check `PageResult.hasErrors` or `report.summary.pagesWithErrors` for the full picture.
+
+## Report shape (abridged)
 
 ```json
 {
   "baseUrl": "http://localhost:3000",
+  "seed": 42,
+  "reproCommand": "chaosbringer --url http://localhost:3000 --seed 42 --max-pages 20",
   "duration": 12345,
   "pagesVisited": 20,
   "totalErrors": 2,
   "blockedExternalNavigations": 5,
+  "recoveryCount": 1,
   "pages": [
     {
       "url": "http://localhost:3000/",
       "status": "success",
+      "statusCode": 200,
       "loadTime": 500,
       "errors": [],
+      "hasErrors": false,
       "metrics": { "ttfb": 50, "fcp": 120 }
     }
   ],
   "summary": {
     "successPages": 20,
+    "pagesWithErrors": 1,
     "consoleErrors": 1,
     "jsExceptions": 1,
-    "unhandledRejections": 0
-  }
+    "unhandledRejections": 0,
+    "invariantViolations": 0
+  },
+  "faultInjections": [{ "rule": "api-500", "matched": 4, "injected": 4 }]
 }
 ```
 

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -1,0 +1,31 @@
+/**
+ * Top-level convenience that runs a crawl and returns a pre-decided
+ * pass/fail + exit code. Most programmatic consumers end up re-deriving
+ * these from CrawlReport; this just makes the common case one call.
+ */
+
+import { ChaosCrawler } from "./crawler.js";
+import { getExitCode } from "./reporter.js";
+import type { CrawlerEvents, CrawlerOptions, CrawlReport } from "./types.js";
+
+export interface ChaosResult {
+  report: CrawlReport;
+  passed: boolean;
+  exitCode: number;
+}
+
+export interface ChaosRunOptions extends CrawlerOptions {
+  /** Treat console errors / JS exceptions as failures when computing exitCode. */
+  strict?: boolean;
+}
+
+export async function chaos(
+  options: ChaosRunOptions,
+  events: CrawlerEvents = {}
+): Promise<ChaosResult> {
+  const { strict, ...crawlerOptions } = options;
+  const crawler = new ChaosCrawler(crawlerOptions, events);
+  const report = await crawler.start();
+  const exitCode = getExitCode(report, strict ?? false);
+  return { report, passed: exitCode === 0, exitCode };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,7 +202,7 @@ async function main() {
     }
 
     // Print report
-    printReport(report, isCompact);
+    printReport(report, isCompact, isStrict);
 
     // Exit with appropriate code
     const exitCode = getExitCode(report, isStrict);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,14 +66,15 @@ OPTIONS:
   --max-pages <n>       Max pages to visit (default: 50)
   --max-actions <n>     Max random actions per page (default: 5)
   --timeout <ms>        Page load timeout (default: 30000)
-  --headless            Run headless (default: true)
-  --no-headless         Show browser window
+  --no-headless         Show the browser window (headless is the default)
   --screenshots         Take screenshots
   --screenshot-dir      Screenshot directory (default: ./screenshots)
   --output <path>       Output report path (default: chaos-report.json)
   --exclude <pattern>   Exclude URL patterns (regex, can be repeated)
   --ignore-error <p>    Ignore error patterns (regex, can be repeated)
-  --ignore-analytics    Ignore common analytics script errors
+  --ignore-analytics    Ignore common analytics script errors (googletagmanager,
+                        google-analytics, hotjar, clarity, segment, amplitude,
+                        cloudflareinsights, facebook.net, and net::ERR_FAILED)
   --spa <pattern>       Mark URLs as SPA (errors shown separately, can be repeated)
   --log-file <path>     Write execution log to file (JSON format)
   --log-level <level>   Log level: debug, info, warn, error (default: info)
@@ -176,9 +177,12 @@ async function main() {
     },
     onPageComplete: (result) => {
       if (!isQuiet && !isCompact) {
-        const status = result.status === "success" ? "OK" : result.status.toUpperCase();
-        const errors = result.errors.length > 0 ? ` (${result.errors.length} errors)` : "";
-        console.log(` ${status}${errors} [${result.loadTime}ms]`);
+        // OK = navigation succeeded. Page-level errors are shown separately
+        // so a user reading the line above can tell an OK-but-noisy page
+        // apart from one that failed to load.
+        const baseLabel = result.status === "success" ? "OK" : result.status.toUpperCase();
+        const label = result.hasErrors ? `${baseLabel} (${result.errors.length} errors)` : baseLabel;
+        console.log(` ${label} [${result.loadTime}ms]`);
       }
     },
     onProgress: (visited, total) => {
@@ -195,16 +199,15 @@ async function main() {
       console.log(""); // New line after progress
     }
 
-    // Save report
+    // Print report first, then save + announce the file. This way the main
+    // textual output is one contiguous block and the "saved to" line is the
+    // last thing on screen — friendlier for scrolling CI logs.
+    printReport(report, isCompact, isStrict);
     saveReport(report, outputPath);
     if (!isQuiet) {
       console.log(`\nReport saved to: ${outputPath}`);
     }
 
-    // Print report
-    printReport(report, isCompact, isStrict);
-
-    // Exit with appropriate code
     const exitCode = getExitCode(report, isStrict);
     process.exit(exitCode);
   } catch (err) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -679,6 +679,7 @@ export class ChaosCrawler {
         statusCode: response?.status(),
         loadTime,
         errors,
+        hasErrors: errors.length > 0,
         warnings,
         metrics,
         links,
@@ -690,20 +691,22 @@ export class ChaosCrawler {
       const loadTime = Date.now() - startTime;
       const isTimeout = err instanceof Error && err.message.includes("Timeout");
 
+      const combinedErrors: PageError[] = [
+        ...errors,
+        {
+          type: "exception",
+          message: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+          url,
+          timestamp: Date.now(),
+        },
+      ];
       result = {
         url,
         status: isTimeout ? "timeout" : "error",
         loadTime,
-        errors: [
-          ...errors,
-          {
-            type: "exception",
-            message: err instanceof Error ? err.message : String(err),
-            stack: err instanceof Error ? err.stack : undefined,
-            url,
-            timestamp: Date.now(),
-          },
-        ],
+        errors: combinedErrors,
+        hasErrors: combinedErrors.length > 0,
         warnings,
         links: [],
       };

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -131,6 +131,8 @@ export class ChaosCrawler {
   }> = [];
 
   constructor(options: CrawlerOptions, events: CrawlerEvents = {}) {
+    validateOptions(options);
+
     // Filter out undefined values to preserve defaults
     const filteredOptions = Object.fromEntries(
       Object.entries(options).filter(([_, v]) => v !== undefined)
@@ -1135,6 +1137,75 @@ export class ChaosCrawler {
 
   private calculateSummary(): CrawlSummary {
     return summarizePages(this.results, this.discoveryMetrics);
+  }
+}
+
+/**
+ * Validate user-supplied options up front so downstream code can assume
+ * well-formed inputs. Every error starts with `chaosbringer:` and names
+ * the field, so users don't get an anonymous `TypeError: Invalid URL`.
+ */
+export function validateOptions(options: CrawlerOptions): void {
+  // baseUrl — parse and surface a named error.
+  try {
+    // eslint-disable-next-line no-new
+    new URL(options.baseUrl);
+  } catch {
+    throw new Error(
+      `chaosbringer: "baseUrl" must be an absolute URL (got ${JSON.stringify(options.baseUrl)})`
+    );
+  }
+
+  const requirePositive = (name: string, value: number | undefined, min: number): void => {
+    if (value === undefined) return;
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < min) {
+      throw new Error(
+        `chaosbringer: "${name}" must be an integer >= ${min} (got ${JSON.stringify(value)})`
+      );
+    }
+  };
+  requirePositive("maxPages", options.maxPages, 1);
+  requirePositive("maxActionsPerPage", options.maxActionsPerPage, 0);
+  requirePositive("timeout", options.timeout, 1);
+  requirePositive("recoveryHistorySize", options.recoveryHistorySize, 0);
+
+  if (options.seed !== undefined) {
+    if (!Number.isFinite(options.seed) || !Number.isInteger(options.seed) || options.seed < 0) {
+      throw new Error(
+        `chaosbringer: "seed" must be a non-negative integer (got ${JSON.stringify(options.seed)})`
+      );
+    }
+  }
+
+  const assertRegex = (label: string, pattern: string | undefined): void => {
+    if (pattern === undefined) return;
+    try {
+      // eslint-disable-next-line no-new
+      new RegExp(pattern);
+    } catch {
+      throw new Error(`chaosbringer: ${label} has invalid regex: ${JSON.stringify(pattern)}`);
+    }
+  };
+
+  for (const p of options.excludePatterns ?? []) assertRegex(`excludePatterns entry`, p);
+  for (const p of options.ignoreErrorPatterns ?? []) assertRegex(`ignoreErrorPatterns entry`, p);
+  for (const p of options.spaPatterns ?? []) assertRegex(`spaPatterns entry`, p);
+
+  for (const rule of options.faultInjection ?? []) {
+    const label = rule.name ? `faultInjection rule "${rule.name}"` : `faultInjection rule`;
+    assertRegex(`${label} urlPattern`, rule.urlPattern);
+    if (rule.probability !== undefined) {
+      const p = rule.probability;
+      if (!Number.isFinite(p) || p < 0 || p > 1) {
+        throw new Error(
+          `chaosbringer: ${label} probability must be in [0, 1] (got ${JSON.stringify(p)})`
+        );
+      }
+    }
+  }
+
+  for (const inv of options.invariants ?? []) {
+    assertRegex(`invariant "${inv.name}" urlPattern`, inv.urlPattern);
   }
 }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -27,6 +27,7 @@ import type {
   FaultRule,
   FaultInjectionStats,
   Fault,
+  UrlMatcher,
 } from "./types.js";
 import { Logger, createNullLogger } from "./logger.js";
 import {
@@ -212,11 +213,9 @@ export class ChaosCrawler {
       const when = inv.when ?? "afterActions";
       if (when !== phase) continue;
       if (inv.urlPattern) {
-        try {
-          if (!new RegExp(inv.urlPattern).test(url)) continue;
-        } catch {
-          continue;
-        }
+        const re = toRegExp(inv.urlPattern);
+        if (re && !re.test(url)) continue;
+        if (!re) continue; // Invalid pattern — silently skip (already flagged by validateOptions).
       }
 
       let failureReason: string | null = null;
@@ -1130,8 +1129,8 @@ export class ChaosCrawler {
 
   /** Per-rule fault injection stats (for reporting). */
   getFaultStats(): FaultInjectionStats[] {
-    return this.compiledFaultRules.map((c, i) => ({
-      rule: c.rule.name ?? c.rule.urlPattern,
+    return this.compiledFaultRules.map((c) => ({
+      rule: c.rule.name ?? c.pattern.toString(),
       matched: c.matched,
       injected: c.injected,
     }));
@@ -1179,7 +1178,7 @@ export function validateOptions(options: CrawlerOptions): void {
     }
   }
 
-  const assertRegex = (label: string, pattern: string | undefined): void => {
+  const assertRegexString = (label: string, pattern: string | undefined): void => {
     if (pattern === undefined) return;
     try {
       // eslint-disable-next-line no-new
@@ -1189,13 +1188,19 @@ export function validateOptions(options: CrawlerOptions): void {
     }
   };
 
-  for (const p of options.excludePatterns ?? []) assertRegex(`excludePatterns entry`, p);
-  for (const p of options.ignoreErrorPatterns ?? []) assertRegex(`ignoreErrorPatterns entry`, p);
-  for (const p of options.spaPatterns ?? []) assertRegex(`spaPatterns entry`, p);
+  const assertMatcher = (label: string, m: UrlMatcher | undefined): void => {
+    if (m === undefined) return;
+    if (m instanceof RegExp) return; // Already compiled, always valid.
+    assertRegexString(label, m);
+  };
+
+  for (const p of options.excludePatterns ?? []) assertRegexString(`excludePatterns entry`, p);
+  for (const p of options.ignoreErrorPatterns ?? []) assertRegexString(`ignoreErrorPatterns entry`, p);
+  for (const p of options.spaPatterns ?? []) assertRegexString(`spaPatterns entry`, p);
 
   for (const rule of options.faultInjection ?? []) {
     const label = rule.name ? `faultInjection rule "${rule.name}"` : `faultInjection rule`;
-    assertRegex(`${label} urlPattern`, rule.urlPattern);
+    assertMatcher(`${label} urlPattern`, rule.urlPattern);
     if (rule.probability !== undefined) {
       const p = rule.probability;
       if (!Number.isFinite(p) || p < 0 || p > 1) {
@@ -1207,7 +1212,17 @@ export function validateOptions(options: CrawlerOptions): void {
   }
 
   for (const inv of options.invariants ?? []) {
-    assertRegex(`invariant "${inv.name}" urlPattern`, inv.urlPattern);
+    assertMatcher(`invariant "${inv.name}" urlPattern`, inv.urlPattern);
+  }
+}
+
+/** Coerce a UrlMatcher to RegExp. Returns null if the string is not a valid regex. */
+function toRegExp(m: UrlMatcher): RegExp | null {
+  if (m instanceof RegExp) return m;
+  try {
+    return new RegExp(m);
+  } catch {
+    return null;
   }
 }
 
@@ -1227,11 +1242,9 @@ function compileFaultRules(rules: FaultRule[] | undefined): Array<{
     injected: number;
   }> = [];
   for (const rule of rules) {
-    let pattern: RegExp;
-    try {
-      pattern = new RegExp(rule.urlPattern);
-    } catch {
-      // Skip invalid regex silently; same policy as other pattern options.
+    const pattern = toRegExp(rule.urlPattern);
+    if (!pattern) {
+      // Skip invalid regex silently; validateOptions will have already raised.
       continue;
     }
     compiled.push({

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -35,6 +35,7 @@ import {
   isExternalUrl as isExternalUrlPure,
   escapeSelector as escapeSelectorPure,
   summarizePages,
+  normalizeUrl,
 } from "./filters.js";
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 
@@ -294,7 +295,7 @@ export class ChaosCrawler {
     this.startTime = Date.now();
     this.visited.clear();
     this.queue = [{
-      url: this.options.baseUrl,
+      url: normalizeUrl(this.options.baseUrl),
       sourceUrl: "",
       method: "initial",
     }];
@@ -354,8 +355,9 @@ export class ChaosCrawler {
         this.results.push(result);
 
         // Add discovered links to queue with source tracking
-        for (const link of result.links) {
-          const alreadyQueued = this.queue.some(e => e.url === link);
+        for (const rawLink of result.links) {
+          const link = normalizeUrl(rawLink);
+          const alreadyQueued = this.queue.some((e) => e.url === link);
           if (!this.visited.has(link) && !alreadyQueued) {
             this.queue.push({
               url: link,
@@ -889,8 +891,8 @@ export class ChaosCrawler {
           // Boost unvisited links significantly
           if (t.href) {
             try {
-              const absoluteUrl = new URL(t.href, this.baseOrigin).toString();
-              const isQueued = this.queue.some(e => e.url === absoluteUrl);
+              const absoluteUrl = normalizeUrl(new URL(t.href, this.baseOrigin).toString());
+              const isQueued = this.queue.some((e) => e.url === absoluteUrl);
               if (!this.visited.has(absoluteUrl) && !isQueued) {
                 weight *= 3; // Strong boost for unvisited links
               } else if (this.visited.has(absoluteUrl)) {
@@ -1057,8 +1059,8 @@ export class ChaosCrawler {
         // Track link clicks that navigate (only if not already tracked)
         if (href && !href.startsWith("#") && !href.startsWith("javascript:")) {
           try {
-            const absoluteUrl = new URL(href, url).toString();
-            const alreadyQueued = this.queue.some(e => e.url === absoluteUrl);
+            const absoluteUrl = normalizeUrl(new URL(href, url).toString());
+            const alreadyQueued = this.queue.some((e) => e.url === absoluteUrl);
             if (!this.visited.has(absoluteUrl) && !alreadyQueued) {
               this.queue.push({
                 url: absoluteUrl,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1115,6 +1115,7 @@ export class ChaosCrawler {
     return {
       baseUrl: this.options.baseUrl,
       seed: this.rng.seed,
+      reproCommand: this.buildReproCommand(),
       startTime: this.startTime,
       endTime,
       duration: endTime - this.startTime,
@@ -1128,6 +1129,25 @@ export class ChaosCrawler {
       summary,
       faultInjections: this.compiledFaultRules.length > 0 ? this.getFaultStats() : undefined,
     };
+  }
+
+  /** Build a shell command that reruns this crawl with the same seed / limits. */
+  private buildReproCommand(): string {
+    const parts: string[] = ["chaosbringer", "--url", shellQuote(this.options.baseUrl)];
+    parts.push("--seed", String(this.rng.seed));
+    if (this.options.maxPages !== DEFAULT_OPTIONS.maxPages) {
+      parts.push("--max-pages", String(this.options.maxPages));
+    }
+    if (this.options.maxActionsPerPage !== DEFAULT_OPTIONS.maxActionsPerPage) {
+      parts.push("--max-actions", String(this.options.maxActionsPerPage));
+    }
+    for (const p of this.options.excludePatterns ?? []) {
+      parts.push("--exclude", shellQuote(p));
+    }
+    for (const p of this.options.spaPatterns ?? []) {
+      parts.push("--spa", shellQuote(p));
+    }
+    return parts.join(" ");
   }
 
   /** Per-rule fault injection stats (for reporting). */
@@ -1217,6 +1237,13 @@ export function validateOptions(options: CrawlerOptions): void {
   for (const inv of options.invariants ?? []) {
     assertMatcher(`invariant "${inv.name}" urlPattern`, inv.urlPattern);
   }
+}
+
+/** Shell-quote a value for inclusion in a reproducible CLI invocation. */
+function shellQuote(s: string): string {
+  if (s === "") return "''";
+  if (/^[A-Za-z0-9_\-:/.=?&@%+,]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
 /** Coerce a UrlMatcher to RegExp. Returns null if the string is not a valid regex. */

--- a/src/faults.test.ts
+++ b/src/faults.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { faults } from "./faults.js";
+
+describe("faults helpers", () => {
+  it("faults.status produces a status fault rule", () => {
+    const rule = faults.status(500, { urlPattern: /\/api\// });
+    expect(rule.fault).toEqual({ kind: "status", status: 500 });
+    expect(rule.urlPattern).toBeInstanceOf(RegExp);
+  });
+
+  it("faults.status forwards body + contentType when provided", () => {
+    const rule = faults.status(503, {
+      urlPattern: "/api",
+      body: "down",
+      contentType: "text/plain",
+    });
+    expect(rule.fault).toEqual({
+      kind: "status",
+      status: 503,
+      body: "down",
+      contentType: "text/plain",
+    });
+  });
+
+  it("faults.abort defaults errorCode to nothing (crawler supplies default)", () => {
+    const rule = faults.abort({ urlPattern: /tracking/ });
+    expect(rule.fault).toEqual({ kind: "abort" });
+  });
+
+  it("faults.abort passes errorCode through", () => {
+    const rule = faults.abort({ urlPattern: "t", errorCode: "internetdisconnected" });
+    expect(rule.fault).toEqual({ kind: "abort", errorCode: "internetdisconnected" });
+  });
+
+  it("faults.delay wraps ms", () => {
+    const rule = faults.delay(2000, { urlPattern: "/slow" });
+    expect(rule.fault).toEqual({ kind: "delay", ms: 2000 });
+  });
+
+  it("forwards common options (name, methods, probability)", () => {
+    const rule = faults.status(500, {
+      urlPattern: "/api",
+      name: "api-500",
+      methods: ["POST"],
+      probability: 0.5,
+    });
+    expect(rule.name).toBe("api-500");
+    expect(rule.methods).toEqual(["POST"]);
+    expect(rule.probability).toBe(0.5);
+  });
+
+  it("omits common options when not set (no undefined pollution)", () => {
+    const rule = faults.status(500, { urlPattern: "/api" });
+    expect(rule).not.toHaveProperty("name");
+    expect(rule).not.toHaveProperty("methods");
+    expect(rule).not.toHaveProperty("probability");
+  });
+});

--- a/src/faults.ts
+++ b/src/faults.ts
@@ -1,0 +1,68 @@
+/**
+ * Small helper functions that build FaultRule objects without the
+ * discriminated-union ceremony. Exported from the package root.
+ *
+ *   import { faults } from "chaosbringer";
+ *   const rules = [
+ *     faults.status(500, { urlPattern: /\/api\// }),
+ *     faults.abort({ urlPattern: /tracking/ }),
+ *     faults.delay(2000, { urlPattern: /\/api\// }),
+ *   ];
+ */
+
+import type { FaultRule, UrlMatcher } from "./types.js";
+
+export interface FaultHelperOptions {
+  urlPattern: UrlMatcher;
+  methods?: string[];
+  probability?: number;
+  name?: string;
+}
+
+function applyCommon(rule: FaultRule, opts: FaultHelperOptions): FaultRule {
+  rule.urlPattern = opts.urlPattern;
+  if (opts.methods !== undefined) rule.methods = opts.methods;
+  if (opts.probability !== undefined) rule.probability = opts.probability;
+  if (opts.name !== undefined) rule.name = opts.name;
+  return rule;
+}
+
+export const faults = {
+  /** Respond with `status` (and optional body / content-type). */
+  status(
+    status: number,
+    opts: FaultHelperOptions & { body?: string; contentType?: string }
+  ): FaultRule {
+    const rule: FaultRule = {
+      urlPattern: opts.urlPattern,
+      fault: {
+        kind: "status",
+        status,
+        ...(opts.body !== undefined ? { body: opts.body } : {}),
+        ...(opts.contentType !== undefined ? { contentType: opts.contentType } : {}),
+      },
+    };
+    return applyCommon(rule, opts);
+  },
+
+  /** Abort the request (e.g. to simulate a blocked third-party or transport failure). */
+  abort(opts: FaultHelperOptions & { errorCode?: string }): FaultRule {
+    const rule: FaultRule = {
+      urlPattern: opts.urlPattern,
+      fault: {
+        kind: "abort",
+        ...(opts.errorCode !== undefined ? { errorCode: opts.errorCode } : {}),
+      },
+    };
+    return applyCommon(rule, opts);
+  },
+
+  /** Wait `ms` milliseconds, then continue the request unchanged. */
+  delay(ms: number, opts: FaultHelperOptions): FaultRule {
+    const rule: FaultRule = {
+      urlPattern: opts.urlPattern,
+      fault: { kind: "delay", ms },
+    };
+    return applyCommon(rule, opts);
+  },
+};

--- a/src/filters.test.ts
+++ b/src/filters.test.ts
@@ -122,11 +122,13 @@ describe("escapeSelector", () => {
 });
 
 function makeResult(overrides: Partial<PageResult> = {}): PageResult {
+  const errors = overrides.errors ?? [];
   return {
     url: "http://localhost/p",
     status: "success",
     loadTime: 100,
-    errors: [],
+    errors,
+    hasErrors: errors.length > 0,
     warnings: [],
     links: [],
     ...overrides,
@@ -201,6 +203,23 @@ describe("summarizePages", () => {
   it("leaves avgMetrics undefined when no page has metrics", () => {
     const s = summarizePages([makeResult({}), makeResult({})]);
     expect(s.avgMetrics).toBeUndefined();
+  });
+
+  it("counts pagesWithErrors independently from navigation status", () => {
+    const s = summarizePages([
+      makeResult({
+        status: "success",
+        errors: [{ type: "console", message: "oops", timestamp: 0 }],
+      }),
+      makeResult({ status: "success" }),
+      makeResult({
+        status: "recovered",
+        errors: [{ type: "network", message: "x", timestamp: 0 }],
+      }),
+    ]);
+    expect(s.successPages).toBe(2);
+    expect(s.recoveredPages).toBe(1);
+    expect(s.pagesWithErrors).toBe(2);
   });
 
   it("passes discovery through unchanged", () => {

--- a/src/filters.test.ts
+++ b/src/filters.test.ts
@@ -5,6 +5,7 @@ import {
   isExternalUrl,
   escapeSelector,
   summarizePages,
+  normalizeUrl,
 } from "./filters.js";
 import type { PageResult } from "./types.js";
 
@@ -75,6 +76,33 @@ describe("isExternalUrl", () => {
 
   it("returns false for invalid URLs", () => {
     expect(isExternalUrl("not a url", base)).toBe(false);
+  });
+});
+
+describe("normalizeUrl", () => {
+  it("collapses bare host and host-with-slash to the same form", () => {
+    expect(normalizeUrl("http://127.0.0.1:4455")).toBe(normalizeUrl("http://127.0.0.1:4455/"));
+  });
+
+  it("strips trailing slash on non-root paths", () => {
+    expect(normalizeUrl("http://x/about/")).toBe("http://x/about");
+    expect(normalizeUrl("http://x/a/b/")).toBe("http://x/a/b");
+  });
+
+  it("keeps root as /", () => {
+    expect(normalizeUrl("http://x/")).toMatch(/\/$/);
+  });
+
+  it("drops fragment", () => {
+    expect(normalizeUrl("http://x/a#anchor")).toBe("http://x/a");
+  });
+
+  it("lowercases host", () => {
+    expect(normalizeUrl("http://EXAMPLE.COM/X")).toBe("http://example.com/X");
+  });
+
+  it("passes invalid URLs through unchanged", () => {
+    expect(normalizeUrl("not a url")).toBe("not a url");
   });
 });
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -81,6 +81,7 @@ export function summarizePages(
   const errorPages = results.filter((r) => r.status === "error").length;
   const timeoutPages = results.filter((r) => r.status === "timeout").length;
   const recoveredPages = results.filter((r) => r.status === "recovered").length;
+  const pagesWithErrors = results.filter((r) => r.errors.length > 0).length;
 
   const allErrors = results.flatMap((r) => r.errors);
   const consoleErrors = allErrors.filter((e) => e.type === "console").length;
@@ -120,6 +121,7 @@ export function summarizePages(
     errorPages,
     timeoutPages,
     recoveredPages,
+    pagesWithErrors,
     consoleErrors,
     networkErrors,
     jsExceptions,

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -52,6 +52,26 @@ export function escapeSelector(text: string): string {
   return text.replace(/"/g, '\\"').replace(/\n/g, " ").slice(0, 50);
 }
 
+/**
+ * Canonical form used for queue dedupe. Drops the fragment, lowercases the
+ * host, and treats `http://x` and `http://x/` as the same URL. Trailing
+ * slashes on non-root paths are stripped so `/about` and `/about/` don't
+ * visit twice. Invalid input round-trips unchanged.
+ */
+export function normalizeUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    u.hash = "";
+    u.hostname = u.hostname.toLowerCase();
+    if (u.pathname.length > 1 && u.pathname.endsWith("/")) {
+      u.pathname = u.pathname.replace(/\/+$/, "");
+    }
+    return u.toString();
+  } catch {
+    return raw;
+  }
+}
+
 /** Compute summary statistics from a list of page results. */
 export function summarizePages(
   results: readonly PageResult[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Core
-export { ChaosCrawler, COMMON_IGNORE_PATTERNS } from "./crawler.js";
+export { ChaosCrawler, COMMON_IGNORE_PATTERNS, validateOptions } from "./crawler.js";
 export { formatReport, formatCompactReport, saveReport, printReport, getExitCode } from "./reporter.js";
 export { Logger, createNullLogger, type LogEntry, type LogLevel, type LoggerOptions } from "./logger.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,5 @@ export type {
   Fault,
   FaultRule,
   FaultInjectionStats,
+  UrlMatcher,
 } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@
 export { ChaosCrawler, COMMON_IGNORE_PATTERNS, validateOptions } from "./crawler.js";
 export { formatReport, formatCompactReport, saveReport, printReport, getExitCode } from "./reporter.js";
 export { Logger, createNullLogger, type LogEntry, type LogLevel, type LoggerOptions } from "./logger.js";
+export { chaos, type ChaosResult, type ChaosRunOptions } from "./chaos.js";
+export { faults, type FaultHelperOptions } from "./faults.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -121,6 +121,18 @@ describe("formatCompactReport", () => {
     const out = formatCompactReport(makeReport({ seed: 99999 }));
     expect(out).toContain("seed=99999");
   });
+
+  it("reports FAIL in strict mode when console errors exist (matching getExitCode)", () => {
+    const report = makeReport({ summary: makeSummary({ consoleErrors: 1 }) });
+    expect(formatCompactReport(report)).toContain("[PASS]");
+    expect(formatCompactReport(report, true)).toContain("[FAIL]");
+  });
+
+  it("reports FAIL when any invariant violated, regardless of strict", () => {
+    const report = makeReport({ summary: makeSummary({ invariantViolations: 1 }) });
+    expect(formatCompactReport(report)).toContain("[FAIL]");
+    expect(formatCompactReport(report, true)).toContain("[FAIL]");
+  });
 });
 
 describe("saveReport", () => {

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -11,6 +11,7 @@ function makeSummary(overrides: Partial<CrawlSummary> = {}): CrawlSummary {
     errorPages: 0,
     timeoutPages: 0,
     recoveredPages: 0,
+    pagesWithErrors: 0,
     consoleErrors: 0,
     networkErrors: 0,
     jsExceptions: 0,

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -26,6 +26,7 @@ function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
   return {
     baseUrl: "http://localhost:3000",
     seed: 42,
+    reproCommand: "chaosbringer --url http://localhost:3000 --seed 42",
     startTime: 0,
     endTime: 1000,
     duration: 1000,

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -14,6 +14,7 @@ export function formatReport(report: CrawlReport): string {
   lines.push("");
   lines.push(`Base URL: ${report.baseUrl}`);
   lines.push(`Seed: ${report.seed}`);
+  lines.push(`Repro: ${report.reproCommand}`);
   lines.push(`Duration: ${(report.duration / 1000).toFixed(2)}s`);
   lines.push(`Pages Visited: ${report.pagesVisited}`);
   if (report.blockedExternalNavigations > 0) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -31,6 +31,11 @@ export function formatReport(report: CrawlReport): string {
   if (report.summary.recoveredPages > 0) {
     lines.push(`Recovered (404/5xx): ${report.summary.recoveredPages}`);
   }
+  if (report.summary.pagesWithErrors > 0) {
+    // A page can have status=success but still hold console/exception errors,
+    // so surface that count separately from navigation outcomes.
+    lines.push(`Pages with errors: ${report.summary.pagesWithErrors}`);
+  }
   lines.push(`Console Errors: ${report.summary.consoleErrors}`);
   lines.push(`Network Errors: ${report.summary.networkErrors}`);
   lines.push(`JS Exceptions: ${report.summary.jsExceptions}`);

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -166,8 +166,11 @@ export function formatReport(report: CrawlReport): string {
   return lines.join("\n");
 }
 
-export function formatCompactReport(report: CrawlReport): string {
-  const status = report.summary.errorPages > 0 || report.summary.timeoutPages > 0 ? "FAIL" : "PASS";
+export function formatCompactReport(report: CrawlReport, strict = false): string {
+  // Use the same rule as getExitCode so the human label matches the exit
+  // code. Previously the label ignored strict mode and console errors,
+  // producing `[PASS]` runs that exited 1. See #6.
+  const status = getExitCode(report, strict) === 0 ? "PASS" : "FAIL";
   const errors = report.summary.consoleErrors + report.summary.networkErrors + report.summary.jsExceptions;
 
   return [
@@ -184,8 +187,8 @@ export function saveReport(report: CrawlReport, path: string): void {
   writeFileSync(path, JSON.stringify(report, null, 2));
 }
 
-export function printReport(report: CrawlReport, compact = false): void {
-  console.log(compact ? formatCompactReport(report) : formatReport(report));
+export function printReport(report: CrawlReport, compact = false, strict = false): void {
+  console.log(compact ? formatCompactReport(report, strict) : formatReport(report));
 }
 
 function truncate(str: string, maxLen: number): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,11 +55,14 @@ export type Fault =
   | { kind: "status"; status: number; body?: string; contentType?: string }
   | { kind: "delay"; ms: number };
 
+/** Anything that can match a URL. String inputs are compiled with `new RegExp`. */
+export type UrlMatcher = string | RegExp;
+
 export interface FaultRule {
   /** Optional human-readable name used in stats. */
   name?: string;
-  /** Regex string matched against the full request URL. */
-  urlPattern: string;
+  /** URL matcher — a regex literal or a regex string. */
+  urlPattern: UrlMatcher;
   /** HTTP methods to match (case-insensitive). Empty = all methods. */
   methods?: string[];
   /** Action taken on a match. */
@@ -120,8 +123,8 @@ export interface Invariant {
   check: (ctx: InvariantContext) => boolean | string | void | Promise<boolean | string | void>;
   /** When to evaluate. Default: "afterActions". */
   when?: "afterLoad" | "afterActions";
-  /** Restrict to URLs matching this regex (string). If omitted, run on every page. */
-  urlPattern?: string;
+  /** Restrict to URLs matching this matcher (regex literal or regex string). Omit to run on every page. */
+  urlPattern?: UrlMatcher;
 }
 
 export interface InvariantContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,12 @@ export interface CrawlReport {
   baseUrl: string;
   /** Seed used for random action selection (for reproducibility). */
   seed: number;
+  /**
+   * Copy-pasteable CLI invocation that reproduces this run. Only includes
+   * CLI-expressible options; programmatic-only options (invariants,
+   * faultInjection) cannot be encoded in a shell command and are omitted.
+   */
+  reproCommand: string;
   startTime: number;
   endTime: number;
   duration: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,10 +153,18 @@ export interface PerformanceMetrics {
 
 export interface PageResult {
   url: string;
+  /**
+   * Outcome of the navigation, not the page overall. A page can have
+   * `status: "success"` but still contain console errors / exceptions /
+   * unhandled rejections — check `hasErrors` or `errors.length` to
+   * judge page health.
+   */
   status: "success" | "error" | "timeout" | "recovered";
   statusCode?: number;
   loadTime: number;
   errors: PageError[];
+  /** True when `errors.length > 0`. Computed once when the result is built. */
+  hasErrors: boolean;
   warnings: string[];
   metrics?: PerformanceMetrics;
   links: string[];
@@ -229,6 +237,8 @@ export interface CrawlSummary {
   errorPages: number;
   timeoutPages: number;
   recoveredPages: number;
+  /** Pages where `errors.length > 0`, independent of navigation status. */
+  pagesWithErrors: number;
   consoleErrors: number;
   networkErrors: number;
   jsExceptions: number;

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -95,4 +95,24 @@ describe("validateOptions", () => {
       /excludePatterns/
     );
   });
+
+  it("accepts a RegExp literal for fault urlPattern", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          faultInjection: [{ name: "r", urlPattern: /\/api\//, fault: { kind: "abort" } }],
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts a RegExp literal for invariant urlPattern", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          invariants: [{ name: "r", urlPattern: /home/, check: () => true }],
+        })
+      )
+    ).not.toThrow();
+  });
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { validateOptions } from "./crawler.js";
+
+function base(extra: Record<string, unknown> = {}): any {
+  return { baseUrl: "http://localhost:3000", ...extra };
+}
+
+describe("validateOptions", () => {
+  it("accepts a minimal valid config", () => {
+    expect(() => validateOptions(base())).not.toThrow();
+  });
+
+  it("rejects a non-URL baseUrl with a named message", () => {
+    expect(() => validateOptions({ baseUrl: "not-a-url" } as any)).toThrow(
+      /chaosbringer: "baseUrl"/
+    );
+  });
+
+  it("rejects negative maxPages", () => {
+    expect(() => validateOptions(base({ maxPages: -3 }))).toThrow(/maxPages/);
+  });
+
+  it("rejects zero maxPages", () => {
+    expect(() => validateOptions(base({ maxPages: 0 }))).toThrow(/maxPages/);
+  });
+
+  it("allows maxActionsPerPage of 0", () => {
+    expect(() => validateOptions(base({ maxActionsPerPage: 0 }))).not.toThrow();
+  });
+
+  it("rejects negative maxActionsPerPage", () => {
+    expect(() => validateOptions(base({ maxActionsPerPage: -1 }))).toThrow(/maxActionsPerPage/);
+  });
+
+  it("rejects non-integer timeout", () => {
+    expect(() => validateOptions(base({ timeout: 1.5 }))).toThrow(/timeout/);
+  });
+
+  it("rejects negative seed", () => {
+    expect(() => validateOptions(base({ seed: -1 }))).toThrow(/seed/);
+  });
+
+  it("rejects fault probability > 1", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          faultInjection: [
+            { name: "bad", urlPattern: ".*", fault: { kind: "status", status: 500 }, probability: 2 },
+          ],
+        })
+      )
+    ).toThrow(/probability/);
+  });
+
+  it("rejects fault probability < 0", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          faultInjection: [
+            { urlPattern: ".*", fault: { kind: "status", status: 500 }, probability: -0.1 },
+          ],
+        })
+      )
+    ).toThrow(/probability/);
+  });
+
+  it("rejects an invariant with a malformed urlPattern", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          invariants: [
+            {
+              name: "bad-pattern",
+              urlPattern: "(",
+              check: () => true,
+            },
+          ],
+        })
+      )
+    ).toThrow(/bad-pattern.*urlPattern/);
+  });
+
+  it("rejects a fault rule with a malformed urlPattern", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          faultInjection: [{ name: "bad", urlPattern: "(", fault: { kind: "abort" } }],
+        })
+      )
+    ).toThrow(/bad.*urlPattern/);
+  });
+
+  it("rejects an invalid excludePatterns regex", () => {
+    expect(() => validateOptions(base({ excludePatterns: ["("] }))).toThrow(
+      /excludePatterns/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4, #5, #6, #7, #8, #9, #10, #11, #12.

Implements every item filed after the DX review. Grouped into seven focused commits:

| Commit | Scope |
| --- | --- |
| `fix: compact report matches exit code + fail-fast option validation` | #6 (PASS/FAIL honours `--strict`), #8 (constructor throws named errors for invalid options) |
| `fix: normalize URLs before queue dedupe` | #9 (`http://x` and `http://x/` no longer double-visit) |
| `feat: accept RegExp or string for urlPattern` | #11 (`UrlMatcher = string \| RegExp`) |
| `feat: add PageResult.hasErrors and summary.pagesWithErrors` | #7 (non-breaking clarification that `status` is a nav outcome) |
| `feat: faults helpers, chaos() convenience, and report.reproCommand` | #12 (`faults.status/abort/delay`, `chaos({ … })`, self-describing CI logs) |
| `fix: CLI / report polish` | #10 (`--headless` help text, output ordering, `--ignore-analytics` contents) |
| `docs: rewrite README to cover seed / invariants / fault injection` | #4, #5 (all three headline features documented; snippets wrapped in `async function main()`) |

### New public surface

- `chaos(options, events?)` → `{ report, passed, exitCode }`
- `faults.status(code, opts)` / `faults.abort(opts)` / `faults.delay(ms, opts)`
- `validateOptions(opts)` (also invoked from the `ChaosCrawler` constructor)
- `PageResult.hasErrors`, `CrawlSummary.pagesWithErrors`, `CrawlReport.reproCommand`
- `UrlMatcher = string | RegExp` accepted on every `urlPattern` field

### Behaviour changes worth flagging

- Construction-time validation now throws `chaosbringer: "<field>" …` on bad inputs that used to be silently accepted (negative `maxPages`, `probability` outside `[0,1]`, malformed regex, non-URL `baseUrl`).
- Compact report's `[PASS]` / `[FAIL]` is derived from `getExitCode` and so reflects `--strict` + invariant violations.
- URL queue dedupes trailing slashes, fragments, and host casing.
- Invariants with a broken `urlPattern` now throw at construction time instead of silently never matching.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — 95 passed (7 files, incl. 6 e2e against the fixture)
- [x] `pnpm tsx fixtures/runner/run.ts --seed 42 --max-pages 4` → compact header now `[PASS] … (seed=42)`, full report contains a `Repro:` line
- [x] Manual: feeding obviously-bad options (negative maxPages, `probability: 2`, regex `(`) now throws named errors instead of silently accepting

https://claude.ai/code/session_01GGegJKyzEqkq4yTn2py43e