### PR TITLE
Error clustering + HAR record/replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,51 @@ const { passed } = await chaos({ baseUrl: "http://localhost:3000", invariants })
 
 Violations always fail the run (exit 1), whether or not `strict` is set — a declared invariant is a stronger signal than console noise.
 
+## HAR record / replay
+
+Chaosbringer can capture network traffic to a HAR file on one run and replay it on the next. A replay run is deterministic even if the backend is flaky — every request that was in the HAR gets served from the HAR, not the network.
+
+```bash
+# First run: capture responses
+chaosbringer --url http://localhost:3000 --seed 42 --har-record chaos.har
+
+# Later: replay without the server running
+chaosbringer --url http://localhost:3000 --seed 42 --har-replay chaos.har
+```
+
+Programmatic:
+
+```ts
+await chaos({
+  baseUrl: "http://localhost:3000",
+  seed: 42,
+  har: { path: "chaos.har", mode: "record" },
+});
+
+// Replay
+await chaos({
+  baseUrl: "http://localhost:3000",
+  seed: 42,
+  har: { path: "chaos.har", mode: "replay", notFound: "abort" },
+});
+```
+
+- `notFound: "fallback"` (default) lets unmatched URLs fall through to the real network.
+- `notFound: "abort"` fails them — useful when you want to prove a run is fully deterministic.
+- Fault injection rules still apply in replay mode and take precedence over HAR responses.
+
+## Error clustering
+
+`CrawlReport.errorClusters` collapses repeated errors so a run with 100 identical `console.error("Failed to load X")` calls surfaces as one cluster line with `count: 100`. Each cluster is keyed by `type` + a normalised fingerprint (URLs, line:col, and long numeric ids stripped).
+
+```
+ERROR CLUSTERS
+  [console]×42 [5 urls] Failed to load resource: the server responded with a status of <n> (Not Found)
+  [exception]×3 fixture: boom
+```
+
+Use it to triage noisy fuzz runs — high-count clusters are the first thing to look at.
+
 ## Exit codes
 
 | Condition | Exit |
@@ -241,6 +286,8 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 | `--log-level <level>` | `debug` / `info` / `warn` / `error` | info |
 | `--log-console` | Also log to console | false |
 | `--seed <n>` | Seed for deterministic action selection | random |
+| `--har-record <path>` | Capture network traffic to a HAR file | — |
+| `--har-replay <path>` | Replay network traffic from a HAR file | — |
 | `--compact` | Compact output | false |
 | `--strict` | Fail on console errors + JS exceptions | false |
 | `--quiet` | Minimal output | false |

--- a/fixtures/runner/e2e.test.ts
+++ b/fixtures/runner/e2e.test.ts
@@ -6,6 +6,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ChaosCrawler } from "../../src/crawler.js";
 import type { Invariant } from "../../src/types.js";
 import { startFixtureServer } from "../site/server.js";
@@ -69,6 +72,68 @@ describe("ChaosCrawler against fixture site", () => {
     // check if any appeared in blockedExternalNavigations as a weak signal.
     // (Keeping it assertion-free keeps the test deterministic under seed drift.)
     expect(report.blockedExternalNavigations).toBeGreaterThanOrEqual(0);
+  }, 120000);
+
+  it("records to HAR, then replays the same crawl with the server gone", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "chaosbringer-har-"));
+    const harPath = join(tmp, "replay.har");
+    try {
+      // 1. Record against the live fixture.
+      const live = await startFixtureServer(0);
+      const record = new ChaosCrawler({
+        baseUrl: live.url,
+        maxPages: 3,
+        maxActionsPerPage: 0,
+        headless: true,
+        seed: 11,
+        har: { path: harPath, mode: "record" },
+      });
+      const recordReport = await record.start();
+      await live.close();
+
+      expect(existsSync(harPath)).toBe(true);
+      expect(statSync(harPath).size).toBeGreaterThan(200);
+      expect(recordReport.har?.mode).toBe("record");
+      const recordedUrl = recordReport.baseUrl;
+
+      // 2. Replay against the HAR with the fixture server SHUT DOWN.
+      // notFound: "abort" ensures we're really hitting the HAR, not the network.
+      const replay = new ChaosCrawler({
+        baseUrl: recordedUrl,
+        maxPages: 3,
+        maxActionsPerPage: 0,
+        headless: true,
+        seed: 11,
+        har: { path: harPath, mode: "replay", notFound: "abort" },
+      });
+      const replayReport = await replay.start();
+      expect(replayReport.har?.mode).toBe("replay");
+      // Home page must load from HAR without the server running. The queue
+      // URL gets normalized with a trailing slash on root paths, so match by
+      // startsWith rather than strict equality.
+      expect(replayReport.pagesVisited).toBeGreaterThanOrEqual(1);
+      const home = replayReport.pages.find((p) => p.url.startsWith(recordedUrl));
+      expect(home).toBeDefined();
+      expect(home?.status).toBe("success");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  it("groups repeated identical errors into a single cluster", async () => {
+    const crawler = new ChaosCrawler({
+      baseUrl: `${server.url}/broken-link`,
+      maxPages: 1,
+      maxActionsPerPage: 0,
+      headless: true,
+      seed: 1,
+    });
+    const report = await crawler.start();
+    // broken-link responds 404, which yields a console error. Clusters must
+    // be populated and carry the navigation URL.
+    expect(report.errorClusters.length).toBeGreaterThan(0);
+    const c404 = report.errorClusters.find((c) => c.fingerprint.includes("status of <n>"));
+    expect(c404?.count).toBeGreaterThanOrEqual(1);
   }, 120000);
 
   it("marks a 500-injected page as recovered and fires onPageComplete with the final status", async () => {

--- a/fixtures/runner/har-demo.ts
+++ b/fixtures/runner/har-demo.ts
@@ -1,0 +1,52 @@
+/**
+ * Record network traffic from the fixture site to a HAR file, then replay
+ * it back with the fixture server SHUT DOWN. If replay works without the
+ * server, HAR capture + routing is correct.
+ */
+
+import { unlinkSync, existsSync, statSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ChaosCrawler } from "../../src/crawler.js";
+import { startFixtureServer } from "../site/server.js";
+
+const harPath = join(tmpdir(), `chaosbringer-demo-${Date.now()}.har`);
+
+// --- Record --------------------------------------------------------------
+const live = await startFixtureServer(0);
+console.log(`[record] fixture at ${live.url}, capturing to ${harPath}`);
+
+const recordCrawler = new ChaosCrawler({
+  baseUrl: live.url,
+  maxPages: 4,
+  maxActionsPerPage: 0,
+  headless: true,
+  seed: 1,
+  har: { path: harPath, mode: "record" },
+});
+const recordReport = await recordCrawler.start();
+console.log(`[record] pages=${recordReport.pagesVisited} visited=${recordReport.pages.map((p) => p.url).join(", ")}`);
+await live.close();
+
+const harSize = statSync(harPath).size;
+const har = JSON.parse(readFileSync(harPath, "utf-8"));
+console.log(`[record] HAR file size=${harSize} entries=${har.log.entries.length}`);
+console.log(`[record] HAR URLs:`);
+for (const entry of har.log.entries as Array<{ request: { url: string; method: string }; response: { status: number } }>) {
+  console.log(`    ${entry.request.method} ${entry.request.url} -> ${entry.response.status}`);
+}
+
+// --- Replay against the captured HAR, with the fixture server gone -------
+console.log(`\n[replay] fallback mode (missing URLs go to network — will fail since server is down)`);
+const replayCrawler = new ChaosCrawler({
+  baseUrl: recordReport.baseUrl,
+  maxPages: 4,
+  maxActionsPerPage: 0,
+  headless: true,
+  seed: 1,
+  har: { path: harPath, mode: "replay", notFound: "fallback" },
+});
+const replayReport = await replayCrawler.start();
+console.log(`[replay] pages=${replayReport.pagesVisited} visited=${replayReport.pages.map((p) => `${p.url}[${p.status}]`).join(", ")}`);
+
+if (existsSync(harPath)) unlinkSync(harPath);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,8 @@ const { values, positionals } = parseArgs({
     "log-level": { type: "string" },
     "log-console": { type: "boolean", default: false },
     seed: { type: "string" },
+    "har-record": { type: "string" },
+    "har-replay": { type: "string" },
     compact: { type: "boolean", default: false },
     strict: { type: "boolean", default: false },
     quiet: { type: "boolean", default: false },
@@ -80,6 +82,8 @@ OPTIONS:
   --log-level <level>   Log level: debug, info, warn, error (default: info)
   --log-console         Also output logs to console
   --seed <n>            Seed for deterministic action selection (reproduces a run)
+  --har-record <path>   Record network traffic to a HAR file (mutually exclusive with --har-replay)
+  --har-replay <path>   Replay network traffic from a HAR file (missing URLs fall through to network)
   --compact             Compact output format
   --strict              Exit with error on any console errors
   --quiet               Minimal output
@@ -140,6 +144,14 @@ if (values.seed !== undefined) {
   seed = parsed;
 }
 
+let har: CrawlerOptions["har"];
+if (values["har-record"] && values["har-replay"]) {
+  console.error("Error: --har-record and --har-replay are mutually exclusive");
+  process.exit(1);
+}
+if (values["har-record"]) har = { path: values["har-record"], mode: "record" };
+if (values["har-replay"]) har = { path: values["har-replay"], mode: "replay" };
+
 const options: CrawlerOptions = {
   baseUrl,
   maxPages: values["max-pages"] ? parseInt(values["max-pages"], 10) : undefined,
@@ -155,6 +167,7 @@ const options: CrawlerOptions = {
   logLevel: logLevel,
   logToConsole: values["log-console"],
   seed,
+  har,
 };
 
 const outputPath = values.output || "chaos-report.json";

--- a/src/clusters.test.ts
+++ b/src/clusters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { clusterErrors, fingerprintError } from "./clusters.js";
+import type { PageError } from "./types.js";
+
+function err(overrides: Partial<PageError> & { message: string; type: PageError["type"] }): PageError {
+  return {
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+describe("fingerprintError", () => {
+  it("strips URLs so identical-shape messages collide", () => {
+    const a = fingerprintError(err({ type: "console", message: "Failed: http://x:3000/a/1" }));
+    const b = fingerprintError(err({ type: "console", message: "Failed: http://y:9999/b/2" }));
+    expect(a).toBe(b);
+  });
+
+  it("strips source locations", () => {
+    const a = fingerprintError(err({ type: "exception", message: "boom at a.js:12:5" }));
+    const b = fingerprintError(err({ type: "exception", message: "boom at a.js:99:7" }));
+    expect(a).toBe(b);
+  });
+
+  it("strips large numeric ids but keeps small ones", () => {
+    const a = fingerprintError(err({ type: "console", message: "user 12345 not found" }));
+    const b = fingerprintError(err({ type: "console", message: "user 98765 not found" }));
+    expect(a).toBe(b);
+  });
+
+  it("distinct message shapes produce distinct fingerprints", () => {
+    expect(fingerprintError(err({ type: "console", message: "network failed" }))).not.toBe(
+      fingerprintError(err({ type: "console", message: "auth rejected" }))
+    );
+  });
+});
+
+describe("clusterErrors", () => {
+  it("collapses identical errors", () => {
+    const errors: PageError[] = Array.from({ length: 10 }, () =>
+      err({ type: "console", message: "same message" })
+    );
+    const clusters = clusterErrors(errors);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]!.count).toBe(10);
+  });
+
+  it("splits distinct types apart even with same fingerprint", () => {
+    const clusters = clusterErrors([
+      err({ type: "console", message: "oops" }),
+      err({ type: "exception", message: "oops" }),
+    ]);
+    expect(clusters).toHaveLength(2);
+  });
+
+  it("tracks distinct urls on a cluster", () => {
+    const clusters = clusterErrors([
+      err({ type: "console", message: "HTTP 500 on http://x/a", url: "http://x/a" }),
+      err({ type: "console", message: "HTTP 500 on http://x/b", url: "http://x/b" }),
+      err({ type: "console", message: "HTTP 500 on http://x/a", url: "http://x/a" }),
+    ]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]!.count).toBe(3);
+    expect(clusters[0]!.urls.sort()).toEqual(["http://x/a", "http://x/b"]);
+  });
+
+  it("sorts most frequent cluster first", () => {
+    const clusters = clusterErrors([
+      err({ type: "console", message: "rare" }),
+      ...Array.from({ length: 5 }, () => err({ type: "console", message: "common" })),
+      err({ type: "console", message: "rare" }),
+    ]);
+    expect(clusters[0]!.count).toBe(5);
+    expect(clusters[1]!.count).toBe(2);
+  });
+
+  it("records invariant names per cluster", () => {
+    const clusters = clusterErrors([
+      err({ type: "invariant-violation", message: "[has-h1] no <h1>", invariantName: "has-h1" }),
+      err({ type: "invariant-violation", message: "[has-h1] no <h1>", invariantName: "has-h1" }),
+    ]);
+    expect(clusters[0]!.invariantNames).toEqual(["has-h1"]);
+  });
+});

--- a/src/clusters.ts
+++ b/src/clusters.ts
@@ -1,0 +1,75 @@
+/**
+ * Group similar PageError entries into clusters so a run with 100 identical
+ * `console.error("Failed to load X")` calls becomes one cluster with count=100
+ * instead of 100 lines.
+ *
+ * A "fingerprint" normalises the message — strips URLs, numbers, and stack
+ * locations — so that `HTTP 500 on /api/users/42` and `HTTP 500 on /api/users/99`
+ * collapse to the same cluster but don't swallow unrelated errors.
+ */
+
+import type { PageError } from "./types.js";
+
+export interface ErrorCluster {
+  /** `<type>|<fingerprint>` — stable across runs. */
+  key: string;
+  type: PageError["type"];
+  fingerprint: string;
+  /** A representative error (first one seen). */
+  sample: PageError;
+  /** Number of errors that collapsed into this cluster. */
+  count: number;
+  /** Distinct page URLs on which this cluster fired. */
+  urls: string[];
+  /** Distinct invariant names (only meaningful for type=invariant-violation). */
+  invariantNames?: string[];
+}
+
+/** Normalise an error message to its fingerprint. */
+export function fingerprintError(err: PageError): string {
+  let msg = err.message ?? "";
+  msg = msg
+    // URLs in message bodies vary per run — collapse them.
+    .replace(/https?:\/\/[^\s"'()<>]+/g, "<url>")
+    // Source locations like `foo.js:123:45`
+    .replace(/:\d+:\d+/g, ":<loc>")
+    // Ephemeral ports (4-5 digits). Keep 6+ digit numbers; they're rarely a port.
+    .replace(/:\d{4,5}\b/g, ":<port>")
+    // Any other long-ish number run — ids, counts, timestamps
+    .replace(/\b\d{3,}\b/g, "<n>")
+    // Collapse whitespace
+    .replace(/\s+/g, " ")
+    .trim();
+
+  // Keep the prefix so messages of different shapes don't collide.
+  return msg.slice(0, 160);
+}
+
+/** Collapse a list of errors into stable clusters. */
+export function clusterErrors(errors: readonly PageError[]): ErrorCluster[] {
+  const bucket = new Map<string, ErrorCluster>();
+  for (const err of errors) {
+    const fp = fingerprintError(err);
+    const key = `${err.type}|${fp}`;
+    const existing = bucket.get(key);
+    if (existing) {
+      existing.count++;
+      if (err.url && !existing.urls.includes(err.url)) existing.urls.push(err.url);
+      if (err.invariantName && existing.invariantNames && !existing.invariantNames.includes(err.invariantName)) {
+        existing.invariantNames.push(err.invariantName);
+      }
+    } else {
+      bucket.set(key, {
+        key,
+        type: err.type,
+        fingerprint: fp,
+        sample: err,
+        count: 1,
+        urls: err.url ? [err.url] : [],
+        invariantNames: err.invariantName ? [err.invariantName] : undefined,
+      });
+    }
+  }
+  // Sort by count descending — most frequent first, which is the priority for triage.
+  return [...bucket.values()].sort((a, b) => b.count - a.count);
+}

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -39,6 +39,7 @@ import {
   normalizeUrl,
 } from "./filters.js";
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
+import { clusterErrors } from "./clusters.js";
 
 const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl">> = {
   maxPages: 50,
@@ -1128,6 +1129,7 @@ export class ChaosCrawler {
       actions: this.actions,
       summary,
       faultInjections: this.compiledFaultRules.length > 0 ? this.getFaultStats() : undefined,
+      errorClusters: clusterErrors(this.results.flatMap((r) => r.errors)),
     };
   }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -41,7 +41,9 @@ import {
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 import { clusterErrors } from "./clusters.js";
 
-const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl">> = {
+// `har` has no meaningful default (it's opt-in), so we carve it out of the
+// Required<> type instead of inventing a sentinel.
+const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl" | "har">> = {
   maxPages: 50,
   maxActionsPerPage: 5,
   timeout: 30000,
@@ -334,7 +336,18 @@ export class ChaosCrawler {
     this.context = await this.browser.newContext({
       viewport: this.options.viewport,
       userAgent: this.options.userAgent || undefined,
+      // Record mode: ask Playwright to capture all network into the HAR.
+      recordHar: this.options.har?.mode === "record" ? { path: this.options.har.path } : undefined,
     });
+
+    // Replay mode: serve every matching request from the HAR before it hits
+    // the network. Fault injection (installed per-page) still wins because
+    // page.route runs before context.route in Playwright.
+    if (this.options.har?.mode === "replay") {
+      await this.context.routeFromHAR(this.options.har.path, {
+        notFound: this.options.har.notFound ?? "fallback",
+      });
+    }
 
     try {
       while (this.queue.length > 0 && this.visited.size < this.options.maxPages) {
@@ -369,6 +382,9 @@ export class ChaosCrawler {
         }
       }
     } finally {
+      // Close the context explicitly so the HAR file (record mode) is flushed
+      // before `browser.close()` tears everything down.
+      await this.context?.close();
       await this.browser.close();
     }
 
@@ -467,7 +483,9 @@ export class ChaosCrawler {
         // Allow non-navigation external requests (images, scripts, etc.)
       }
 
-      await route.continue();
+      // route.fallback() (not continue) so context-level routes — notably
+      // routeFromHAR for replay — still get a chance to serve this request.
+      await route.fallback();
     });
   }
 
@@ -1130,6 +1148,7 @@ export class ChaosCrawler {
       summary,
       faultInjections: this.compiledFaultRules.length > 0 ? this.getFaultStats() : undefined,
       errorClusters: clusterErrors(this.results.flatMap((r) => r.errors)),
+      har: this.options.har,
     };
   }
 
@@ -1239,6 +1258,18 @@ export function validateOptions(options: CrawlerOptions): void {
   for (const inv of options.invariants ?? []) {
     assertMatcher(`invariant "${inv.name}" urlPattern`, inv.urlPattern);
   }
+
+  if (options.har) {
+    const { path, mode } = options.har;
+    if (typeof path !== "string" || path.length === 0) {
+      throw new Error(`chaosbringer: "har.path" must be a non-empty string`);
+    }
+    if (mode !== "record" && mode !== "replay") {
+      throw new Error(
+        `chaosbringer: "har.mode" must be "record" or "replay" (got ${JSON.stringify(mode)})`
+      );
+    }
+  }
 }
 
 /** Shell-quote a value for inclusion in a reproducible CLI invocation. */
@@ -1310,7 +1341,7 @@ async function applyFault(route: Route, fault: Fault): Promise<void> {
     }
     case "delay":
       await new Promise((r) => setTimeout(r, fault.ms));
-      await route.continue();
+      await route.fallback();
       return;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,4 +35,6 @@ export type {
   FaultRule,
   FaultInjectionStats,
   UrlMatcher,
+  HarConfig,
+  HarMode,
 } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { formatReport, formatCompactReport, saveReport, printReport, getExitCode
 export { Logger, createNullLogger, type LogEntry, type LogLevel, type LoggerOptions } from "./logger.js";
 export { chaos, type ChaosResult, type ChaosRunOptions } from "./chaos.js";
 export { faults, type FaultHelperOptions } from "./faults.js";
+export { clusterErrors, fingerprintError, type ErrorCluster } from "./clusters.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -38,6 +38,7 @@ function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
     pages: [],
     actions: [],
     summary: makeSummary(),
+    errorClusters: [],
     ...overrides,
   };
 }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -15,6 +15,10 @@ export function formatReport(report: CrawlReport): string {
   lines.push(`Base URL: ${report.baseUrl}`);
   lines.push(`Seed: ${report.seed}`);
   lines.push(`Repro: ${report.reproCommand}`);
+  if (report.har) {
+    const arrow = report.har.mode === "record" ? "→" : "←";
+    lines.push(`HAR:   ${report.har.mode} ${arrow} ${report.har.path}`);
+  }
   lines.push(`Duration: ${(report.duration / 1000).toFixed(2)}s`);
   lines.push(`Pages Visited: ${report.pagesVisited}`);
   if (report.blockedExternalNavigations > 0) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -156,6 +156,18 @@ export function formatReport(report: CrawlReport): string {
     }
   }
 
+  if (report.errorClusters.length > 0) {
+    lines.push("");
+    lines.push("-".repeat(40));
+    lines.push("ERROR CLUSTERS");
+    lines.push("-".repeat(40));
+    for (const cluster of report.errorClusters) {
+      const countStr = cluster.count > 1 ? `×${cluster.count}` : "";
+      const urlStr = cluster.urls.length > 1 ? ` [${cluster.urls.length} urls]` : "";
+      lines.push(`  [${cluster.type}]${countStr}${urlStr} ${truncate(cluster.fingerprint, 80)}`);
+    }
+  }
+
   if (report.faultInjections && report.faultInjections.length > 0) {
     lines.push("");
     lines.push("-".repeat(40));

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,22 @@ export interface CrawlerOptions {
   invariants?: Invariant[];
   /** Fault injection rules applied via Playwright's route API. */
   faultInjection?: FaultRule[];
+  /** HAR record/replay configuration for deterministic network state. */
+  har?: HarConfig;
+}
+
+/** `record` captures responses to a HAR file; `replay` serves them back. */
+export type HarMode = "record" | "replay";
+
+export interface HarConfig {
+  /** Filesystem path to the HAR file. */
+  path: string;
+  mode: HarMode;
+  /**
+   * When replaying and a request has no match in the HAR, fall through to the
+   * network (`"fallback"`, default) or fail it (`"abort"`).
+   */
+  notFound?: "fallback" | "abort";
 }
 
 import type { ErrorCluster } from "./clusters.js";
@@ -245,6 +261,8 @@ export interface CrawlReport {
    * repeatedly. Always populated, even when empty.
    */
   errorClusters: ErrorCluster[];
+  /** Echo of the HAR config used for this run, if any. */
+  har?: HarConfig;
 }
 
 export interface CrawlSummary {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,9 @@ export interface CrawlerOptions {
   faultInjection?: FaultRule[];
 }
 
+import type { ErrorCluster } from "./clusters.js";
+export type { ErrorCluster };
+
 /** What to do when a FaultRule matches a request. */
 export type Fault =
   | { kind: "abort"; errorCode?: string }
@@ -236,6 +239,12 @@ export interface CrawlReport {
   summary: CrawlSummary;
   /** Per-rule fault injection stats (present only when rules were configured). */
   faultInjections?: FaultInjectionStats[];
+  /**
+   * Errors grouped into clusters by fingerprint (type + normalised message).
+   * Use `ErrorCluster.count` to triage noisy runs where the same issue fires
+   * repeatedly. Always populated, even when empty.
+   */
+  errorClusters: ErrorCluster[];
 }
 
 export interface CrawlSummary {


### PR DESCRIPTION
## Summary

Two features that move chaosbringer from "runs chaos" to "runs deterministic chaos":

- **Error clustering** — collapse repeated errors by fingerprint (type + normalised message with URLs / `:line:col` / long numeric ids stripped). A noisy run with 100 identical console errors now surfaces as one `×100` cluster line, most-frequent first. `CrawlReport.errorClusters` is always populated; new "ERROR CLUSTERS" section in the full report.
- **HAR record / replay** — `--har-record <path>` captures every response, `--har-replay <path>` serves them back. A replay run is deterministic even with the backend gone. Required a latent fix — page-level `route.continue()` was skipping context-level routes, including `routeFromHAR`; swapped to `route.fallback()`. Fault injection still wins over HAR because page routes run before context routes.

### Commits

| | |
| --- | --- |
| `feat: error clustering` | `src/clusters.ts` (fingerprint + cluster), reporter section, 9 unit tests, exported from package root |
| `feat: HAR record / replay for deterministic network state` | `CrawlerOptions.har`, CLI flags, `route.fallback()` fix, e2e record→replay test against the fixture |

### New public surface

- `clusterErrors(errors)`, `fingerprintError(err)`, `ErrorCluster`
- `HarConfig`, `HarMode`, `CrawlerOptions.har`, `CrawlReport.har`
- `CrawlReport.errorClusters: ErrorCluster[]`
- CLI: `--har-record <path>`, `--har-replay <path>` (mutually exclusive)

### Behaviour changes worth flagging

- `PageResult`'s internal route handler now calls `route.fallback()` instead of `route.continue()` for pass-through requests. This is the compatible choice: `fallback()` continues to network when no other handler matches. Needed to make HAR replay work.
- `BrowserContext` is now closed explicitly before `browser.close()` so HAR writes flush.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — 106 passed (8 files; 2 new cases for clusters + HAR roundtrip)
- [x] `pnpm tsx fixtures/runner/har-demo.ts` — record 4 pages, shut fixture down, replay all 4 pages from HAR

https://claude.ai/code/session_01GGegJKyzEqkq4yTn2py43e