### PR TITLE
ci: add build + test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit path)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Test
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "description": "Playwright-based chaos testing tool for web applications",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Summary

Adds a minimal GitHub Actions pipeline that runs on every push to main and every pull request.

- Node 22, pnpm via `packageManager` pin in `package.json` (local/CI drift-proof)
- `pnpm install --frozen-lockfile` → `pnpm build` → `pnpm test`
- Cached Playwright Chromium install (key = `pnpm-lock.yaml` hash), with a fallback step that only pulls system libs on cache hit
- 10 min job timeout (local run ≈30s)

This is PR 1 of a series — intentionally minimal so we can watch it pass green, then layer on (typecheck only, lint, coverage, platform matrix) in follow-up PRs.

## Test plan

- [x] `pnpm install --frozen-lockfile` — lockfile in sync
- [x] `pnpm build` — green locally
- [x] `pnpm test` — 106 passed locally
- [x] CI run on this PR — will observe in the Checks tab

https://claude.ai/code/session_01GGegJKyzEqkq4yTn2py43e