### PR TITLE
Add baseline diff, auth, perf budget, axe, trace record/replay/minimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,26 @@ await chaos({
 - `notFound: "abort"` fails them — useful when you want to prove a run is fully deterministic.
 - Fault injection rules still apply in replay mode and take precedence over HAR responses.
 
+## Performance budget
+
+Declare a per-metric budget (in ms). Any page whose measured metric exceeds its limit is recorded as an invariant violation (`perf-budget.<metric>`), which fails the run just like any other invariant.
+
+```bash
+# CLI — comma-separated pairs, or repeat the flag
+chaosbringer --url http://localhost:3000 --budget ttfb=200,fcp=1800,lcp=2500
+```
+
+```ts
+await chaos({
+  baseUrl: "http://localhost:3000",
+  performanceBudget: { ttfb: 200, fcp: 1800, lcp: 2500 },
+});
+```
+
+Supported keys: `ttfb`, `fcp`, `lcp`, `tbt`, `domContentLoaded`, `load`. Omitted keys are not enforced. Metrics that weren't captured (e.g. `lcp` on a page that didn't render anything large) don't produce violations — only observed-and-over-limit cases do.
+
+Budget violations are clustered by metric name, so `perf-budget.lcp` firing on 20 pages shows up as one cluster with `count: 20` in the report and the baseline diff.
+
 ## Baseline diff (regression detection)
 
 Pass a previous report to `--baseline` and the current run is diffed against it — new error clusters and newly failing pages are surfaced separately from ones that were already broken.
@@ -356,6 +376,7 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 | `--har-record <path>` | Capture network traffic to a HAR file | — |
 | `--har-replay <path>` | Replay network traffic from a HAR file | — |
 | `--storage-state <path>` | Playwright storageState JSON for authenticated crawls | — |
+| `--budget <k=ms,...>` | Per-metric performance budget (repeatable) | — |
 | `--baseline <path>` | Diff this run against a previous report | — |
 | `--baseline-strict` | Fail on new clusters / newly failing pages vs baseline | false |
 | `--compact` | Compact output | false |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,35 @@ await chaos({
 - `notFound: "abort"` fails them — useful when you want to prove a run is fully deterministic.
 - Fault injection rules still apply in replay mode and take precedence over HAR responses.
 
+## Accessibility (axe-core)
+
+Install `axe-core` as a peer and opt in with either the `invariants.axe()` preset or the `--axe` flag. Each visited page is scanned; violations are reported as invariant failures (name: `a11y-axe`), which always fail the run.
+
+```bash
+pnpm add axe-core
+chaosbringer --url http://localhost:3000 --axe
+chaosbringer --url http://localhost:3000 --axe --axe-tags wcag2aa,best-practice
+```
+
+```ts
+import { chaos, invariants } from "chaosbringer";
+
+await chaos({
+  baseUrl: "http://localhost:3000",
+  invariants: [
+    invariants.axe({
+      tags: ["wcag2aa"],
+      exclude: [".third-party-widget"],
+      disableRules: ["color-contrast"],
+    }),
+  ],
+});
+```
+
+`axe-core` is an optional peer dependency — the preset fails with a clear install hint if it isn't present. The preset is thin; drop to a custom invariant if you need multiple axe runs per page, per-URL rule overrides, or full-result capture (passes / incomplete).
+
+A failing scan is rendered on one line: `[a11y-axe] 3 a11y violations: color-contrast(×5, serious), image-alt(×2, critical), region(×1)`. Because violations cluster by their fingerprint, a11y regressions show up in the baseline diff just like any other invariant.
+
 ## Performance budget
 
 Declare a per-metric budget (in ms). Any page whose measured metric exceeds its limit is recorded as an invariant violation (`perf-budget.<metric>`), which fails the run just like any other invariant.
@@ -377,6 +406,8 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 | `--har-replay <path>` | Replay network traffic from a HAR file | — |
 | `--storage-state <path>` | Playwright storageState JSON for authenticated crawls | — |
 | `--budget <k=ms,...>` | Per-metric performance budget (repeatable) | — |
+| `--axe` | Enable axe-core a11y scan on every page (requires `axe-core` installed) | false |
+| `--axe-tags <list>` | Comma-separated axe tags | `wcag2a,wcag2aa,wcag21a,wcag21aa` |
 | `--baseline <path>` | Diff this run against a previous report | — |
 | `--baseline-strict` | Fail on new clusters / newly failing pages vs baseline | false |
 | `--compact` | Compact output | false |

--- a/README.md
+++ b/README.md
@@ -285,6 +285,30 @@ Supported keys: `ttfb`, `fcp`, `lcp`, `tbt`, `domContentLoaded`, `load`. Omitted
 
 Budget violations are clustered by metric name, so `perf-budget.lcp` firing on 20 pages shows up as one cluster with `count: 20` in the report and the baseline diff.
 
+## Trace record / replay / minimize
+
+For failures that are hard to diagnose from a seed alone, record the exact sequence of visits + actions to a JSONL file, then replay or minimize that sequence.
+
+```bash
+# Record
+chaosbringer --url http://localhost:3000 --seed 42 --trace-out chaos.trace.jsonl
+
+# Replay the exact sequence (no RNG, no discovery)
+chaosbringer --url http://localhost:3000 --trace-replay chaos.trace.jsonl
+
+# Shrink the trace to the minimum subsequence that still reproduces a failure
+chaosbringer minimize --url http://localhost:3000 \
+  --trace chaos.trace.jsonl \
+  --match "Cannot read properties of undefined" \
+  --trace-out min.trace.jsonl
+```
+
+A trace is line-delimited JSON: a leading `meta` entry with the seed + baseUrl, then alternating `visit` and `action` lines. Each `action` carries the selector that was clicked (or the scroll amount, or the input target), so replay can locate the same element in a fresh page. The format version is tracked — parsing refuses traces written by incompatible future versions rather than silently misinterpreting them.
+
+Replay skips link discovery and the RNG entirely: only URLs listed as `visit` entries are loaded, and only the recorded actions are performed. Missing selectors are logged as failed actions and the run continues.
+
+`minimize` drives repeated replays via delta debugging (ddmin) — it keeps removing action entries and re-running as long as `--match` still fires against an error cluster. Output goes to `--trace-out` (defaults to `min.trace.jsonl`).
+
 ## Baseline diff (regression detection)
 
 Pass a previous report to `--baseline` and the current run is diffed against it — new error clusters and newly failing pages are surfaced separately from ones that were already broken.
@@ -408,6 +432,8 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 | `--budget <k=ms,...>` | Per-metric performance budget (repeatable) | — |
 | `--axe` | Enable axe-core a11y scan on every page (requires `axe-core` installed) | false |
 | `--axe-tags <list>` | Comma-separated axe tags | `wcag2a,wcag2aa,wcag21a,wcag21aa` |
+| `--trace-out <path>` | Write a JSONL trace of visits + actions | — |
+| `--trace-replay <path>` | Replay a previously recorded trace | — |
 | `--baseline <path>` | Diff this run against a previous report | — |
 | `--baseline-strict` | Fail on new clusters / newly failing pages vs baseline | false |
 | `--compact` | Compact output | false |

--- a/README.md
+++ b/README.md
@@ -406,6 +406,22 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 });
 ```
 
+## Subcommands
+
+### `minimize`
+
+Shrink a recorded trace to the minimum subsequence of actions that still reproduces a failure. Drives ddmin (delta debugging) by repeatedly running the crawler in replay mode with subsets of the recorded actions; the reproduction predicate matches an error cluster fingerprint against a regex.
+
+```bash
+chaosbringer minimize \
+  --url http://localhost:3000 \
+  --trace chaos.trace.jsonl \
+  --match "Cannot read properties of undefined" \
+  --trace-out min.trace.jsonl
+```
+
+`--max-pages`, `--timeout`, `--ignore-analytics` are forwarded to each replay. `min.trace.jsonl` is the default output path. Visit entries are preserved — only action entries are candidates for removal.
+
 ## CLI reference
 
 | Option | Description | Default |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,40 @@ const { passed } = await chaos({ baseUrl: "http://localhost:3000", invariants })
 
 Violations always fail the run (exit 1), whether or not `strict` is set — a declared invariant is a stronger signal than console noise.
 
+## Authenticated crawls (storage state)
+
+To crawl pages behind a login, point chaosbringer at a Playwright `storageState` file — the JSON containing cookies + localStorage that a logged-in browser context produces. Run a one-off login script once, save the state, then reuse it for every chaos run.
+
+```ts
+// auth-setup.ts — run once, or as a Playwright global setup
+import { chromium } from "playwright";
+
+const browser = await chromium.launch();
+const context = await browser.newContext();
+const page = await context.newPage();
+await page.goto("http://localhost:3000/login");
+await page.getByLabel("Email").fill("ci@example.com");
+await page.getByLabel("Password").fill(process.env.TEST_PASSWORD!);
+await page.getByRole("button", { name: "Sign in" }).click();
+await page.waitForURL("**/dashboard");
+await context.storageState({ path: "auth.json" });
+await browser.close();
+```
+
+```bash
+# Chaos-test the authenticated surface
+chaosbringer --url http://localhost:3000/dashboard --storage-state auth.json
+```
+
+```ts
+await chaos({
+  baseUrl: "http://localhost:3000/dashboard",
+  storageState: "auth.json",
+});
+```
+
+The file is read by Playwright and not modified by the crawl. If the session expires mid-run, you'll see auth-redirect pages surface as errors — regenerate the state file and rerun.
+
 ## HAR record / replay
 
 Chaosbringer can capture network traffic to a HAR file on one run and replay it on the next. A replay run is deterministic even if the backend is flaky — every request that was in the HAR gets served from the HAR, not the network.
@@ -321,6 +355,7 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 | `--seed <n>` | Seed for deterministic action selection | random |
 | `--har-record <path>` | Capture network traffic to a HAR file | — |
 | `--har-replay <path>` | Replay network traffic from a HAR file | — |
+| `--storage-state <path>` | Playwright storageState JSON for authenticated crawls | — |
 | `--baseline <path>` | Diff this run against a previous report | — |
 | `--baseline-strict` | Fail on new clusters / newly failing pages vs baseline | false |
 | `--compact` | Compact output | false |

--- a/README.md
+++ b/README.md
@@ -202,6 +202,39 @@ await chaos({
 - `notFound: "abort"` fails them — useful when you want to prove a run is fully deterministic.
 - Fault injection rules still apply in replay mode and take precedence over HAR responses.
 
+## Baseline diff (regression detection)
+
+Pass a previous report to `--baseline` and the current run is diffed against it — new error clusters and newly failing pages are surfaced separately from ones that were already broken.
+
+```bash
+# First run: writes chaos-report.json as usual (no baseline yet, warns and continues)
+chaosbringer --url http://localhost:3000 --baseline chaos-report.json
+
+# Subsequent runs: compare against the prior report
+chaosbringer --url http://localhost:3000 --baseline chaos-report.json --baseline-strict
+```
+
+- `--baseline <path>` — diff against this report. A missing file produces a warning, not an error (the run still writes its own report so a later invocation has a baseline to compare against).
+- `--baseline-strict` — exit 1 when the diff contains new clusters or newly failing pages. Resolved / unchanged entries never fail the run.
+
+Programmatic:
+
+```ts
+import { chaos } from "chaosbringer";
+
+const { report, passed } = await chaos({
+  baseUrl: "http://localhost:3000",
+  baseline: "chaos-report.json",
+  baselineStrict: true,
+});
+
+for (const c of report.diff?.newClusters ?? []) {
+  console.log(`NEW [${c.type}]×${c.after}: ${c.fingerprint}`);
+}
+```
+
+Clusters are matched by the same fingerprint used for `errorClusters` (URL / line:col / long numeric ids stripped), so `HTTP 500 on /api/users/42` and `HTTP 500 on /api/users/99` collapse to the same entry. Pages are matched by URL.
+
 ## Error clustering
 
 `CrawlReport.errorClusters` collapses repeated errors so a run with 100 identical `console.error("Failed to load X")` calls surfaces as one cluster line with `count: 100`. Each cluster is keyed by `type` + a normalised fingerprint (URLs, line:col, and long numeric ids stripped).
@@ -288,6 +321,8 @@ chaosTest("crawl entire site", async ({ chaos }) => {
 | `--seed <n>` | Seed for deterministic action selection | random |
 | `--har-record <path>` | Capture network traffic to a HAR file | — |
 | `--har-replay <path>` | Replay network traffic from a HAR file | — |
+| `--baseline <path>` | Diff this run against a previous report | — |
+| `--baseline-strict` | Fail on new clusters / newly failing pages vs baseline | false |
 | `--compact` | Compact output | false |
 | `--strict` | Fail on console errors + JS exceptions | false |
 | `--quiet` | Minimal output | false |

--- a/package.json
+++ b/package.json
@@ -43,16 +43,21 @@
   ],
   "peerDependencies": {
     "@playwright/test": "^1.40.0",
+    "axe-core": "^4.0.0",
     "playwright": "^1.40.0"
   },
   "peerDependenciesMeta": {
     "@playwright/test": {
+      "optional": true
+    },
+    "axe-core": {
       "optional": true
     }
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.0.0",
+    "axe-core": "^4.11.3",
     "playwright": "^1.52.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      axe-core:
+        specifier: ^4.11.3
+        version: 4.11.3
       playwright:
         specifier: ^1.52.0
         version: 1.59.1
@@ -375,6 +378,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -837,6 +844,8 @@ snapshots:
       tinyrainbow: 2.0.0
 
   assertion-error@2.0.1: {}
+
+  axe-core@4.11.3: {}
 
   cac@6.7.14: {}
 

--- a/src/budget.test.ts
+++ b/src/budget.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { checkPerformanceBudget } from "./budget.js";
+
+describe("checkPerformanceBudget", () => {
+  it("returns no violations when budget is undefined", () => {
+    expect(checkPerformanceBudget({ ttfb: 5000 }, undefined, "http://x/")).toEqual([]);
+  });
+
+  it("returns no violations when every metric is within limit", () => {
+    const out = checkPerformanceBudget(
+      { ttfb: 100, fcp: 500, lcp: 1000 },
+      { ttfb: 200, fcp: 1800, lcp: 2500 },
+      "http://x/"
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("flags each breached metric as a separate invariant-violation", () => {
+    const out = checkPerformanceBudget(
+      { ttfb: 500, fcp: 2000, lcp: 3000 },
+      { ttfb: 200, fcp: 1800, lcp: 2500 },
+      "http://x/"
+    );
+    expect(out).toHaveLength(3);
+    const names = out.map((e) => e.invariantName).sort();
+    expect(names).toEqual(["perf-budget.fcp", "perf-budget.lcp", "perf-budget.ttfb"]);
+    for (const e of out) {
+      expect(e.type).toBe("invariant-violation");
+      expect(e.url).toBe("http://x/");
+    }
+  });
+
+  it("treats equality as within budget (<=, not <)", () => {
+    const out = checkPerformanceBudget({ ttfb: 200 }, { ttfb: 200 }, "http://x/");
+    expect(out).toEqual([]);
+  });
+
+  it("ignores metrics that were not measured", () => {
+    // lcp wasn't captured; the budget on it should not produce a violation.
+    const out = checkPerformanceBudget(
+      { ttfb: 100 },
+      { ttfb: 200, lcp: 1000 },
+      "http://x/"
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("ignores budget entries with non-numeric limits defensively", () => {
+    const out = checkPerformanceBudget(
+      { ttfb: 5000 },
+      // biome-ignore lint: testing defensive path
+      { ttfb: undefined as unknown as number },
+      "http://x/"
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("rounds measured ms in the message and includes the budget", () => {
+    const out = checkPerformanceBudget(
+      { ttfb: 250.7 },
+      { ttfb: 200 },
+      "http://x/",
+      123456
+    );
+    expect(out[0]!.message).toBe("[perf-budget.ttfb] ttfb=251ms > budget 200ms");
+    expect(out[0]!.timestamp).toBe(123456);
+  });
+});

--- a/src/budget.ts
+++ b/src/budget.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-page performance budget enforcement. Kept as pure helpers so unit tests
+ * don't need a running browser — the crawler calls `checkPerformanceBudget`
+ * after metrics are collected and appends the resulting PageErrors.
+ */
+
+import type { PageError, PerformanceBudget, PerformanceMetrics } from "./types.js";
+import { PERF_BUDGET_KEYS } from "./types.js";
+
+/**
+ * Compare measured metrics against a budget and return one invariant-violation
+ * per breach. Returns an empty array when budget is undefined or empty,
+ * or when every measured metric is within its limit.
+ */
+export function checkPerformanceBudget(
+  metrics: PerformanceMetrics,
+  budget: PerformanceBudget | undefined,
+  url: string,
+  now: number = Date.now()
+): PageError[] {
+  if (!budget) return [];
+  const errors: PageError[] = [];
+  for (const key of PERF_BUDGET_KEYS) {
+    const limit = budget[key];
+    const measured = metrics[key];
+    if (typeof limit !== "number" || typeof measured !== "number") continue;
+    if (measured <= limit) continue;
+    const name = `perf-budget.${key}`;
+    errors.push({
+      type: "invariant-violation",
+      message: `[${name}] ${key}=${Math.round(measured)}ms > budget ${limit}ms`,
+      invariantName: name,
+      url,
+      timestamp: now,
+    });
+  }
+  return errors;
+}

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -5,6 +5,7 @@
  */
 
 import { ChaosCrawler } from "./crawler.js";
+import { diffReports, hasRegressions, loadBaseline } from "./diff.js";
 import { getExitCode } from "./reporter.js";
 import type { CrawlerEvents, CrawlerOptions, CrawlReport } from "./types.js";
 
@@ -17,15 +18,34 @@ export interface ChaosResult {
 export interface ChaosRunOptions extends CrawlerOptions {
   /** Treat console errors / JS exceptions as failures when computing exitCode. */
   strict?: boolean;
+  /**
+   * Path to a previous report to diff against. A missing file is treated as
+   * "first run" (no diff is produced, no warning raised in the library —
+   * the CLI handles the warning). When supplied and readable, `report.diff`
+   * is populated.
+   */
+  baseline?: string;
+  /** When true, new regressions vs the baseline force exitCode=1. */
+  baselineStrict?: boolean;
 }
 
 export async function chaos(
   options: ChaosRunOptions,
   events: CrawlerEvents = {}
 ): Promise<ChaosResult> {
-  const { strict, ...crawlerOptions } = options;
+  const { strict, baseline, baselineStrict, ...crawlerOptions } = options;
   const crawler = new ChaosCrawler(crawlerOptions, events);
   const report = await crawler.start();
-  const exitCode = getExitCode(report, strict ?? false);
+
+  if (baseline) {
+    const prev = loadBaseline(baseline);
+    if (prev) {
+      report.diff = diffReports(prev, report, { baselinePath: baseline });
+    }
+  }
+
+  const exitCode = getExitCode(report, { strict, baselineStrict });
   return { report, passed: exitCode === 0, exitCode };
 }
+
+export { diffReports, loadBaseline, hasRegressions };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,16 @@ if (subcommand === "minimize") {
     process.exit(1);
   }
 }
+if (subcommand === "flake") {
+  const { runFlakeCli } = await import("./flake.js");
+  try {
+    await runFlakeCli(process.argv.slice(3));
+    process.exit(0);
+  } catch (err) {
+    console.error("flake failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
 
 const { values, positionals } = parseArgs({
   options: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,21 @@ import { axe } from "./invariants.js";
 import { printReport, saveReport, getExitCode } from "./reporter.js";
 import type { CrawlerOptions } from "./types.js";
 
+// Subcommand dispatch. Intercept before parseArgs runs so subcommand-specific
+// flags (e.g. --match for `minimize`) don't trip the main options map.
+const rawSub = process.argv[2];
+const subcommand = rawSub && !rawSub.startsWith("-") ? rawSub : null;
+if (subcommand === "minimize") {
+  const { runMinimizeCli } = await import("./minimize.js");
+  try {
+    await runMinimizeCli(process.argv.slice(3));
+    process.exit(0);
+  } catch (err) {
+    console.error("minimize failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+
 const { values, positionals } = parseArgs({
   options: {
     url: { type: "string" },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ const { values, positionals } = parseArgs({
     "har-record": { type: "string" },
     "har-replay": { type: "string" },
     "storage-state": { type: "string" },
+    budget: { type: "string", multiple: true },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
@@ -89,6 +90,7 @@ OPTIONS:
   --har-record <path>   Record network traffic to a HAR file (mutually exclusive with --har-replay)
   --har-replay <path>   Replay network traffic from a HAR file (missing URLs fall through to network)
   --storage-state <p>   Playwright storageState JSON (cookies + localStorage) for authenticated crawls
+  --budget <k=ms,...>   Per-metric performance budget, e.g. ttfb=200,fcp=1800,lcp=2500 (repeatable)
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --compact             Compact output format
@@ -159,6 +161,25 @@ if (values["har-record"] && values["har-replay"]) {
 if (values["har-record"]) har = { path: values["har-record"], mode: "record" };
 if (values["har-replay"]) har = { path: values["har-replay"], mode: "replay" };
 
+let performanceBudget: CrawlerOptions["performanceBudget"];
+if (values.budget && values.budget.length > 0) {
+  performanceBudget = {};
+  for (const raw of values.budget) {
+    for (const entry of raw.split(",")) {
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) {
+        console.error(`Error: --budget expects key=ms pairs (got "${trimmed}")`);
+        process.exit(1);
+      }
+      const key = trimmed.slice(0, eq).trim();
+      const ms = Number(trimmed.slice(eq + 1).trim());
+      (performanceBudget as Record<string, number>)[key] = ms;
+    }
+  }
+}
+
 const options: CrawlerOptions = {
   baseUrl,
   maxPages: values["max-pages"] ? parseInt(values["max-pages"], 10) : undefined,
@@ -176,6 +197,7 @@ const options: CrawlerOptions = {
   seed,
   har,
   storageState: values["storage-state"],
+  performanceBudget,
 };
 
 const outputPath = values.output || "chaos-report.json";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,8 @@ const { values, positionals } = parseArgs({
     budget: { type: "string", multiple: true },
     axe: { type: "boolean", default: false },
     "axe-tags": { type: "string" },
+    "trace-out": { type: "string" },
+    "trace-replay": { type: "string" },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
@@ -96,6 +98,8 @@ OPTIONS:
   --budget <k=ms,...>   Per-metric performance budget, e.g. ttfb=200,fcp=1800,lcp=2500 (repeatable)
   --axe                 Enable axe-core accessibility scan on every page (requires axe-core installed)
   --axe-tags <list>     Comma-separated axe tags (default: wcag2a,wcag2aa,wcag21a,wcag21aa)
+  --trace-out <path>    Write a JSONL trace of visits + actions for replay / minimize
+  --trace-replay <path> Replay a previously recorded trace instead of random actions
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --compact             Compact output format
@@ -203,6 +207,8 @@ const options: CrawlerOptions = {
   har,
   storageState: values["storage-state"],
   performanceBudget,
+  traceOut: values["trace-out"],
+  traceReplay: values["trace-replay"],
   invariants: values.axe
     ? [
         axe({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,8 @@ const { values, positionals } = parseArgs({
     "axe-tags": { type: "string" },
     "trace-out": { type: "string" },
     "trace-replay": { type: "string" },
+    device: { type: "string" },
+    network: { type: "string" },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
@@ -125,6 +127,8 @@ OPTIONS:
   --axe-tags <list>     Comma-separated axe tags (default: wcag2a,wcag2aa,wcag21a,wcag21aa)
   --trace-out <path>    Write a JSONL trace of visits + actions for replay / minimize
   --trace-replay <path> Replay a previously recorded trace instead of random actions
+  --device <name>       Emulate a Playwright device descriptor (e.g. "iPhone 14", "Pixel 7")
+  --network <profile>   Throttle with a CDP preset: slow-3g, fast-3g, offline
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --compact             Compact output format
@@ -234,6 +238,8 @@ const options: CrawlerOptions = {
   performanceBudget,
   traceOut: values["trace-out"],
   traceReplay: values["trace-replay"],
+  device: values.device,
+  network: values.network as CrawlerOptions["network"],
   invariants: values.axe
     ? [
         axe({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,6 +84,7 @@ const { values, positionals } = parseArgs({
     "trace-replay": { type: "string" },
     device: { type: "string" },
     network: { type: "string" },
+    "seed-from-sitemap": { type: "string" },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
     "github-annotations": { type: "boolean", default: false },
@@ -131,6 +132,7 @@ OPTIONS:
   --trace-replay <path> Replay a previously recorded trace instead of random actions
   --device <name>       Emulate a Playwright device descriptor (e.g. "iPhone 14", "Pixel 7")
   --network <profile>   Throttle with a CDP preset: slow-3g, fast-3g, offline
+  --seed-from-sitemap <url|path>  Prepend URLs listed in a sitemap.xml (or sitemap index)
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --github-annotations  Emit GitHub Actions workflow commands for each cluster / dead link
@@ -243,6 +245,7 @@ const options: CrawlerOptions = {
   traceReplay: values["trace-replay"],
   device: values.device,
   network: values.network as CrawlerOptions["network"],
+  seedFromSitemap: values["seed-from-sitemap"],
   invariants: values.axe
     ? [
         axe({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@
 
 import { parseArgs } from "node:util";
 import { ChaosCrawler, COMMON_IGNORE_PATTERNS } from "./crawler.js";
+import { diffReports, loadBaseline } from "./diff.js";
 import { printReport, saveReport, getExitCode } from "./reporter.js";
 import type { CrawlerOptions } from "./types.js";
 
@@ -48,6 +49,8 @@ const { values, positionals } = parseArgs({
     seed: { type: "string" },
     "har-record": { type: "string" },
     "har-replay": { type: "string" },
+    baseline: { type: "string" },
+    "baseline-strict": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
     strict: { type: "boolean", default: false },
     quiet: { type: "boolean", default: false },
@@ -84,6 +87,8 @@ OPTIONS:
   --seed <n>            Seed for deterministic action selection (reproduces a run)
   --har-record <path>   Record network traffic to a HAR file (mutually exclusive with --har-replay)
   --har-replay <path>   Replay network traffic from a HAR file (missing URLs fall through to network)
+  --baseline <path>     Diff this run against a previous report (warns if missing)
+  --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --compact             Compact output format
   --strict              Exit with error on any console errors
   --quiet               Minimal output
@@ -174,6 +179,8 @@ const outputPath = values.output || "chaos-report.json";
 const isQuiet = values.quiet;
 const isCompact = values.compact;
 const isStrict = values.strict;
+const baselinePath = values.baseline;
+const isBaselineStrict = values["baseline-strict"];
 
 async function main() {
   if (!isQuiet) {
@@ -212,16 +219,28 @@ async function main() {
       console.log(""); // New line after progress
     }
 
+    if (baselinePath) {
+      const prev = loadBaseline(baselinePath);
+      if (prev) {
+        report.diff = diffReports(prev, report, { baselinePath });
+      } else if (!isQuiet) {
+        // First CI run won't have a baseline yet. Warn, but keep going — the
+        // report we write here becomes the baseline for next time.
+        console.warn(`Baseline not found at ${baselinePath} — skipping diff.`);
+      }
+    }
+
     // Print report first, then save + announce the file. This way the main
     // textual output is one contiguous block and the "saved to" line is the
     // last thing on screen — friendlier for scrolling CI logs.
-    printReport(report, isCompact, isStrict);
+    const exitOptions = { strict: isStrict, baselineStrict: isBaselineStrict };
+    printReport(report, isCompact, exitOptions);
     saveReport(report, outputPath);
     if (!isQuiet) {
       console.log(`\nReport saved to: ${outputPath}`);
     }
 
-    const exitCode = getExitCode(report, isStrict);
+    const exitCode = getExitCode(report, exitOptions);
     process.exit(exitCode);
   } catch (err) {
     console.error("Crawl failed:", err);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@
 import { parseArgs } from "node:util";
 import { ChaosCrawler, COMMON_IGNORE_PATTERNS } from "./crawler.js";
 import { diffReports, loadBaseline } from "./diff.js";
+import { axe } from "./invariants.js";
 import { printReport, saveReport, getExitCode } from "./reporter.js";
 import type { CrawlerOptions } from "./types.js";
 
@@ -51,6 +52,8 @@ const { values, positionals } = parseArgs({
     "har-replay": { type: "string" },
     "storage-state": { type: "string" },
     budget: { type: "string", multiple: true },
+    axe: { type: "boolean", default: false },
+    "axe-tags": { type: "string" },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
@@ -91,6 +94,8 @@ OPTIONS:
   --har-replay <path>   Replay network traffic from a HAR file (missing URLs fall through to network)
   --storage-state <p>   Playwright storageState JSON (cookies + localStorage) for authenticated crawls
   --budget <k=ms,...>   Per-metric performance budget, e.g. ttfb=200,fcp=1800,lcp=2500 (repeatable)
+  --axe                 Enable axe-core accessibility scan on every page (requires axe-core installed)
+  --axe-tags <list>     Comma-separated axe tags (default: wcag2a,wcag2aa,wcag21a,wcag21aa)
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --compact             Compact output format
@@ -198,6 +203,18 @@ const options: CrawlerOptions = {
   har,
   storageState: values["storage-state"],
   performanceBudget,
+  invariants: values.axe
+    ? [
+        axe({
+          tags: values["axe-tags"]
+            ? values["axe-tags"]
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean)
+            : undefined,
+        }),
+      ]
+    : undefined,
 };
 
 const outputPath = values.output || "chaos-report.json";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@
 import { parseArgs } from "node:util";
 import { ChaosCrawler, COMMON_IGNORE_PATTERNS } from "./crawler.js";
 import { diffReports, loadBaseline } from "./diff.js";
+import { printGithubAnnotations } from "./github.js";
 import { axe } from "./invariants.js";
 import { printReport, saveReport, getExitCode } from "./reporter.js";
 import type { CrawlerOptions } from "./types.js";
@@ -85,6 +86,7 @@ const { values, positionals } = parseArgs({
     network: { type: "string" },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
+    "github-annotations": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
     strict: { type: "boolean", default: false },
     quiet: { type: "boolean", default: false },
@@ -131,6 +133,7 @@ OPTIONS:
   --network <profile>   Throttle with a CDP preset: slow-3g, fast-3g, offline
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
+  --github-annotations  Emit GitHub Actions workflow commands for each cluster / dead link
   --compact             Compact output format
   --strict              Exit with error on any console errors
   --quiet               Minimal output
@@ -260,6 +263,7 @@ const isCompact = values.compact;
 const isStrict = values.strict;
 const baselinePath = values.baseline;
 const isBaselineStrict = values["baseline-strict"];
+const emitGithub = values["github-annotations"];
 
 async function main() {
   if (!isQuiet) {
@@ -314,6 +318,9 @@ async function main() {
     // last thing on screen — friendlier for scrolling CI logs.
     const exitOptions = { strict: isStrict, baselineStrict: isBaselineStrict };
     printReport(report, isCompact, exitOptions);
+    if (emitGithub) {
+      printGithubAnnotations(report, { strict: isStrict });
+    }
     saveReport(report, outputPath);
     if (!isQuiet) {
       console.log(`\nReport saved to: ${outputPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,7 @@ const { values, positionals } = parseArgs({
     seed: { type: "string" },
     "har-record": { type: "string" },
     "har-replay": { type: "string" },
+    "storage-state": { type: "string" },
     baseline: { type: "string" },
     "baseline-strict": { type: "boolean", default: false },
     compact: { type: "boolean", default: false },
@@ -87,6 +88,7 @@ OPTIONS:
   --seed <n>            Seed for deterministic action selection (reproduces a run)
   --har-record <path>   Record network traffic to a HAR file (mutually exclusive with --har-replay)
   --har-replay <path>   Replay network traffic from a HAR file (missing URLs fall through to network)
+  --storage-state <p>   Playwright storageState JSON (cookies + localStorage) for authenticated crawls
   --baseline <path>     Diff this run against a previous report (warns if missing)
   --baseline-strict     Exit 1 when the diff shows new clusters or newly failing pages
   --compact             Compact output format
@@ -173,6 +175,7 @@ const options: CrawlerOptions = {
   logToConsole: values["log-console"],
   seed,
   har,
+  storageState: values["storage-state"],
 };
 
 const outputPath = values.output || "chaos-report.json";

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -390,12 +390,11 @@ export class ChaosCrawler {
 
     try {
       if (this.options.traceReplay) {
-        // Replay: iterate the recorded (visit, actions) groups in order.
-        // Link discovery is skipped — only URLs in the trace are visited,
-        // exactly as many times as the trace visits them.
+        // Replay: iterate every recorded (visit, actions) group. The trace
+        // itself defines the scope — applying maxPages here would silently
+        // truncate larger traces, so the cap only applies to live crawls.
         const groups = groupTrace(readTrace(this.options.traceReplay));
-        const limit = Math.min(groups.length, this.options.maxPages);
-        for (let i = 0; i < limit; i++) {
+        for (let i = 0; i < groups.length; i++) {
           const group = groups[i]!;
           if (this.shouldExclude(group.url)) {
             this.logger.debug("page_excluded", { url: group.url });
@@ -404,8 +403,8 @@ export class ChaosCrawler {
           this.currentEntry = { url: group.url, sourceUrl: "", method: "initial" };
           this.currentReplayActions = group.actions;
           this.discoveryMetrics.uniquePages++;
-          this.events.onProgress?.(i + 1, limit);
-          this.logger.logProgress(i + 1, limit);
+          this.events.onProgress?.(i + 1, groups.length);
+          this.logger.logProgress(i + 1, groups.length);
           if (this.options.traceOut) {
             this.trace.push({ kind: "visit", url: group.url });
           }
@@ -1143,7 +1142,19 @@ export class ChaosCrawler {
       const timestamp = Date.now();
       let result: ActionResult;
       try {
-        if (action.type === "scroll") {
+        if (action.blockedExternal) {
+          // The original run detected an external link and did not click it.
+          // Faithfully reproduce that non-action — clicking would introduce
+          // behavior the source trace never performed.
+          result = {
+            type: action.type,
+            target: action.target,
+            selector: action.selector,
+            success: true,
+            blockedExternal: true,
+            timestamp,
+          };
+        } else if (action.type === "scroll") {
           const m = /scrollY:\s*(\d+)/i.exec(action.target ?? "");
           const y = m ? Number(m[1]) : 0;
           await page.evaluate((yy) => window.scrollTo(0, yy), y);

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -44,6 +44,7 @@ import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./rand
 import { clusterErrors } from "./clusters.js";
 import { checkPerformanceBudget } from "./budget.js";
 import { networkConditionsFor } from "./network.js";
+import { fetchSitemapUrls } from "./sitemap.js";
 import {
   TRACE_FORMAT_VERSION,
   actionToTraceEntry,
@@ -68,6 +69,7 @@ const DEFAULT_OPTIONS: Required<
     | "traceReplay"
     | "device"
     | "network"
+    | "seedFromSitemap"
   >
 > = {
   maxPages: 50,
@@ -350,6 +352,10 @@ export class ChaosCrawler {
       });
     }
 
+    if (this.options.seedFromSitemap) {
+      await this.seedQueueFromSitemap(this.options.seedFromSitemap);
+    }
+
     // Reset recovery state
     this.currentPageActions = [];
     this.lastSuccessfulUrl = this.options.baseUrl;
@@ -534,6 +540,50 @@ export class ChaosCrawler {
 
   private isExternalUrl(url: string): boolean {
     return isExternalUrlPure(url, this.baseOrigin);
+  }
+
+  /**
+   * Pull URLs out of a sitemap (index-aware) and prepend them to the queue.
+   * URLs outside the baseUrl origin are dropped — the crawler's
+   * blockExternalNavigation would block them anyway, and queueing them
+   * wastes visit budget.
+   */
+  private async seedQueueFromSitemap(source: string): Promise<void> {
+    let urls: string[];
+    try {
+      urls = await fetchSitemapUrls(source);
+    } catch (err) {
+      this.logger.warn("sitemap_fetch_failed", {
+        source,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    const baseOrigin = this.baseOrigin;
+    const queuedUrls = new Set(this.queue.map((q) => q.url));
+    let added = 0;
+    let skippedExternal = 0;
+    for (const raw of urls) {
+      let normalized: string;
+      try {
+        normalized = normalizeUrl(new URL(raw, this.options.baseUrl).toString());
+      } catch {
+        continue;
+      }
+      try {
+        if (new URL(normalized).origin !== baseOrigin) {
+          skippedExternal++;
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      if (queuedUrls.has(normalized)) continue;
+      queuedUrls.add(normalized);
+      this.queue.push({ url: normalized, sourceUrl: source, method: "extracted" });
+      added++;
+    }
+    this.logger.info("sitemap_seeded", { source, added, skippedExternal, total: urls.length });
   }
 
   /**
@@ -1426,6 +1476,9 @@ export class ChaosCrawler {
     if (this.options.network) {
       parts.push("--network", shellQuote(this.options.network));
     }
+    if (this.options.seedFromSitemap) {
+      parts.push("--seed-from-sitemap", shellQuote(this.options.seedFromSitemap));
+    }
     return parts.join(" ");
   }
 
@@ -1545,6 +1598,7 @@ export function validateOptions(options: CrawlerOptions): void {
   };
   assertNonEmptyStringOpt("traceOut", options.traceOut);
   assertNonEmptyStringOpt("traceReplay", options.traceReplay);
+  assertNonEmptyStringOpt("seedFromSitemap", options.seedFromSitemap);
 
   if (options.device !== undefined) {
     if (typeof options.device !== "string" || options.device.length === 0) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -42,7 +42,15 @@ import {
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 import { clusterErrors } from "./clusters.js";
 import { checkPerformanceBudget } from "./budget.js";
-import { TRACE_FORMAT_VERSION, actionToTraceEntry, writeTrace, type TraceEntry } from "./trace.js";
+import {
+  TRACE_FORMAT_VERSION,
+  actionToTraceEntry,
+  groupTrace,
+  readTrace,
+  writeTrace,
+  type TraceAction,
+  type TraceEntry,
+} from "./trace.js";
 
 // Options that are opt-in with no meaningful default (HAR, storage state,
 // perf budget, trace) are carved out of the Required<> type instead of
@@ -135,6 +143,12 @@ export class ChaosCrawler {
   private currentEntry: QueueEntry | null = null;
   /** JSONL trace entries collected when `traceOut` is set. */
   private trace: TraceEntry[] = [];
+  /**
+   * Actions to replay on the current page. Non-null only while a replay run
+   * is mid-flight; the action dispatcher branches on this to decide between
+   * random-weighted and playback.
+   */
+  private currentReplayActions: TraceAction[] | null = null;
   /** Deterministic RNG for reproducible action selection. */
   private rng: Rng;
   /** Fault injection rules compiled once at construction time. */
@@ -375,38 +389,67 @@ export class ChaosCrawler {
     }
 
     try {
-      while (this.queue.length > 0 && this.visited.size < this.options.maxPages) {
-        const entry = this.queue.shift()!;
-        if (this.visited.has(entry.url)) continue;
-        if (this.shouldExclude(entry.url)) {
-          this.logger.debug("page_excluded", { url: entry.url });
-          continue;
+      if (this.options.traceReplay) {
+        // Replay: iterate the recorded (visit, actions) groups in order.
+        // Link discovery is skipped — only URLs in the trace are visited,
+        // exactly as many times as the trace visits them.
+        const groups = groupTrace(readTrace(this.options.traceReplay));
+        const limit = Math.min(groups.length, this.options.maxPages);
+        for (let i = 0; i < limit; i++) {
+          const group = groups[i]!;
+          if (this.shouldExclude(group.url)) {
+            this.logger.debug("page_excluded", { url: group.url });
+            continue;
+          }
+          this.currentEntry = { url: group.url, sourceUrl: "", method: "initial" };
+          this.currentReplayActions = group.actions;
+          this.discoveryMetrics.uniquePages++;
+          this.events.onProgress?.(i + 1, limit);
+          this.logger.logProgress(i + 1, limit);
+          if (this.options.traceOut) {
+            this.trace.push({ kind: "visit", url: group.url });
+          }
+          try {
+            const result = await this.crawlPage(this.currentEntry);
+            this.results.push(result);
+          } finally {
+            this.currentReplayActions = null;
+          }
         }
+      } else {
+        while (this.queue.length > 0 && this.visited.size < this.options.maxPages) {
+          const entry = this.queue.shift()!;
+          if (this.visited.has(entry.url)) continue;
+          if (this.shouldExclude(entry.url)) {
+            this.logger.debug("page_excluded", { url: entry.url });
+            continue;
+          }
 
-        this.visited.add(entry.url);
-        this.currentEntry = entry;
-        this.discoveryMetrics.uniquePages++;
-        this.events.onProgress?.(this.visited.size, this.options.maxPages);
-        this.logger.logProgress(this.visited.size, this.options.maxPages);
+          this.visited.add(entry.url);
+          this.currentEntry = entry;
+          this.discoveryMetrics.uniquePages++;
+          this.events.onProgress?.(this.visited.size, this.options.maxPages);
+          this.logger.logProgress(this.visited.size, this.options.maxPages);
 
-        if (this.options.traceOut) {
-          this.trace.push({ kind: "visit", url: entry.url });
-        }
+          if (this.options.traceOut) {
+            this.trace.push({ kind: "visit", url: entry.url });
+          }
 
-        const result = await this.crawlPage(entry);
-        this.results.push(result);
+          const result = await this.crawlPage(entry);
+          this.results.push(result);
 
-        // Add discovered links to queue with source tracking
-        for (const rawLink of result.links) {
-          const link = normalizeUrl(rawLink);
-          const alreadyQueued = this.queue.some((e) => e.url === link);
-          if (!this.visited.has(link) && !alreadyQueued) {
-            this.queue.push({
-              url: link,
-              sourceUrl: entry.url,
-              method: "extracted",
-            });
-            this.discoveryMetrics.extractedLinks++;
+          // Add discovered links to queue with source tracking
+          for (const rawLink of result.links) {
+            const link = normalizeUrl(rawLink);
+            const alreadyQueued = this.queue.some((e) => e.url === link);
+            if (!this.visited.has(link) && !alreadyQueued) {
+              this.queue.push({
+                url: link,
+                sourceUrl: entry.url,
+                method: "extracted",
+              });
+              this.discoveryMetrics.extractedLinks++;
+            }
           }
         }
       }
@@ -710,8 +753,13 @@ export class ChaosCrawler {
       this.enforcePerformanceBudget(metrics, url, errors);
       const links = await this.extractLinks(page);
 
-      // Perform random actions with accessibility-based weighting
-      await this.performWeightedActions(page, url);
+      // Replay mode bypasses the weighted random driver — playback owns
+      // exactly what runs and in what order.
+      if (this.currentReplayActions) {
+        await this.performReplayActions(page, url, this.currentReplayActions);
+      } else {
+        await this.performWeightedActions(page, url);
+      }
 
       // Drain any rejections that fired during actions.
       this.reclassifyRejections(errors, await this.drainRejections(page), url);
@@ -1076,6 +1124,87 @@ export class ChaosCrawler {
       this.logger.logAction(result);
 
       // Small delay between actions
+      await page.waitForTimeout(100);
+    }
+  }
+
+  /**
+   * Play back a sequence of recorded actions on the current page. Actions
+   * whose selectors no longer resolve are recorded as failed — the run
+   * continues so downstream errors can still surface. Scroll actions
+   * reconstruct the Y offset from the recorded `target` string.
+   */
+  private async performReplayActions(
+    page: Page,
+    url: string,
+    actions: readonly TraceAction[]
+  ): Promise<void> {
+    for (const action of actions) {
+      const timestamp = Date.now();
+      let result: ActionResult;
+      try {
+        if (action.type === "scroll") {
+          const m = /scrollY:\s*(\d+)/i.exec(action.target ?? "");
+          const y = m ? Number(m[1]) : 0;
+          await page.evaluate((yy) => window.scrollTo(0, yy), y);
+          result = { type: "scroll", target: `scrollY: ${y}`, success: true, timestamp };
+        } else if (!action.selector) {
+          result = {
+            type: action.type,
+            target: action.target,
+            success: false,
+            error: "replay: entry has no selector",
+            timestamp,
+          };
+        } else {
+          const element = page.locator(action.selector).first();
+          const visible = await element.isVisible().catch(() => false);
+          if (!visible) {
+            result = {
+              type: action.type,
+              target: action.target,
+              selector: action.selector,
+              success: false,
+              error: "replay: element not visible",
+              timestamp,
+            };
+          } else if (action.type === "input") {
+            await element.fill("test input", { timeout: 1000 });
+            result = {
+              type: "input",
+              target: action.target,
+              selector: action.selector,
+              success: true,
+              timestamp,
+            };
+          } else {
+            await element.click({ timeout: 2000 });
+            result = {
+              type: "click",
+              target: action.target,
+              selector: action.selector,
+              success: true,
+              timestamp,
+            };
+          }
+        }
+      } catch (err) {
+        result = {
+          type: action.type,
+          target: action.target,
+          selector: action.selector,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          timestamp,
+        };
+      }
+      this.actions.push(result);
+      this.addToHistory(result);
+      if (this.options.traceOut) {
+        this.trace.push(actionToTraceEntry(result, url));
+      }
+      this.events.onAction?.(result);
+      this.logger.logAction(result);
       await page.waitForTimeout(100);
     }
   }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Browser, BrowserContext, Page, Route } from "playwright";
-import { chromium } from "playwright";
+import { chromium, devices } from "playwright";
 import { mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type {
@@ -28,8 +28,9 @@ import type {
   FaultInjectionStats,
   Fault,
   UrlMatcher,
+  NetworkProfile,
 } from "./types.js";
-import { PERF_BUDGET_KEYS } from "./types.js";
+import { NETWORK_PROFILES, PERF_BUDGET_KEYS } from "./types.js";
 import { Logger, createNullLogger } from "./logger.js";
 import {
   matchesAnyPattern,
@@ -42,6 +43,7 @@ import {
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 import { clusterErrors } from "./clusters.js";
 import { checkPerformanceBudget } from "./budget.js";
+import { networkConditionsFor } from "./network.js";
 import {
   TRACE_FORMAT_VERSION,
   actionToTraceEntry,
@@ -53,12 +55,19 @@ import {
 } from "./trace.js";
 
 // Options that are opt-in with no meaningful default (HAR, storage state,
-// perf budget, trace) are carved out of the Required<> type instead of
-// inventing sentinels.
+// perf budget, trace, device/network) are carved out of the Required<>
+// type instead of inventing sentinels.
 const DEFAULT_OPTIONS: Required<
   Omit<
     CrawlerOptions,
-    "baseUrl" | "har" | "storageState" | "performanceBudget" | "traceOut" | "traceReplay"
+    | "baseUrl"
+    | "har"
+    | "storageState"
+    | "performanceBudget"
+    | "traceOut"
+    | "traceReplay"
+    | "device"
+    | "network"
   >
 > = {
   maxPages: 50,
@@ -369,9 +378,19 @@ export class ChaosCrawler {
     }
 
     this.browser = await chromium.launch({ headless: this.options.headless });
+    // Device descriptor overrides viewport / userAgent / device pixel ratio;
+    // explicit options in CrawlerOptions still win because they come later.
+    const deviceDesc =
+      this.options.device && devices[this.options.device]
+        ? devices[this.options.device]
+        : undefined;
     this.context = await this.browser.newContext({
-      viewport: this.options.viewport,
-      userAgent: this.options.userAgent || undefined,
+      ...deviceDesc,
+      // Device descriptor's viewport wins when set — device emulation is
+      // only meaningful if the viewport matches. Otherwise fall back to
+      // the configured default.
+      viewport: deviceDesc?.viewport ?? this.options.viewport,
+      userAgent: this.options.userAgent || deviceDesc?.userAgent || undefined,
       // Record mode: ask Playwright to capture all network into the HAR.
       recordHar: this.options.har?.mode === "record" ? { path: this.options.har.path } : undefined,
       // Preloaded cookies + localStorage for auth'd crawls. Playwright parses
@@ -517,6 +536,24 @@ export class ChaosCrawler {
     return isExternalUrlPure(url, this.baseOrigin);
   }
 
+  /**
+   * Attach a CDP session to the page and apply a throttling preset. Called
+   * per-page because `Network.emulateNetworkConditions` is a Page-level
+   * setting in Playwright — there's no context-wide equivalent.
+   */
+  private async applyNetworkProfile(page: Page, profile: NetworkProfile): Promise<void> {
+    try {
+      const client = await this.context!.newCDPSession(page);
+      await client.send("Network.enable");
+      await client.send("Network.emulateNetworkConditions", networkConditionsFor(profile));
+    } catch (err) {
+      this.logger.warn("network_profile_failed", {
+        profile,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   private async setupNavigationBlocking(page: Page): Promise<void> {
     const blockExternal = this.options.blockExternalNavigation;
     const rules = this.compiledFaultRules;
@@ -569,6 +606,10 @@ export class ChaosCrawler {
 
     // Scope recovery diagnostics to this page only.
     this.currentPageActions = [];
+
+    if (this.options.network) {
+      await this.applyNetworkProfile(page, this.options.network);
+    }
 
     if (this.options.blockExternalNavigation || this.compiledFaultRules.length > 0) {
       await this.setupNavigationBlocking(page);
@@ -1379,6 +1420,12 @@ export class ChaosCrawler {
     if (this.options.traceReplay) {
       parts.push("--trace-replay", shellQuote(this.options.traceReplay));
     }
+    if (this.options.device) {
+      parts.push("--device", shellQuote(this.options.device));
+    }
+    if (this.options.network) {
+      parts.push("--network", shellQuote(this.options.network));
+    }
     return parts.join(" ");
   }
 
@@ -1498,6 +1545,28 @@ export function validateOptions(options: CrawlerOptions): void {
   };
   assertNonEmptyStringOpt("traceOut", options.traceOut);
   assertNonEmptyStringOpt("traceReplay", options.traceReplay);
+
+  if (options.device !== undefined) {
+    if (typeof options.device !== "string" || options.device.length === 0) {
+      throw new Error(
+        `chaosbringer: "device" must be a non-empty Playwright device name (got ${JSON.stringify(options.device)})`
+      );
+    }
+    if (!devices[options.device]) {
+      throw new Error(
+        `chaosbringer: "device" ${JSON.stringify(options.device)} is not a known Playwright device descriptor`
+      );
+    }
+  }
+
+  if (options.network !== undefined) {
+    const allowed = new Set<string>(NETWORK_PROFILES);
+    if (typeof options.network !== "string" || !allowed.has(options.network)) {
+      throw new Error(
+        `chaosbringer: "network" must be one of ${NETWORK_PROFILES.join(", ")} (got ${JSON.stringify(options.network)})`
+      );
+    }
+  }
 
   if (options.performanceBudget !== undefined) {
     const budget = options.performanceBudget;

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -29,6 +29,7 @@ import type {
   Fault,
   UrlMatcher,
 } from "./types.js";
+import { PERF_BUDGET_KEYS } from "./types.js";
 import { Logger, createNullLogger } from "./logger.js";
 import {
   matchesAnyPattern,
@@ -40,10 +41,14 @@ import {
 } from "./filters.js";
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 import { clusterErrors } from "./clusters.js";
+import { checkPerformanceBudget } from "./budget.js";
 
-// Options that are opt-in with no meaningful default (HAR, storage state) are
-// carved out of the Required<> type instead of inventing sentinels.
-const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl" | "har" | "storageState">> = {
+// Options that are opt-in with no meaningful default (HAR, storage state,
+// perf budget) are carved out of the Required<> type instead of inventing
+// sentinels.
+const DEFAULT_OPTIONS: Required<
+  Omit<CrawlerOptions, "baseUrl" | "har" | "storageState" | "performanceBudget">
+> = {
   maxPages: 50,
   maxActionsPerPage: 5,
   timeout: 30000,
@@ -678,6 +683,7 @@ export class ChaosCrawler {
 
       const loadTime = Date.now() - startTime;
       const metrics = await this.collectMetrics(page);
+      this.enforcePerformanceBudget(metrics, url, errors);
       const links = await this.extractLinks(page);
 
       // Perform random actions with accessibility-based weighting
@@ -742,6 +748,25 @@ export class ChaosCrawler {
     // onPageComplete fires from the caller (crawlPage / testPage) after any
     // recovery reclassification so the callback sees the final status.
     return result;
+  }
+
+  /**
+   * Compare measured metrics against the configured budget and push one
+   * invariant-violation per breached metric. Delegates to a pure helper
+   * (`checkPerformanceBudget`) so the check is unit-testable without a
+   * running browser.
+   */
+  private enforcePerformanceBudget(
+    metrics: PerformanceMetrics,
+    url: string,
+    errors: PageError[]
+  ): void {
+    const violations = checkPerformanceBudget(metrics, this.options.performanceBudget, url);
+    for (const error of violations) {
+      errors.push(error);
+      this.events.onError?.(error);
+      this.logger.logPageError(error);
+    }
   }
 
   private async collectMetrics(page: Page): Promise<PerformanceMetrics> {
@@ -1174,6 +1199,13 @@ export class ChaosCrawler {
     if (this.options.storageState) {
       parts.push("--storage-state", shellQuote(this.options.storageState));
     }
+    if (this.options.performanceBudget) {
+      const budget = this.options.performanceBudget;
+      const entries = PERF_BUDGET_KEYS.filter((k) => typeof budget[k] === "number")
+        .map((k) => `${k}=${budget[k]}`)
+        .join(",");
+      if (entries.length > 0) parts.push("--budget", entries);
+    }
     return parts.join(" ");
   }
 
@@ -1282,6 +1314,29 @@ export function validateOptions(options: CrawlerOptions): void {
       throw new Error(
         `chaosbringer: "storageState" must be a non-empty path string (got ${JSON.stringify(options.storageState)})`
       );
+    }
+  }
+
+  if (options.performanceBudget !== undefined) {
+    const budget = options.performanceBudget;
+    if (budget === null || typeof budget !== "object" || Array.isArray(budget)) {
+      throw new Error(
+        `chaosbringer: "performanceBudget" must be an object (got ${JSON.stringify(budget)})`
+      );
+    }
+    const allowed = new Set<string>(PERF_BUDGET_KEYS);
+    for (const key of Object.keys(budget)) {
+      if (!allowed.has(key)) {
+        throw new Error(
+          `chaosbringer: "performanceBudget.${key}" is not a known metric (allowed: ${PERF_BUDGET_KEYS.join(", ")})`
+        );
+      }
+      const val = (budget as Record<string, unknown>)[key];
+      if (typeof val !== "number" || !Number.isFinite(val) || val <= 0) {
+        throw new Error(
+          `chaosbringer: "performanceBudget.${key}" must be a positive number of ms (got ${JSON.stringify(val)})`
+        );
+      }
     }
   }
 }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -41,9 +41,9 @@ import {
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 import { clusterErrors } from "./clusters.js";
 
-// `har` has no meaningful default (it's opt-in), so we carve it out of the
-// Required<> type instead of inventing a sentinel.
-const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl" | "har">> = {
+// Options that are opt-in with no meaningful default (HAR, storage state) are
+// carved out of the Required<> type instead of inventing sentinels.
+const DEFAULT_OPTIONS: Required<Omit<CrawlerOptions, "baseUrl" | "har" | "storageState">> = {
   maxPages: 50,
   maxActionsPerPage: 5,
   timeout: 30000,
@@ -338,6 +338,9 @@ export class ChaosCrawler {
       userAgent: this.options.userAgent || undefined,
       // Record mode: ask Playwright to capture all network into the HAR.
       recordHar: this.options.har?.mode === "record" ? { path: this.options.har.path } : undefined,
+      // Preloaded cookies + localStorage for auth'd crawls. Playwright parses
+      // and validates the file; we don't touch it.
+      storageState: this.options.storageState || undefined,
     });
 
     // Replay mode: serve every matching request from the HAR before it hits
@@ -1168,6 +1171,9 @@ export class ChaosCrawler {
     for (const p of this.options.spaPatterns ?? []) {
       parts.push("--spa", shellQuote(p));
     }
+    if (this.options.storageState) {
+      parts.push("--storage-state", shellQuote(this.options.storageState));
+    }
     return parts.join(" ");
   }
 
@@ -1267,6 +1273,14 @@ export function validateOptions(options: CrawlerOptions): void {
     if (mode !== "record" && mode !== "replay") {
       throw new Error(
         `chaosbringer: "har.mode" must be "record" or "replay" (got ${JSON.stringify(mode)})`
+      );
+    }
+  }
+
+  if (options.storageState !== undefined) {
+    if (typeof options.storageState !== "string" || options.storageState.length === 0) {
+      throw new Error(
+        `chaosbringer: "storageState" must be a non-empty path string (got ${JSON.stringify(options.storageState)})`
       );
     }
   }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -42,12 +42,16 @@ import {
 import { createRng, randomSeed, weightedPick, randomInt, type Rng } from "./random.js";
 import { clusterErrors } from "./clusters.js";
 import { checkPerformanceBudget } from "./budget.js";
+import { TRACE_FORMAT_VERSION, actionToTraceEntry, writeTrace, type TraceEntry } from "./trace.js";
 
 // Options that are opt-in with no meaningful default (HAR, storage state,
-// perf budget) are carved out of the Required<> type instead of inventing
-// sentinels.
+// perf budget, trace) are carved out of the Required<> type instead of
+// inventing sentinels.
 const DEFAULT_OPTIONS: Required<
-  Omit<CrawlerOptions, "baseUrl" | "har" | "storageState" | "performanceBudget">
+  Omit<
+    CrawlerOptions,
+    "baseUrl" | "har" | "storageState" | "performanceBudget" | "traceOut" | "traceReplay"
+  >
 > = {
   maxPages: 50,
   maxActionsPerPage: 5,
@@ -129,6 +133,8 @@ export class ChaosCrawler {
   };
   /** Current page being crawled (for source tracking) */
   private currentEntry: QueueEntry | null = null;
+  /** JSONL trace entries collected when `traceOut` is set. */
+  private trace: TraceEntry[] = [];
   /** Deterministic RNG for reproducible action selection. */
   private rng: Rng;
   /** Fault injection rules compiled once at construction time. */
@@ -308,7 +314,18 @@ export class ChaosCrawler {
     }];
     this.results = [];
     this.actions = [];
+    this.trace = [];
     this.blockedExternalCount = 0;
+
+    if (this.options.traceOut) {
+      this.trace.push({
+        kind: "meta",
+        v: TRACE_FORMAT_VERSION,
+        seed: this.rng.seed,
+        baseUrl: this.options.baseUrl,
+        startTime: this.startTime,
+      });
+    }
 
     // Reset recovery state
     this.currentPageActions = [];
@@ -372,6 +389,10 @@ export class ChaosCrawler {
         this.events.onProgress?.(this.visited.size, this.options.maxPages);
         this.logger.logProgress(this.visited.size, this.options.maxPages);
 
+        if (this.options.traceOut) {
+          this.trace.push({ kind: "visit", url: entry.url });
+        }
+
         const result = await this.crawlPage(entry);
         this.results.push(result);
 
@@ -394,6 +415,9 @@ export class ChaosCrawler {
       // before `browser.close()` tears everything down.
       await this.context?.close();
       await this.browser.close();
+      if (this.options.traceOut && this.trace.length > 0) {
+        writeTrace(this.options.traceOut, this.trace);
+      }
     }
 
     const endTime = Date.now();
@@ -1045,6 +1069,9 @@ export class ChaosCrawler {
       actionsPerformed++;
       this.actions.push(result);
       this.addToHistory(result);  // Add to recovery history
+      if (this.options.traceOut) {
+        this.trace.push(actionToTraceEntry(result, url));
+      }
       this.events.onAction?.(result);
       this.logger.logAction(result);
 
@@ -1206,6 +1233,12 @@ export class ChaosCrawler {
         .join(",");
       if (entries.length > 0) parts.push("--budget", entries);
     }
+    if (this.options.traceOut) {
+      parts.push("--trace-out", shellQuote(this.options.traceOut));
+    }
+    if (this.options.traceReplay) {
+      parts.push("--trace-replay", shellQuote(this.options.traceReplay));
+    }
     return parts.join(" ");
   }
 
@@ -1316,6 +1349,15 @@ export function validateOptions(options: CrawlerOptions): void {
       );
     }
   }
+
+  const assertNonEmptyStringOpt = (name: string, v: unknown): void => {
+    if (v === undefined) return;
+    if (typeof v !== "string" || v.length === 0) {
+      throw new Error(`chaosbringer: "${name}" must be a non-empty path string (got ${JSON.stringify(v)})`);
+    }
+  };
+  assertNonEmptyStringOpt("traceOut", options.traceOut);
+  assertNonEmptyStringOpt("traceReplay", options.traceReplay);
 
   if (options.performanceBudget !== undefined) {
     const budget = options.performanceBudget;

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,0 +1,238 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { diffReports, hasRegressions, loadBaseline } from "./diff.js";
+import { getExitCode } from "./reporter.js";
+import type { CrawlReport, CrawlSummary, PageError, PageResult } from "./types.js";
+
+function cluster(overrides: Partial<ErrorCluster> & { key: string; fingerprint: string }): ErrorCluster {
+  const sample: PageError = { type: "console", message: overrides.fingerprint, timestamp: 0 };
+  return {
+    key: overrides.key,
+    type: overrides.type ?? "console",
+    fingerprint: overrides.fingerprint,
+    sample,
+    count: overrides.count ?? 1,
+    urls: overrides.urls ?? [],
+    invariantNames: overrides.invariantNames,
+  };
+}
+
+function page(overrides: Partial<PageResult> & { url: string }): PageResult {
+  return {
+    url: overrides.url,
+    status: overrides.status ?? "success",
+    loadTime: 0,
+    errors: overrides.errors ?? [],
+    hasErrors: (overrides.errors ?? []).length > 0,
+    warnings: [],
+    links: [],
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<CrawlSummary> = {}): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    pagesWithErrors: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    invariantViolations: 0,
+    avgLoadTime: 0,
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://localhost:3000",
+    seed: 1,
+    reproCommand: "chaosbringer",
+    startTime: 0,
+    endTime: 0,
+    duration: 0,
+    pagesVisited: 0,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: makeSummary(),
+    errorClusters: [],
+    ...overrides,
+  };
+}
+
+describe("diffReports", () => {
+  it("surfaces clusters present only in the current run as new", () => {
+    const prev = makeReport({ errorClusters: [cluster({ key: "console|old", fingerprint: "old", count: 3 })] });
+    const curr = makeReport({
+      errorClusters: [
+        cluster({ key: "console|old", fingerprint: "old", count: 3 }),
+        cluster({ key: "console|new", fingerprint: "new", count: 2 }),
+      ],
+    });
+    const diff = diffReports(prev, curr);
+    expect(diff.newClusters.map((c) => c.key)).toEqual(["console|new"]);
+    expect(diff.newClusters[0]!.before).toBe(0);
+    expect(diff.newClusters[0]!.after).toBe(2);
+    expect(diff.unchangedClusters.map((c) => c.key)).toEqual(["console|old"]);
+  });
+
+  it("surfaces clusters gone from the current run as resolved", () => {
+    const prev = makeReport({
+      errorClusters: [
+        cluster({ key: "console|gone", fingerprint: "gone", count: 5 }),
+        cluster({ key: "console|kept", fingerprint: "kept", count: 1 }),
+      ],
+    });
+    const curr = makeReport({ errorClusters: [cluster({ key: "console|kept", fingerprint: "kept", count: 1 })] });
+    const diff = diffReports(prev, curr);
+    expect(diff.resolvedClusters.map((c) => c.key)).toEqual(["console|gone"]);
+    expect(diff.resolvedClusters[0]!.before).toBe(5);
+    expect(diff.resolvedClusters[0]!.after).toBe(0);
+  });
+
+  it("carries baselineSeed and baselinePath through", () => {
+    const prev = makeReport({ seed: 999 });
+    const curr = makeReport({ seed: 1 });
+    const diff = diffReports(prev, curr, { baselinePath: "/tmp/prev.json" });
+    expect(diff.baselineSeed).toBe(999);
+    expect(diff.baselinePath).toBe("/tmp/prev.json");
+  });
+
+  it("flags a page that was clean but is now failing", () => {
+    const err: PageError = { type: "console", message: "boom", timestamp: 0 };
+    const prev = makeReport({ pages: [page({ url: "http://x/a", status: "success" })] });
+    const curr = makeReport({ pages: [page({ url: "http://x/a", status: "success", errors: [err] })] });
+    const diff = diffReports(prev, curr);
+    expect(diff.newFailedPages.map((p) => p.url)).toEqual(["http://x/a"]);
+    expect(diff.newFailedPages[0]!.before?.errors).toBe(0);
+    expect(diff.newFailedPages[0]!.after?.errors).toBe(1);
+    expect(diff.resolvedFailedPages).toHaveLength(0);
+  });
+
+  it("flags a page that was failing but is now clean as resolved", () => {
+    const err: PageError = { type: "console", message: "boom", timestamp: 0 };
+    const prev = makeReport({ pages: [page({ url: "http://x/a", status: "error", errors: [err] })] });
+    const curr = makeReport({ pages: [page({ url: "http://x/a", status: "success" })] });
+    const diff = diffReports(prev, curr);
+    expect(diff.resolvedFailedPages.map((p) => p.url)).toEqual(["http://x/a"]);
+    expect(diff.newFailedPages).toHaveLength(0);
+  });
+
+  it("treats URLs new to this run as new if they fail, ignores them if clean", () => {
+    const err: PageError = { type: "console", message: "x", timestamp: 0 };
+    const prev = makeReport({ pages: [] });
+    const curr = makeReport({
+      pages: [
+        page({ url: "http://x/new-fail", status: "error", errors: [err] }),
+        page({ url: "http://x/new-ok", status: "success" }),
+      ],
+    });
+    const diff = diffReports(prev, curr);
+    expect(diff.newFailedPages.map((p) => p.url)).toEqual(["http://x/new-fail"]);
+    expect(diff.newFailedPages[0]!.before).toBeNull();
+  });
+
+  it("counts pages that failed before but were not revisited as resolved", () => {
+    const err: PageError = { type: "console", message: "x", timestamp: 0 };
+    const prev = makeReport({ pages: [page({ url: "http://x/gone", status: "error", errors: [err] })] });
+    const curr = makeReport({ pages: [] });
+    const diff = diffReports(prev, curr);
+    expect(diff.resolvedFailedPages.map((p) => p.url)).toEqual(["http://x/gone"]);
+    expect(diff.resolvedFailedPages[0]!.after).toBeNull();
+  });
+});
+
+describe("hasRegressions", () => {
+  it("is true when there are new clusters", () => {
+    const diff = diffReports(
+      makeReport(),
+      makeReport({ errorClusters: [cluster({ key: "k", fingerprint: "f" })] })
+    );
+    expect(hasRegressions(diff)).toBe(true);
+  });
+
+  it("is false when only clusters resolve", () => {
+    const diff = diffReports(
+      makeReport({ errorClusters: [cluster({ key: "k", fingerprint: "f" })] }),
+      makeReport()
+    );
+    expect(hasRegressions(diff)).toBe(false);
+  });
+});
+
+describe("loadBaseline", () => {
+  it("returns null when the file does not exist", () => {
+    expect(loadBaseline(join(tmpdir(), `missing-${Date.now()}-${Math.random()}.json`))).toBeNull();
+  });
+
+  it("reads a valid report", () => {
+    const dir = mkdtempSync(join(tmpdir(), "chaos-diff-"));
+    try {
+      const path = join(dir, "baseline.json");
+      writeFileSync(path, JSON.stringify(makeReport({ seed: 42 })));
+      const loaded = loadBaseline(path);
+      expect(loaded?.seed).toBe(42);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws on malformed JSON content", () => {
+    const dir = mkdtempSync(join(tmpdir(), "chaos-diff-"));
+    try {
+      const path = join(dir, "garbage.json");
+      writeFileSync(path, "{}"); // valid JSON but not a report (missing errorClusters)
+      expect(() => loadBaseline(path)).toThrow(/not a chaos report/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("getExitCode with baselineStrict", () => {
+  it("returns 1 when baselineStrict and the diff has new clusters", () => {
+    const report = makeReport({
+      diff: {
+        baselineSeed: 0,
+        newClusters: [{ key: "k", type: "console", fingerprint: "f", before: 0, after: 1 }],
+        resolvedClusters: [],
+        unchangedClusters: [],
+        newFailedPages: [],
+        resolvedFailedPages: [],
+      },
+    });
+    expect(getExitCode(report, { baselineStrict: true })).toBe(1);
+    expect(getExitCode(report, { baselineStrict: false })).toBe(0);
+  });
+
+  it("returns 0 when baselineStrict but the diff is clean", () => {
+    const report = makeReport({
+      diff: {
+        baselineSeed: 0,
+        newClusters: [],
+        resolvedClusters: [{ key: "k", type: "console", fingerprint: "f", before: 1, after: 0 }],
+        unchangedClusters: [],
+        newFailedPages: [],
+        resolvedFailedPages: [],
+      },
+    });
+    expect(getExitCode(report, { baselineStrict: true })).toBe(0);
+  });
+
+  it("still accepts a bare boolean for the legacy strict flag", () => {
+    const report = makeReport({ summary: makeSummary({ consoleErrors: 1 }) });
+    expect(getExitCode(report, true)).toBe(1);
+    expect(getExitCode(report, false)).toBe(0);
+  });
+});

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,136 @@
+/**
+ * Compute a diff between a baseline report and the current report. The goal is
+ * regression detection in CI: surface what's newly broken since the last run
+ * while ignoring clusters / pages that were already broken.
+ *
+ * Clusters are matched by `ErrorCluster.key` (already fingerprinted, stable
+ * across runs); pages are matched by URL. Nothing else is compared.
+ */
+
+import { readFileSync } from "node:fs";
+import type {
+  ClusterDiffEntry,
+  CrawlReport,
+  PageDiffEntry,
+  PageResult,
+  ReportDiff,
+} from "./types.js";
+
+function pageFailed(page: Pick<PageResult, "status" | "errors">): boolean {
+  return page.errors.length > 0 || page.status === "error" || page.status === "timeout";
+}
+
+function pageSummary(page: PageResult): PageDiffEntry["after"] {
+  return { errors: page.errors.length, status: page.status };
+}
+
+export function diffReports(
+  baseline: CrawlReport,
+  current: CrawlReport,
+  options: { baselinePath?: string } = {}
+): ReportDiff {
+  const baselineClusters = new Map(baseline.errorClusters.map((c) => [c.key, c]));
+  const currentClusters = new Map(current.errorClusters.map((c) => [c.key, c]));
+
+  const newClusters: ClusterDiffEntry[] = [];
+  const resolvedClusters: ClusterDiffEntry[] = [];
+  const unchangedClusters: ClusterDiffEntry[] = [];
+
+  for (const [key, curr] of currentClusters) {
+    const prev = baselineClusters.get(key);
+    const entry: ClusterDiffEntry = {
+      key,
+      type: curr.type,
+      fingerprint: curr.fingerprint,
+      before: prev?.count ?? 0,
+      after: curr.count,
+    };
+    if (prev) unchangedClusters.push(entry);
+    else newClusters.push(entry);
+  }
+  for (const [key, prev] of baselineClusters) {
+    if (currentClusters.has(key)) continue;
+    resolvedClusters.push({
+      key,
+      type: prev.type,
+      fingerprint: prev.fingerprint,
+      before: prev.count,
+      after: 0,
+    });
+  }
+
+  const baselinePages = new Map(baseline.pages.map((p) => [p.url, p]));
+  const currentPages = new Map(current.pages.map((p) => [p.url, p]));
+  const newFailedPages: PageDiffEntry[] = [];
+  const resolvedFailedPages: PageDiffEntry[] = [];
+
+  for (const [url, curr] of currentPages) {
+    const prev = baselinePages.get(url);
+    const currFailed = pageFailed(curr);
+    const prevFailed = prev ? pageFailed(prev) : false;
+    if (currFailed && !prevFailed) {
+      newFailedPages.push({
+        url,
+        before: prev ? pageSummary(prev) : null,
+        after: pageSummary(curr),
+      });
+    } else if (!currFailed && prevFailed && prev) {
+      resolvedFailedPages.push({
+        url,
+        before: pageSummary(prev),
+        after: pageSummary(curr),
+      });
+    }
+  }
+  // Pages that were failing before and weren't revisited — also "resolved"
+  // from the current run's perspective (we can't claim they're still broken).
+  for (const [url, prev] of baselinePages) {
+    if (currentPages.has(url)) continue;
+    if (!pageFailed(prev)) continue;
+    resolvedFailedPages.push({
+      url,
+      before: pageSummary(prev),
+      after: null,
+    });
+  }
+
+  return {
+    baselinePath: options.baselinePath,
+    baselineSeed: baseline.seed,
+    newClusters,
+    resolvedClusters,
+    unchangedClusters,
+    newFailedPages,
+    resolvedFailedPages,
+  };
+}
+
+/**
+ * Read a baseline report from disk. Returns `null` when the file is missing —
+ * callers (CLI / chaos()) treat that as "first run, no baseline yet" and warn.
+ * Throws if the file exists but is not a parseable report.
+ */
+export function loadBaseline(path: string): CrawlReport | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+  const parsed = JSON.parse(raw) as CrawlReport;
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.errorClusters)) {
+    throw new Error(`Baseline file is not a chaos report: ${path}`);
+  }
+  return parsed;
+}
+
+/**
+ * True when the diff contains regressions worth failing a run over. Used by
+ * `--baseline-strict` — a less aggressive default than failing on any diff
+ * (which would flag "resolved" pages too).
+ */
+export function hasRegressions(diff: ReportDiff): boolean {
+  return diff.newClusters.length > 0 || diff.newFailedPages.length > 0;
+}

--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -32,6 +32,13 @@ export interface ChaosFixture {
   /** Assert no errors were found */
   expectNoErrors(result: PageResult | CrawlReport): void;
 
+  /**
+   * Assert the crawl discovered no dead links. Prints each dead link's
+   * source page so the reviewer can find the broken anchor without
+   * cross-referencing the full report.
+   */
+  expectNoDeadLinks(result: CrawlReport): void;
+
   /** Get the underlying crawler instance */
   crawler: ChaosCrawler;
 }
@@ -97,6 +104,15 @@ export function withChaos(defaultOptions: ChaosTestOptions = {}) {
             }
           }
         },
+
+        expectNoDeadLinks(result: CrawlReport): void {
+          const dead = result.summary.discovery?.deadLinks ?? [];
+          if (dead.length === 0) return;
+          const lines = dead.map(
+            (d) => `  ${d.url} (${d.statusCode}) ← ${d.sourceUrl || "(initial)"}`
+          );
+          throw new Error(`Found ${dead.length} dead links:\n${lines.join("\n")}`);
+        },
       };
 
       await use(fixture);
@@ -159,5 +175,20 @@ export const chaosExpect = {
     expect(result.loadTime, `Page load time ${result.loadTime}ms exceeded ${maxMs}ms`).toBeLessThanOrEqual(
       maxMs
     );
+  },
+
+  toHaveNoDeadLinks(result: CrawlReport) {
+    const dead = result.summary.discovery?.deadLinks ?? [];
+    if (dead.length === 0) {
+      expect(dead).toHaveLength(0);
+      return;
+    }
+    const detail = dead
+      .map((d) => `  ${d.url} (${d.statusCode}) ← ${d.sourceUrl || "(initial)"}`)
+      .join("\n");
+    expect(
+      dead,
+      `Expected no dead links but found ${dead.length}:\n${detail}`
+    ).toHaveLength(0);
   },
 };

--- a/src/flake.test.ts
+++ b/src/flake.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { flakeReport, formatFlakeReport } from "./flake.js";
+import type { CrawlReport, CrawlSummary, PageError, PageResult } from "./types.js";
+
+function summary(over: Partial<CrawlSummary> = {}): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    pagesWithErrors: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    invariantViolations: 0,
+    avgLoadTime: 0,
+    ...over,
+  };
+}
+
+function cluster(key: string, count: number): ErrorCluster {
+  const sample: PageError = { type: "console", message: key, timestamp: 0 };
+  return { key, type: "console", fingerprint: key, sample, count, urls: [] };
+}
+
+function page(over: Partial<PageResult> & { url: string }): PageResult {
+  return {
+    url: over.url,
+    status: over.status ?? "success",
+    loadTime: 0,
+    errors: over.errors ?? [],
+    hasErrors: (over.errors ?? []).length > 0,
+    warnings: [],
+    links: [],
+    ...over,
+  };
+}
+
+function makeReport(over: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://x/",
+    seed: 1,
+    reproCommand: "",
+    startTime: 0,
+    endTime: 0,
+    duration: 100,
+    pagesVisited: 0,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: summary(),
+    errorClusters: [],
+    ...over,
+  };
+}
+
+describe("flakeReport", () => {
+  it("labels clusters that fire in every run as stable", () => {
+    const r = [
+      makeReport({ errorClusters: [cluster("k1", 2)] }),
+      makeReport({ errorClusters: [cluster("k1", 3)] }),
+      makeReport({ errorClusters: [cluster("k1", 1)] }),
+    ];
+    const analysis = flakeReport(r);
+    expect(analysis.runs).toBe(3);
+    expect(analysis.stableClusters.map((c) => c.key)).toEqual(["k1"]);
+    expect(analysis.stableClusters[0]!.perRunCounts).toEqual([2, 3, 1]);
+    expect(analysis.flakyClusters).toEqual([]);
+  });
+
+  it("labels clusters that fire in some but not all runs as flaky", () => {
+    const r = [
+      makeReport({ errorClusters: [cluster("k1", 2), cluster("k2", 1)] }),
+      makeReport({ errorClusters: [cluster("k1", 2)] }),
+      makeReport({ errorClusters: [cluster("k1", 2), cluster("k2", 1)] }),
+    ];
+    const analysis = flakeReport(r);
+    expect(analysis.stableClusters.map((c) => c.key)).toEqual(["k1"]);
+    expect(analysis.flakyClusters.map((c) => c.key)).toEqual(["k2"]);
+    expect(analysis.flakyClusters[0]!.runsWithCluster).toBe(2);
+    expect(analysis.flakyClusters[0]!.perRunCounts).toEqual([1, 0, 1]);
+  });
+
+  it("only reports a page as flaky when its outcome varies across visits", () => {
+    const err: PageError = { type: "console", message: "x", timestamp: 0 };
+    const reports = [
+      makeReport({ pages: [page({ url: "http://x/a", errors: [err] })] }),
+      makeReport({ pages: [page({ url: "http://x/a", errors: [] })] }),
+      makeReport({ pages: [page({ url: "http://x/a", errors: [err] })] }),
+    ];
+    const analysis = flakeReport(reports);
+    expect(analysis.flakyPages.map((p) => p.url)).toEqual(["http://x/a"]);
+    expect(analysis.flakyPages[0]!.failedInRuns).toBe(2);
+    expect(analysis.flakyPages[0]!.visitedInRuns).toBe(3);
+  });
+
+  it("does not flag pages that fail in every run as flaky", () => {
+    const err: PageError = { type: "console", message: "x", timestamp: 0 };
+    const reports = [
+      makeReport({ pages: [page({ url: "http://x/a", errors: [err] })] }),
+      makeReport({ pages: [page({ url: "http://x/a", errors: [err] })] }),
+    ];
+    expect(flakeReport(reports).flakyPages).toEqual([]);
+  });
+
+  it("returns an empty analysis for zero runs", () => {
+    expect(flakeReport([])).toEqual({
+      runs: 0,
+      stableClusters: [],
+      flakyClusters: [],
+      flakyPages: [],
+      durations: [],
+    });
+  });
+
+  it("preserves input order for durations", () => {
+    const reports = [makeReport({ duration: 100 }), makeReport({ duration: 50 }), makeReport({ duration: 200 })];
+    expect(flakeReport(reports).durations).toEqual([100, 50, 200]);
+  });
+});
+
+describe("formatFlakeReport", () => {
+  it("includes the run count, stable / flaky counts, and duration stats", () => {
+    const reports = [
+      makeReport({ duration: 100, errorClusters: [cluster("stable", 1)] }),
+      makeReport({ duration: 200, errorClusters: [cluster("stable", 1), cluster("flaky", 1)] }),
+    ];
+    const out = formatFlakeReport(flakeReport(reports));
+    expect(out).toContain("FLAKE REPORT — 2 runs");
+    expect(out).toContain("Stable clusters (fire every run): 1");
+    expect(out).toContain("Flaky clusters (fire in some runs): 1");
+    expect(out).toContain("Duration (ms): avg=150");
+  });
+});

--- a/src/flake.ts
+++ b/src/flake.ts
@@ -1,0 +1,293 @@
+/**
+ * Flake detection. Runs chaos N times with the same seed and reports which
+ * error clusters are stable (fire in every run) vs flaky (fire in some but
+ * not all). Useful for triaging whether a failure is real or a race.
+ *
+ * The analysis itself is a pure function over CrawlReports; orchestration
+ * (running chaos N times + pretty-printing) is layered on top so tests can
+ * exercise the analysis without a browser.
+ */
+
+import { parseArgs } from "node:util";
+import { writeFileSync } from "node:fs";
+import type { CrawlReport, PageError } from "./types.js";
+
+export interface ClusterOccurrence {
+  key: string;
+  type: PageError["type"];
+  fingerprint: string;
+  /** Count per run (length === N). Zero means the cluster did not fire. */
+  perRunCounts: number[];
+  /** Number of runs in which this cluster fired at least once. */
+  runsWithCluster: number;
+}
+
+export interface PageOccurrence {
+  url: string;
+  /** Runs in which this URL was visited AND had at least one error. */
+  failedInRuns: number;
+  /** Runs in which the URL was visited at all (regardless of outcome). */
+  visitedInRuns: number;
+}
+
+export interface FlakeAnalysis {
+  runs: number;
+  /** Clusters that fired in every run. */
+  stableClusters: ClusterOccurrence[];
+  /** Clusters that fired in some runs but not others. */
+  flakyClusters: ClusterOccurrence[];
+  /** Pages whose failed/clean state differed across runs. */
+  flakyPages: PageOccurrence[];
+  /** Per-run duration in ms, in input order. */
+  durations: number[];
+}
+
+/**
+ * Given N CrawlReports from runs of the same configuration, separate the
+ * error clusters into stable (always fire) vs flaky (inconsistent), and the
+ * pages into flaky (different failed/clean outcomes) vs stable.
+ */
+export function flakeReport(reports: readonly CrawlReport[]): FlakeAnalysis {
+  const runs = reports.length;
+  if (runs === 0) {
+    return { runs: 0, stableClusters: [], flakyClusters: [], flakyPages: [], durations: [] };
+  }
+
+  const keyMap = new Map<string, ClusterOccurrence>();
+  reports.forEach((report, idx) => {
+    for (const cluster of report.errorClusters) {
+      let occ = keyMap.get(cluster.key);
+      if (!occ) {
+        occ = {
+          key: cluster.key,
+          type: cluster.type,
+          fingerprint: cluster.fingerprint,
+          perRunCounts: Array(runs).fill(0),
+          runsWithCluster: 0,
+        };
+        keyMap.set(cluster.key, occ);
+      }
+      occ.perRunCounts[idx] = cluster.count;
+    }
+  });
+  for (const occ of keyMap.values()) {
+    occ.runsWithCluster = occ.perRunCounts.filter((c) => c > 0).length;
+  }
+
+  const stableClusters: ClusterOccurrence[] = [];
+  const flakyClusters: ClusterOccurrence[] = [];
+  for (const occ of keyMap.values()) {
+    if (occ.runsWithCluster === runs) stableClusters.push(occ);
+    else if (occ.runsWithCluster > 0) flakyClusters.push(occ);
+  }
+  stableClusters.sort((a, b) => b.perRunCounts.reduce((x, y) => x + y, 0) - a.perRunCounts.reduce((x, y) => x + y, 0));
+  flakyClusters.sort((a, b) => b.runsWithCluster - a.runsWithCluster);
+
+  const pageFailedSet = new Map<string, { failed: boolean[]; visited: boolean[] }>();
+  reports.forEach((report, idx) => {
+    for (const page of report.pages) {
+      let rec = pageFailedSet.get(page.url);
+      if (!rec) {
+        rec = { failed: Array(runs).fill(false), visited: Array(runs).fill(false) };
+        pageFailedSet.set(page.url, rec);
+      }
+      rec.visited[idx] = true;
+      const isFailed =
+        page.errors.length > 0 || page.status === "error" || page.status === "timeout";
+      rec.failed[idx] = isFailed;
+    }
+  });
+
+  const flakyPages: PageOccurrence[] = [];
+  for (const [url, rec] of pageFailedSet) {
+    const failedInRuns = rec.failed.filter(Boolean).length;
+    const visitedInRuns = rec.visited.filter(Boolean).length;
+    // Only flag as flaky if the URL was visited in more than one run and
+    // its outcome differs across those visits.
+    if (visitedInRuns >= 2 && failedInRuns > 0 && failedInRuns < visitedInRuns) {
+      flakyPages.push({ url, failedInRuns, visitedInRuns });
+    }
+  }
+  flakyPages.sort((a, b) => b.failedInRuns - a.failedInRuns);
+
+  return {
+    runs,
+    stableClusters,
+    flakyClusters,
+    flakyPages,
+    durations: reports.map((r) => r.duration),
+  };
+}
+
+export function formatFlakeReport(analysis: FlakeAnalysis): string {
+  const lines: string[] = [];
+  lines.push("=".repeat(60));
+  lines.push(`FLAKE REPORT — ${analysis.runs} runs`);
+  lines.push("=".repeat(60));
+  if (analysis.durations.length > 0) {
+    const min = Math.min(...analysis.durations);
+    const max = Math.max(...analysis.durations);
+    const avg = analysis.durations.reduce((a, b) => a + b, 0) / analysis.durations.length;
+    lines.push(`Duration (ms): avg=${avg.toFixed(0)} min=${min} max=${max}`);
+  }
+  lines.push("");
+  lines.push(`Stable clusters (fire every run): ${analysis.stableClusters.length}`);
+  for (const c of analysis.stableClusters) {
+    lines.push(`  [${c.type}] ${truncate(c.fingerprint, 70)}  counts=${c.perRunCounts.join(",")}`);
+  }
+  lines.push("");
+  lines.push(`Flaky clusters (fire in some runs): ${analysis.flakyClusters.length}`);
+  for (const c of analysis.flakyClusters) {
+    lines.push(
+      `  [${c.type}] ${truncate(c.fingerprint, 70)}  runs=${c.runsWithCluster}/${analysis.runs}  counts=${c.perRunCounts.join(",")}`
+    );
+  }
+  lines.push("");
+  lines.push(`Flaky pages (outcome varies across runs): ${analysis.flakyPages.length}`);
+  for (const p of analysis.flakyPages) {
+    lines.push(`  ${p.url}  failed=${p.failedInRuns}/${p.visitedInRuns}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 3) + "...";
+}
+
+interface FlakeCliArgs {
+  baseUrl: string;
+  runs: number;
+  seed?: number;
+  maxPages?: number;
+  maxActions?: number;
+  timeout?: number;
+  ignoreAnalytics: boolean;
+  harReplay?: string;
+  traceReplay?: string;
+  storageState?: string;
+  output?: string;
+  quiet: boolean;
+}
+
+function parseFlakeArgs(argv: string[]): FlakeCliArgs {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      url: { type: "string" },
+      runs: { type: "string" },
+      seed: { type: "string" },
+      "max-pages": { type: "string" },
+      "max-actions": { type: "string" },
+      timeout: { type: "string" },
+      "ignore-analytics": { type: "boolean", default: false },
+      "har-replay": { type: "string" },
+      "trace-replay": { type: "string" },
+      "storage-state": { type: "string" },
+      output: { type: "string" },
+      quiet: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    printFlakeHelp();
+    process.exit(0);
+  }
+  if (!values.url) fail("--url is required");
+
+  const runs = values.runs ? Number(values.runs) : 3;
+  if (!Number.isFinite(runs) || !Number.isInteger(runs) || runs < 2) {
+    fail(`--runs must be an integer >= 2 (got ${JSON.stringify(values.runs)})`);
+  }
+
+  let seed: number | undefined;
+  if (values.seed !== undefined) {
+    const parsed = Number(values.seed);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+      fail(`--seed must be a non-negative integer (got ${JSON.stringify(values.seed)})`);
+    }
+    seed = parsed;
+  }
+
+  return {
+    baseUrl: values.url!,
+    runs,
+    seed,
+    maxPages: values["max-pages"] ? Number(values["max-pages"]) : undefined,
+    maxActions: values["max-actions"] ? Number(values["max-actions"]) : undefined,
+    timeout: values.timeout ? Number(values.timeout) : undefined,
+    ignoreAnalytics: values["ignore-analytics"] ?? false,
+    harReplay: values["har-replay"],
+    traceReplay: values["trace-replay"],
+    storageState: values["storage-state"],
+    output: values.output,
+    quiet: values.quiet ?? false,
+  };
+}
+
+function printFlakeHelp(): void {
+  console.log(`
+chaosbringer flake — run the same crawl N times and surface flaky errors.
+
+USAGE:
+  chaosbringer flake --url <url> [--runs N] [options]
+
+OPTIONS:
+  --url <url>           Base URL (required)
+  --runs <n>            Number of runs (default: 3, minimum: 2)
+  --seed <n>            Fixed seed — makes RNG-driven variance impossible,
+                        so any flake points at non-determinism outside
+                        chaosbringer (server, network, timers).
+  --max-pages <n>       Forward to each crawl
+  --max-actions <n>     Forward to each crawl
+  --timeout <ms>        Forward to each crawl
+  --ignore-analytics    Forward to each crawl
+  --har-replay <path>   Forward to each crawl
+  --trace-replay <path> Forward to each crawl
+  --storage-state <p>   Forward to each crawl
+  --output <path>       Write the flake analysis as JSON alongside stdout
+  --quiet               Print only the final summary
+  --help                Show this help
+`);
+}
+
+function fail(msg: string): never {
+  console.error(`Error: ${msg}`);
+  console.error("Run `chaosbringer flake --help` for usage information.");
+  process.exit(1);
+}
+
+/** Entry point wired from src/cli.ts when the `flake` subcommand is used. */
+export async function runFlakeCli(argv: string[]): Promise<void> {
+  const args = parseFlakeArgs(argv);
+  const { ChaosCrawler, COMMON_IGNORE_PATTERNS } = await import("./crawler.js");
+  const reports: CrawlReport[] = [];
+  for (let i = 0; i < args.runs; i++) {
+    if (!args.quiet) console.log(`Run ${i + 1}/${args.runs}...`);
+    const crawler = new ChaosCrawler({
+      baseUrl: args.baseUrl,
+      seed: args.seed,
+      maxPages: args.maxPages,
+      maxActionsPerPage: args.maxActions,
+      timeout: args.timeout,
+      ignoreErrorPatterns: args.ignoreAnalytics ? COMMON_IGNORE_PATTERNS : undefined,
+      har: args.harReplay ? { path: args.harReplay, mode: "replay" } : undefined,
+      traceReplay: args.traceReplay,
+      storageState: args.storageState,
+    });
+    const report = await crawler.start();
+    reports.push(report);
+  }
+  const analysis = flakeReport(reports);
+  console.log(formatFlakeReport(analysis));
+  if (args.output) {
+    writeFileSync(args.output, JSON.stringify(analysis, null, 2));
+    if (!args.quiet) console.log(`Analysis saved to: ${args.output}`);
+  }
+  // Exit 1 if anything flaked — CI uses this to fail a gate.
+  if (analysis.flakyClusters.length > 0 || analysis.flakyPages.length > 0) {
+    process.exit(1);
+  }
+}

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { buildGithubAnnotations, formatGithubAnnotation, printGithubAnnotations } from "./github.js";
+import type { CrawlReport, CrawlSummary, PageError } from "./types.js";
+
+function cluster(over: Partial<ErrorCluster> & { key: string; fingerprint: string; type: PageError["type"] }): ErrorCluster {
+  const sample: PageError = {
+    type: over.type,
+    message: over.fingerprint,
+    timestamp: 0,
+  };
+  return {
+    key: over.key,
+    type: over.type,
+    fingerprint: over.fingerprint,
+    sample,
+    count: over.count ?? 1,
+    urls: over.urls ?? [],
+    invariantNames: over.invariantNames,
+  };
+}
+
+function makeSummary(over: Partial<CrawlSummary> = {}): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    pagesWithErrors: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    invariantViolations: 0,
+    avgLoadTime: 0,
+    ...over,
+  };
+}
+
+function makeReport(over: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://x/",
+    seed: 1,
+    reproCommand: "",
+    startTime: 0,
+    endTime: 0,
+    duration: 0,
+    pagesVisited: 0,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: makeSummary(),
+    errorClusters: [],
+    ...over,
+  };
+}
+
+describe("buildGithubAnnotations", () => {
+  it("emits one annotation per error cluster", () => {
+    const report = makeReport({
+      errorClusters: [
+        cluster({ key: "k1", type: "invariant-violation", fingerprint: "has-h1 no <h1>" }),
+        cluster({ key: "k2", type: "console", fingerprint: "Failed to fetch" }),
+      ],
+    });
+    const out = buildGithubAnnotations(report);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.level).toBe("error");
+    expect(out[0]!.title).toContain("invariant-violation");
+    expect(out[1]!.level).toBe("warning");
+  });
+
+  it("upgrades warnings to errors in strict mode", () => {
+    const report = makeReport({
+      errorClusters: [cluster({ key: "k", type: "console", fingerprint: "f" })],
+    });
+    expect(buildGithubAnnotations(report, { strict: false })[0]!.level).toBe("warning");
+    expect(buildGithubAnnotations(report, { strict: true })[0]!.level).toBe("error");
+  });
+
+  it("adds a separate error annotation for each dead link", () => {
+    const report = makeReport({
+      summary: makeSummary({
+        discovery: {
+          extractedLinks: 0,
+          clickedLinks: 0,
+          uniquePages: 0,
+          deadLinks: [
+            {
+              url: "http://x/gone",
+              statusCode: 404,
+              sourceUrl: "http://x/home",
+              sourceElement: "a[href='/gone']",
+              method: "extracted",
+            },
+          ],
+          spaIssues: [],
+        },
+      }),
+    });
+    const out = buildGithubAnnotations(report);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.level).toBe("error");
+    expect(out[0]!.title).toContain("Dead link");
+    expect(out[0]!.message).toContain("HTTP 404");
+  });
+
+  it("includes cluster URL count in the message when multiple URLs are involved", () => {
+    const report = makeReport({
+      errorClusters: [
+        cluster({
+          key: "k",
+          type: "network",
+          fingerprint: "failed",
+          urls: ["http://x/a", "http://x/b", "http://x/c"],
+          count: 3,
+        }),
+      ],
+    });
+    const out = buildGithubAnnotations(report);
+    expect(out[0]!.message).toContain("3 URLs");
+    expect(out[0]!.title).toContain("×3");
+  });
+});
+
+describe("formatGithubAnnotation", () => {
+  it("emits the workflow-command form", () => {
+    const line = formatGithubAnnotation({ level: "error", title: "boom", message: "x" });
+    expect(line).toBe("::error title=boom::x");
+  });
+
+  it("escapes characters that would corrupt the property or break the line", () => {
+    const line = formatGithubAnnotation({
+      level: "warning",
+      title: "a:b,c\nd",
+      message: "hello\nworld",
+    });
+    expect(line).toBe("::warning title=a%3Ab%2Cc%0Ad::hello%0Aworld");
+  });
+});
+
+describe("printGithubAnnotations", () => {
+  it("writes one line per annotation to the sink", () => {
+    const report = makeReport({
+      errorClusters: [
+        cluster({ key: "k", type: "exception", fingerprint: "boom" }),
+      ],
+    });
+    const sink: string[] = [];
+    printGithubAnnotations(report, { sink: (l) => sink.push(l) });
+    expect(sink).toHaveLength(1);
+    expect(sink[0]).toMatch(/^::error /);
+  });
+});

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,102 @@
+/**
+ * GitHub Actions annotation emitter. Renders a run's error clusters + dead
+ * links as `::error ...::` / `::warning ...::` workflow commands so GitHub
+ * surfaces them on the PR Checks tab without requiring a separate bot.
+ *
+ * See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+ *
+ * chaosbringer doesn't know source file locations (the failures are on URLs),
+ * so `file=` is omitted. GitHub still renders the annotation; it just shows
+ * up on the run summary instead of the diff.
+ */
+
+import type { CrawlReport } from "./types.js";
+
+/** Escape newlines + carriage returns so a single annotation stays on one line. */
+function escapeProperty(s: string): string {
+  return s.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+}
+
+function escapeMessage(s: string): string {
+  return s.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+export interface AnnotationLine {
+  level: "error" | "warning" | "notice";
+  title: string;
+  message: string;
+}
+
+/**
+ * Decide which severity each error cluster deserves. Invariant violations and
+ * network errors are errors; console errors / rejections are warnings; anything
+ * else is a notice. Strict mode upgrades warnings to errors so the annotation
+ * level matches `getExitCode` with `strict=true`.
+ */
+function levelForClusterType(type: CrawlReport["errorClusters"][number]["type"], strict: boolean): AnnotationLine["level"] {
+  switch (type) {
+    case "invariant-violation":
+    case "network":
+    case "exception":
+    case "crash":
+      return "error";
+    case "console":
+    case "unhandled-rejection":
+      return strict ? "error" : "warning";
+    default:
+      return "notice";
+  }
+}
+
+/**
+ * Build the list of annotations for a report. Pure — the CLI just prints each
+ * entry. Callers that want to inject into their own logger can use this.
+ */
+export function buildGithubAnnotations(
+  report: CrawlReport,
+  opts: { strict?: boolean } = {}
+): AnnotationLine[] {
+  const strict = opts.strict ?? false;
+  const out: AnnotationLine[] = [];
+
+  for (const cluster of report.errorClusters) {
+    const count = cluster.count > 1 ? ` ×${cluster.count}` : "";
+    const urls = cluster.urls.length > 0 ? ` (on ${cluster.urls.length} URL${cluster.urls.length > 1 ? "s" : ""})` : "";
+    out.push({
+      level: levelForClusterType(cluster.type, strict),
+      title: `[${cluster.type}]${count} ${truncate(cluster.fingerprint, 80)}`,
+      message: `${cluster.sample.message}${urls}`,
+    });
+  }
+
+  const dead = report.summary.discovery?.deadLinks ?? [];
+  for (const link of dead) {
+    out.push({
+      level: "error",
+      title: `Dead link: ${truncate(link.url, 80)}`,
+      message: `HTTP ${link.statusCode} — found on ${link.sourceUrl || "(initial)"}${link.sourceElement ? ` via ${truncate(link.sourceElement, 40)}` : ""}`,
+    });
+  }
+
+  return out;
+}
+
+/** Serialize one annotation into its workflow-command text form. */
+export function formatGithubAnnotation(a: AnnotationLine): string {
+  return `::${a.level} title=${escapeProperty(a.title)}::${escapeMessage(a.message)}`;
+}
+
+/** Write every annotation to `sink` (default: console.log). */
+export function printGithubAnnotations(
+  report: CrawlReport,
+  opts: { strict?: boolean; sink?: (line: string) => void } = {}
+): void {
+  const sink = opts.sink ?? ((s) => console.log(s));
+  for (const a of buildGithubAnnotations(report, { strict: opts.strict })) {
+    sink(formatGithubAnnotation(a));
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 3) + "...";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,3 +85,9 @@ export type {
 } from "./types.js";
 export { NETWORK_PROFILES, PERF_BUDGET_KEYS } from "./types.js";
 export { networkConditionsFor, type NetworkConditions } from "./network.js";
+export {
+  fetchSitemapUrls,
+  isSitemapIndex,
+  parseSitemap,
+  type FetchSitemapOptions,
+} from "./sitemap.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,14 @@ export {
   type TraceMeta,
   type TraceVisit,
 } from "./trace.js";
+export {
+  ddmin,
+  minimizeTrace,
+  reportMatches,
+  traceWithActions,
+  type MinimizeOptions,
+  type MinimizeResult,
+} from "./minimize.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,21 @@ export { clusterErrors, fingerprintError, type ErrorCluster } from "./clusters.j
 export { diffReports, loadBaseline, hasRegressions } from "./diff.js";
 export { checkPerformanceBudget } from "./budget.js";
 export { invariants, axe, buildAxeRunPayload, formatAxeViolations, type AxeInvariantOptions } from "./invariants.js";
+export {
+  TRACE_FORMAT_VERSION,
+  actionToTraceEntry,
+  groupTrace,
+  metaOf,
+  parseTrace,
+  readTrace,
+  serializeTrace,
+  writeTrace,
+  type TraceAction,
+  type TraceEntry,
+  type TraceGroup,
+  type TraceMeta,
+  type TraceVisit,
+} from "./trace.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,12 @@
 
 // Core
 export { ChaosCrawler, COMMON_IGNORE_PATTERNS, validateOptions } from "./crawler.js";
-export { formatReport, formatCompactReport, saveReport, printReport, getExitCode } from "./reporter.js";
+export { formatReport, formatCompactReport, saveReport, printReport, getExitCode, type ExitCodeOptions } from "./reporter.js";
 export { Logger, createNullLogger, type LogEntry, type LogLevel, type LoggerOptions } from "./logger.js";
 export { chaos, type ChaosResult, type ChaosRunOptions } from "./chaos.js";
 export { faults, type FaultHelperOptions } from "./faults.js";
 export { clusterErrors, fingerprintError, type ErrorCluster } from "./clusters.js";
+export { diffReports, loadBaseline, hasRegressions } from "./diff.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";
@@ -37,4 +38,7 @@ export type {
   UrlMatcher,
   HarConfig,
   HarMode,
+  ReportDiff,
+  ClusterDiffEntry,
+  PageDiffEntry,
 } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,13 @@ export {
   type MinimizeOptions,
   type MinimizeResult,
 } from "./minimize.js";
+export {
+  flakeReport,
+  formatFlakeReport,
+  type FlakeAnalysis,
+  type ClusterOccurrence,
+  type PageOccurrence,
+} from "./flake.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,10 +70,12 @@ export type {
   UrlMatcher,
   HarConfig,
   HarMode,
+  NetworkProfile,
   PerformanceBudget,
   PerfBudgetKey,
   ReportDiff,
   ClusterDiffEntry,
   PageDiffEntry,
 } from "./types.js";
-export { PERF_BUDGET_KEYS } from "./types.js";
+export { NETWORK_PROFILES, PERF_BUDGET_KEYS } from "./types.js";
+export { networkConditionsFor, type NetworkConditions } from "./network.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { faults, type FaultHelperOptions } from "./faults.js";
 export { clusterErrors, fingerprintError, type ErrorCluster } from "./clusters.js";
 export { diffReports, loadBaseline, hasRegressions } from "./diff.js";
 export { checkPerformanceBudget } from "./budget.js";
+export { invariants, axe, buildAxeRunPayload, formatAxeViolations, type AxeInvariantOptions } from "./invariants.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { chaos, type ChaosResult, type ChaosRunOptions } from "./chaos.js";
 export { faults, type FaultHelperOptions } from "./faults.js";
 export { clusterErrors, fingerprintError, type ErrorCluster } from "./clusters.js";
 export { diffReports, loadBaseline, hasRegressions } from "./diff.js";
+export { checkPerformanceBudget } from "./budget.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";
@@ -38,7 +39,10 @@ export type {
   UrlMatcher,
   HarConfig,
   HarMode,
+  PerformanceBudget,
+  PerfBudgetKey,
   ReportDiff,
   ClusterDiffEntry,
   PageDiffEntry,
 } from "./types.js";
+export { PERF_BUDGET_KEYS } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,12 @@ export {
   type ClusterOccurrence,
   type PageOccurrence,
 } from "./flake.js";
+export {
+  buildGithubAnnotations,
+  formatGithubAnnotation,
+  printGithubAnnotations,
+  type AnnotationLine,
+} from "./github.js";
 
 // Playwright Test integration
 export { chaosTest, withChaos, runChaosTest, chaosExpect, type ChaosFixture, type ChaosFixtures } from "./fixture.js";

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { axe, buildAxeRunPayload, formatAxeViolations, invariants } from "./invariants.js";
+
+describe("buildAxeRunPayload", () => {
+  it("defaults to the WCAG 2 A / AA tags when none are provided", () => {
+    const p = buildAxeRunPayload();
+    expect(p.options.runOnly).toEqual({
+      type: "tag",
+      values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
+    });
+    expect(p.context).toBeNull();
+    expect(p.options.rules).toBeUndefined();
+  });
+
+  it("passes custom tags through verbatim", () => {
+    const p = buildAxeRunPayload({ tags: ["best-practice"] });
+    expect(p.options.runOnly.values).toEqual(["best-practice"]);
+  });
+
+  it("wraps include/exclude selectors into axe's nested-array context shape", () => {
+    const p = buildAxeRunPayload({ include: ["main"], exclude: [".ads", "#third-party"] });
+    expect(p.context).toEqual({
+      include: [["main"]],
+      exclude: [[".ads"], ["#third-party"]],
+    });
+  });
+
+  it("emits a rules map when disableRules is non-empty", () => {
+    const p = buildAxeRunPayload({ disableRules: ["color-contrast", "region"] });
+    expect(p.options.rules).toEqual({
+      "color-contrast": { enabled: false },
+      region: { enabled: false },
+    });
+  });
+
+  it("omits the rules map when disableRules is empty", () => {
+    expect(buildAxeRunPayload({ disableRules: [] }).options.rules).toBeUndefined();
+  });
+
+  it("returns resultTypes restricted to violations (we don't ship passes/incomplete)", () => {
+    expect(buildAxeRunPayload().options.resultTypes).toEqual(["violations"]);
+  });
+});
+
+describe("formatAxeViolations", () => {
+  it("returns an empty string for an empty list", () => {
+    expect(formatAxeViolations([])).toBe("");
+  });
+
+  it("summarises each violation with node count and impact when available", () => {
+    const out = formatAxeViolations([
+      { id: "color-contrast", impact: "serious", nodes: [{}, {}, {}, {}, {}] },
+      { id: "image-alt", impact: "critical", nodes: [{}, {}] },
+    ]);
+    expect(out).toBe(
+      "2 a11y violations: color-contrast(×5, serious), image-alt(×2, critical)"
+    );
+  });
+
+  it("omits impact when not provided", () => {
+    const out = formatAxeViolations([{ id: "region", nodes: [{}] }]);
+    expect(out).toBe("1 a11y violations: region(×1)");
+  });
+});
+
+describe("axe() invariant factory", () => {
+  it("returns an Invariant with a default name and afterActions phase", () => {
+    const inv = axe();
+    expect(inv.name).toBe("a11y-axe");
+    expect(inv.when).toBe("afterActions");
+    expect(typeof inv.check).toBe("function");
+  });
+
+  it("honours custom name / when / urlPattern", () => {
+    const inv = axe({ name: "a11y-home", when: "afterLoad", urlPattern: /^http:\/\/x\/$/ });
+    expect(inv.name).toBe("a11y-home");
+    expect(inv.when).toBe("afterLoad");
+    expect(inv.urlPattern).toBeInstanceOf(RegExp);
+  });
+
+  it("is re-exported as invariants.axe for ergonomic consumption", () => {
+    expect(invariants.axe).toBe(axe);
+  });
+});

--- a/src/invariants.ts
+++ b/src/invariants.ts
@@ -1,0 +1,144 @@
+/**
+ * Built-in invariant presets. Mirrors the `faults` helpers — lets users wire
+ * common assertions without writing the check() closure each time.
+ *
+ * Presets declared here are otherwise ordinary Invariants. They just know how
+ * to set up their own tooling (e.g. inject axe-core into the page).
+ */
+
+import type { Invariant } from "./types.js";
+
+export interface AxeInvariantOptions {
+  /** Display name for reporting. Default: `a11y-axe`. */
+  name?: string;
+  /** Restrict to URLs matching this matcher. */
+  urlPattern?: Invariant["urlPattern"];
+  /** Phase to evaluate. Default: `afterActions`. */
+  when?: Invariant["when"];
+  /**
+   * Axe rule tags to include. Default: WCAG 2 A / AA. Pass fewer for stricter
+   * runs (`["wcag2a"]`) or more for exhaustive audits (add `"best-practice"`).
+   */
+  tags?: string[];
+  /** CSS selectors to restrict the scan to. */
+  include?: string[];
+  /** CSS selectors to skip (e.g. 3rd-party widgets you don't own). */
+  exclude?: string[];
+  /** Rule ids to disable, e.g. `["color-contrast"]`. */
+  disableRules?: string[];
+}
+
+const DEFAULT_AXE_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+/** Shape of the axe-core run result we rely on. Kept minimal. */
+interface AxeViolationNode {
+  html?: string;
+  target?: unknown;
+}
+interface AxeViolation {
+  id: string;
+  impact?: string | null;
+  help?: string;
+  nodes: AxeViolationNode[];
+}
+interface AxeResults {
+  violations: AxeViolation[];
+}
+
+/** Shape of what axe.run receives. Pure — returned verbatim into page.evaluate. */
+export interface AxeRunPayload {
+  context: { include?: string[][]; exclude?: string[][] } | null;
+  options: {
+    runOnly: { type: "tag"; values: string[] };
+    rules?: Record<string, { enabled: false }>;
+    resultTypes: ["violations"];
+  };
+}
+
+export function buildAxeRunPayload(opts: AxeInvariantOptions = {}): AxeRunPayload {
+  const tags = opts.tags && opts.tags.length > 0 ? opts.tags : DEFAULT_AXE_TAGS;
+  const contextEntries: { include?: string[][]; exclude?: string[][] } = {};
+  if (opts.include && opts.include.length > 0) {
+    contextEntries.include = opts.include.map((s) => [s]);
+  }
+  if (opts.exclude && opts.exclude.length > 0) {
+    contextEntries.exclude = opts.exclude.map((s) => [s]);
+  }
+  const hasContext = contextEntries.include || contextEntries.exclude;
+  const rules: Record<string, { enabled: false }> | undefined = opts.disableRules?.length
+    ? Object.fromEntries(opts.disableRules.map((r) => [r, { enabled: false as const }]))
+    : undefined;
+  return {
+    context: hasContext ? contextEntries : null,
+    options: {
+      runOnly: { type: "tag", values: tags },
+      ...(rules ? { rules } : {}),
+      resultTypes: ["violations"],
+    },
+  };
+}
+
+/**
+ * Render a violations array to a single-line summary suitable for the
+ * invariant failure message. Example:
+ *   `3 violations: color-contrast(×5, serious), image-alt(×2, critical)`
+ */
+export function formatAxeViolations(violations: AxeViolation[]): string {
+  if (violations.length === 0) return "";
+  const parts = violations.map((v) => {
+    const count = v.nodes?.length ?? 0;
+    const impact = v.impact ? `, ${v.impact}` : "";
+    return `${v.id}(×${count}${impact})`;
+  });
+  return `${violations.length} a11y violations: ${parts.join(", ")}`;
+}
+
+async function loadAxeSource(): Promise<string> {
+  try {
+    const mod = (await import("axe-core")) as unknown as { default?: { source?: string }; source?: string };
+    const source = mod.default?.source ?? mod.source;
+    if (typeof source !== "string" || source.length === 0) {
+      throw new Error("axe-core did not expose a `source` string — check the installed version.");
+    }
+    return source;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("axe-core")) throw err;
+    throw new Error(
+      "chaosbringer: invariants.axe() requires the `axe-core` package. Install it with `pnpm add axe-core`."
+    );
+  }
+}
+
+/**
+ * Axe-core invariant preset. Injects axe into every page the invariant runs
+ * on, calls `axe.run`, and fails with a one-line summary of the violations.
+ * Requires `axe-core` to be installed — it's an optional peer dep.
+ */
+export function axe(options: AxeInvariantOptions = {}): Invariant {
+  const payload = buildAxeRunPayload(options);
+  return {
+    name: options.name ?? "a11y-axe",
+    urlPattern: options.urlPattern,
+    when: options.when ?? "afterActions",
+    async check({ page }) {
+      const source = await loadAxeSource();
+      await page.addScriptTag({ content: source });
+      const results = (await page.evaluate(
+        async (p) => {
+          // @ts-ignore - axe is attached to window by the script tag above.
+          const ax = (globalThis as { axe?: { run: (c: unknown, o: unknown) => Promise<unknown> } }).axe;
+          if (!ax) throw new Error("axe-core failed to install on the page");
+          return ax.run(p.context ?? document, p.options);
+        },
+        payload
+      )) as AxeResults;
+      if (!results || !Array.isArray(results.violations) || results.violations.length === 0) {
+        return true;
+      }
+      return formatAxeViolations(results.violations);
+    },
+  };
+}
+
+/** Exported as a namespace so consumers can write `invariants.axe(...)`. */
+export const invariants = { axe };

--- a/src/minimize.test.ts
+++ b/src/minimize.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { ddmin, reportMatches, traceWithActions } from "./minimize.js";
+import {
+  TRACE_FORMAT_VERSION,
+  type TraceAction,
+  type TraceEntry,
+  type TraceMeta,
+} from "./trace.js";
+import type { CrawlReport, PageError } from "./types.js";
+
+const META: TraceMeta = {
+  kind: "meta",
+  v: TRACE_FORMAT_VERSION,
+  seed: 1,
+  baseUrl: "http://x/",
+  startTime: 0,
+};
+
+function action(i: number, type: TraceAction["type"] = "click"): TraceAction {
+  return {
+    kind: "action",
+    url: "http://x/",
+    type,
+    selector: `a#${i}`,
+    success: true,
+  };
+}
+
+describe("ddmin", () => {
+  it("narrows down to the 1-minimal set for a simple conjunction predicate", async () => {
+    const items = [1, 2, 3, 4, 5, 6, 7, 8];
+    const required = new Set([3, 7]);
+    const predicate = async (subset: number[]) =>
+      Array.from(required).every((r) => subset.includes(r));
+    const out = await ddmin(items, predicate);
+    expect(out.sort((a, b) => a - b)).toEqual([3, 7]);
+  });
+
+  it("preserves the original order of items it keeps", async () => {
+    const items = ["a", "b", "c", "d", "e"];
+    const required = new Set(["b", "d"]);
+    const predicate = async (s: string[]) =>
+      Array.from(required).every((r) => s.includes(r));
+    const out = await ddmin(items, predicate);
+    expect(out).toEqual(["b", "d"]);
+  });
+
+  it("returns a single item when only one is required", async () => {
+    const predicate = async (s: number[]) => s.includes(42);
+    const out = await ddmin([1, 2, 42, 3, 4], predicate);
+    expect(out).toEqual([42]);
+  });
+
+  it("is stable on an empty input (no predicate calls)", async () => {
+    let calls = 0;
+    const predicate = async () => {
+      calls++;
+      return true;
+    };
+    const out = await ddmin<number>([], predicate);
+    expect(out).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  it("invokes onStep for each successful reduction", async () => {
+    const steps: Array<{ size: number; keptAfter: number }> = [];
+    const predicate = async (s: number[]) => s.includes(5);
+    await ddmin([1, 2, 3, 4, 5, 6, 7, 8], predicate, (info) =>
+      steps.push({ size: info.size, keptAfter: info.keptAfter })
+    );
+    expect(steps.length).toBeGreaterThan(0);
+    // Each step must shrink monotonically.
+    for (let i = 1; i < steps.length; i++) {
+      expect(steps[i]!.keptAfter).toBeLessThanOrEqual(steps[i - 1]!.keptAfter);
+    }
+  });
+});
+
+describe("traceWithActions", () => {
+  it("keeps every non-action entry and drops unselected actions", () => {
+    const a1 = action(1);
+    const a2 = action(2);
+    const a3 = action(3);
+    const source: TraceEntry[] = [
+      META,
+      { kind: "visit", url: "http://x/" },
+      a1,
+      a2,
+      { kind: "visit", url: "http://x/b" },
+      a3,
+    ];
+    const keep = new Set([a1, a3]);
+    const out = traceWithActions(source, keep);
+    expect(out).toEqual([
+      META,
+      { kind: "visit", url: "http://x/" },
+      a1,
+      { kind: "visit", url: "http://x/b" },
+      a3,
+    ]);
+  });
+
+  it("preserves the original meta → visit order even when all actions are removed", () => {
+    const a = action(1);
+    const out = traceWithActions(
+      [META, { kind: "visit", url: "/" }, a],
+      new Set()
+    );
+    expect(out).toEqual([META, { kind: "visit", url: "/" }]);
+  });
+});
+
+describe("reportMatches", () => {
+  function cluster(fingerprint: string): ErrorCluster {
+    const sample: PageError = { type: "console", message: fingerprint, timestamp: 0 };
+    return {
+      key: `console|${fingerprint}`,
+      type: "console",
+      fingerprint,
+      sample,
+      count: 1,
+      urls: [],
+    };
+  }
+  function report(clusters: ErrorCluster[]): CrawlReport {
+    return {
+      baseUrl: "http://x/",
+      seed: 0,
+      reproCommand: "",
+      startTime: 0,
+      endTime: 0,
+      duration: 0,
+      pagesVisited: 0,
+      totalErrors: 0,
+      totalWarnings: 0,
+      blockedExternalNavigations: 0,
+      recoveryCount: 0,
+      pages: [],
+      actions: [],
+      summary: {
+        successPages: 0,
+        errorPages: 0,
+        timeoutPages: 0,
+        recoveredPages: 0,
+        pagesWithErrors: 0,
+        consoleErrors: 0,
+        networkErrors: 0,
+        jsExceptions: 0,
+        unhandledRejections: 0,
+        invariantViolations: 0,
+        avgLoadTime: 0,
+      },
+      errorClusters: clusters,
+    };
+  }
+
+  it("is true when any fingerprint matches the regex", () => {
+    expect(reportMatches(report([cluster("Cannot read property")]), /Cannot read/)).toBe(true);
+  });
+
+  it("is false when no cluster fingerprint matches", () => {
+    expect(reportMatches(report([cluster("some other error")]), /Cannot read/)).toBe(false);
+  });
+
+  it("is false on an empty clusters array", () => {
+    expect(reportMatches(report([]), /./)).toBe(false);
+  });
+});

--- a/src/minimize.ts
+++ b/src/minimize.ts
@@ -1,0 +1,328 @@
+/**
+ * Delta-debugging (ddmin) over a recorded chaos trace, so the user can ask
+ * "which of these 500 actions are actually needed to reproduce this bug?"
+ *
+ * The core `ddmin` helper is pure: it takes a sequence and an async predicate
+ * and returns a 1-minimal subset. The rest of this module wires it up to the
+ * trace format and to `chaos()` so the CLI subcommand can minimise against
+ * a regex match on error-cluster fingerprints.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { ChaosCrawler } from "./crawler.js";
+import {
+  groupTrace,
+  readTrace,
+  writeTrace,
+  type TraceAction,
+  type TraceEntry,
+  type TraceMeta,
+} from "./trace.js";
+import type { CrawlReport } from "./types.js";
+
+/**
+ * Zeller's ddmin. Narrows `items` down to the minimal subsequence that still
+ * satisfies `predicate` ("this reproduces the failure"). `predicate` should
+ * return `true` when the subset still reproduces, `false` otherwise.
+ *
+ * The algorithm preserves order and is deterministic given a deterministic
+ * predicate. Complexity is O(n log n) in the happy case and O(n²) worst case.
+ */
+export async function ddmin<T>(
+  items: readonly T[],
+  predicate: (subset: T[]) => Promise<boolean>,
+  onStep?: (info: { iteration: number; size: number; keptAfter: number }) => void
+): Promise<T[]> {
+  let current: T[] = [...items];
+  let granularity = 2;
+  let iteration = 0;
+
+  while (current.length >= 2) {
+    const chunkSize = Math.ceil(current.length / granularity);
+    const chunks: T[][] = [];
+    for (let i = 0; i < current.length; i += chunkSize) {
+      chunks.push(current.slice(i, i + chunkSize));
+    }
+
+    let reduced = false;
+
+    // Phase 1 — try each chunk alone.
+    for (const chunk of chunks) {
+      iteration++;
+      if (await predicate(chunk)) {
+        onStep?.({ iteration, size: current.length, keptAfter: chunk.length });
+        current = chunk;
+        granularity = 2;
+        reduced = true;
+        break;
+      }
+    }
+    if (reduced) continue;
+
+    // Phase 2 — try each complement (drop one chunk at a time).
+    for (let ci = 0; ci < chunks.length; ci++) {
+      const chunk = chunks[ci]!;
+      const chunkStart = ci * chunkSize;
+      const complement = [
+        ...current.slice(0, chunkStart),
+        ...current.slice(chunkStart + chunk.length),
+      ];
+      if (complement.length === 0) continue;
+      iteration++;
+      if (await predicate(complement)) {
+        onStep?.({ iteration, size: current.length, keptAfter: complement.length });
+        current = complement;
+        granularity = Math.max(granularity - 1, 2);
+        reduced = true;
+        break;
+      }
+    }
+    if (reduced) continue;
+
+    // Phase 3 — increase granularity. If we can't split finer, we're 1-minimal.
+    if (granularity >= current.length) break;
+    granularity = Math.min(current.length, granularity * 2);
+  }
+
+  return current;
+}
+
+/** True when any error cluster fingerprint matches the regex. */
+export function reportMatches(report: CrawlReport, pattern: RegExp): boolean {
+  for (const c of report.errorClusters) {
+    if (pattern.test(c.fingerprint)) return true;
+  }
+  return false;
+}
+
+/**
+ * Build a new trace from `source`, keeping every meta / visit entry and only
+ * the action entries in `keepActions`. Visit→action grouping is preserved so
+ * actions stay on the same pages they were originally recorded on.
+ */
+export function traceWithActions(
+  source: readonly TraceEntry[],
+  keepActions: ReadonlySet<TraceAction>
+): TraceEntry[] {
+  const out: TraceEntry[] = [];
+  for (const entry of source) {
+    if (entry.kind === "action") {
+      if (keepActions.has(entry)) out.push(entry);
+    } else {
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+export interface MinimizeOptions {
+  /** Base URL under test. */
+  baseUrl: string;
+  /** Source trace to minimise. */
+  trace: readonly TraceEntry[];
+  /** Predicate — typically `reportMatches(report, /regex/)`. */
+  predicate: (report: CrawlReport) => boolean | Promise<boolean>;
+  /** Extra crawler knobs (timeout, maxPages, etc.) forwarded verbatim. */
+  crawlerOverrides?: Record<string, unknown>;
+  /** Observer for minimise progress. */
+  onStep?: (info: { iteration: number; size: number; keptAfter: number }) => void;
+  /** Working directory for temp trace files. Default: os.tmpdir(). */
+  tmpDir?: string;
+}
+
+export interface MinimizeResult {
+  /** All actions from the source trace, in order. */
+  originalActions: TraceAction[];
+  /** Actions retained by ddmin. */
+  minimizedActions: TraceAction[];
+  /** Trace containing every visit + only the minimized actions. */
+  minimizedTrace: TraceEntry[];
+  /** Total replay runs executed. */
+  iterations: number;
+}
+
+/**
+ * Drive ddmin over the action entries in a trace. For each candidate subset,
+ * writes a temp trace, runs the crawler in replay mode, and evaluates the
+ * predicate against the resulting report.
+ *
+ * Visit entries are preserved in full so URLs in the replay match the
+ * original — only action removal is attempted. A source trace with no actions
+ * returns unchanged.
+ */
+export async function minimizeTrace(options: MinimizeOptions): Promise<MinimizeResult> {
+  const source = options.trace;
+  const originalActions: TraceAction[] = source.filter(
+    (e): e is TraceAction => e.kind === "action"
+  );
+
+  if (originalActions.length === 0) {
+    return {
+      originalActions,
+      minimizedActions: [],
+      minimizedTrace: [...source],
+      iterations: 0,
+    };
+  }
+
+  const workdir = mkdtempSync(join(options.tmpDir ?? tmpdir(), "chaos-min-"));
+  let iterationCounter = 0;
+
+  try {
+    const predicate = async (subset: TraceAction[]): Promise<boolean> => {
+      const keep = new Set(subset);
+      const candidate = traceWithActions(source, keep);
+      const tracePath = join(workdir, `iter-${iterationCounter++}.jsonl`);
+      writeTrace(tracePath, candidate);
+      const crawler = new ChaosCrawler({
+        ...(options.crawlerOverrides ?? {}),
+        baseUrl: options.baseUrl,
+        traceReplay: tracePath,
+      } as never);
+      const report = await crawler.start();
+      return Boolean(await options.predicate(report));
+    };
+
+    const minimizedActions = await ddmin(originalActions, predicate, options.onStep);
+    const keep = new Set(minimizedActions);
+    const minimizedTrace = traceWithActions(source, keep);
+    return {
+      originalActions,
+      minimizedActions,
+      minimizedTrace,
+      iterations: iterationCounter,
+    };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+/** Parsed CLI arguments for the minimize subcommand. */
+interface MinimizeCliArgs {
+  baseUrl: string;
+  tracePath: string;
+  match: RegExp;
+  traceOut: string;
+  maxPages?: number;
+  timeout?: number;
+  ignoreAnalytics: boolean;
+  quiet: boolean;
+}
+
+function parseMinimizeArgs(argv: string[]): MinimizeCliArgs {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      url: { type: "string" },
+      trace: { type: "string" },
+      match: { type: "string" },
+      "trace-out": { type: "string" },
+      "max-pages": { type: "string" },
+      timeout: { type: "string" },
+      "ignore-analytics": { type: "boolean", default: false },
+      quiet: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    printMinimizeHelp();
+    process.exit(0);
+  }
+  if (!values.url) fail("--url is required");
+  if (!values.trace) fail("--trace is required");
+  if (!values.match) fail("--match is required");
+
+  let match: RegExp;
+  try {
+    match = new RegExp(values.match!);
+  } catch (err) {
+    fail(`--match is not a valid regex: ${(err as Error).message}`);
+  }
+
+  return {
+    baseUrl: values.url!,
+    tracePath: values.trace!,
+    match: match!,
+    traceOut: values["trace-out"] ?? "min.trace.jsonl",
+    maxPages: values["max-pages"] ? Number(values["max-pages"]) : undefined,
+    timeout: values.timeout ? Number(values.timeout) : undefined,
+    ignoreAnalytics: values["ignore-analytics"] ?? false,
+    quiet: values.quiet ?? false,
+  };
+}
+
+function printMinimizeHelp(): void {
+  console.log(`
+chaosbringer minimize — shrink a recorded trace to the minimum actions
+that still reproduce a failure.
+
+USAGE:
+  chaosbringer minimize --url <url> --trace <in.jsonl> --match <regex> [options]
+
+OPTIONS:
+  --url <url>           Base URL under test (required)
+  --trace <path>        Source trace to shrink (required)
+  --match <regex>       Reproduction predicate — matches error cluster fingerprints
+  --trace-out <path>    Where to write the minimized trace (default: min.trace.jsonl)
+  --max-pages <n>       Forward to the crawler
+  --timeout <ms>        Forward to the crawler
+  --ignore-analytics    Suppress common analytics noise during replays
+  --quiet               Print only the final summary
+  --help                Show this help
+`);
+}
+
+function fail(msg: string): never {
+  console.error(`Error: ${msg}`);
+  console.error("Run `chaosbringer minimize --help` for usage information.");
+  process.exit(1);
+}
+
+/** Entry point wired from src/cli.ts when the `minimize` subcommand is used. */
+export async function runMinimizeCli(argv: string[]): Promise<void> {
+  const args = parseMinimizeArgs(argv);
+  const trace = readTrace(args.tracePath);
+  const meta = trace[0] as TraceMeta;
+
+  if (!args.quiet) {
+    const actionCount = trace.filter((e) => e.kind === "action").length;
+    console.log(
+      `Minimizing ${actionCount} actions from ${args.tracePath} (baseUrl=${meta.baseUrl}, match=${args.match})`
+    );
+  }
+
+  const overrides: Record<string, unknown> = {};
+  if (args.maxPages !== undefined) overrides.maxPages = args.maxPages;
+  if (args.timeout !== undefined) overrides.timeout = args.timeout;
+  if (args.ignoreAnalytics) {
+    const { COMMON_IGNORE_PATTERNS } = await import("./crawler.js");
+    overrides.ignoreErrorPatterns = COMMON_IGNORE_PATTERNS;
+  }
+
+  const result = await minimizeTrace({
+    baseUrl: args.baseUrl,
+    trace,
+    predicate: (report) => reportMatches(report, args.match),
+    crawlerOverrides: overrides,
+    onStep: args.quiet
+      ? undefined
+      : (info) =>
+          console.log(
+            `  iter=${info.iteration} size=${info.size} kept=${info.keptAfter}`
+          ),
+  });
+
+  writeTrace(args.traceOut, result.minimizedTrace);
+  if (!args.quiet) {
+    console.log("");
+    console.log(
+      `Reduced ${result.originalActions.length} → ${result.minimizedActions.length} actions over ${result.iterations} replays`
+    );
+    console.log(`Minimized trace written to ${args.traceOut}`);
+  }
+}

--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { networkConditionsFor } from "./network.js";
+
+describe("networkConditionsFor", () => {
+  it("returns offline conditions for the offline profile", () => {
+    const c = networkConditionsFor("offline");
+    expect(c.offline).toBe(true);
+    expect(c.downloadThroughput).toBe(0);
+    expect(c.uploadThroughput).toBe(0);
+  });
+
+  it("returns slow-3g with 2s latency", () => {
+    const c = networkConditionsFor("slow-3g");
+    expect(c.offline).toBe(false);
+    expect(c.latency).toBe(2000);
+    expect(c.downloadThroughput).toBeGreaterThan(0);
+    expect(c.uploadThroughput).toBeGreaterThan(0);
+  });
+
+  it("returns fast-3g with lower latency than slow-3g", () => {
+    const slow = networkConditionsFor("slow-3g");
+    const fast = networkConditionsFor("fast-3g");
+    expect(fast.latency).toBeLessThan(slow.latency);
+    expect(fast.downloadThroughput).toBeGreaterThan(slow.downloadThroughput);
+  });
+});

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,0 +1,44 @@
+/**
+ * Network throttling presets applied via CDP's `Network.emulateNetworkConditions`.
+ * Values are the same ones DevTools uses for its built-in profiles.
+ */
+
+import type { NetworkProfile } from "./types.js";
+
+export interface NetworkConditions {
+  offline: boolean;
+  /** Extra round-trip latency added to every request, in ms. */
+  latency: number;
+  /** Download throughput in bytes / second; -1 disables throttling. */
+  downloadThroughput: number;
+  /** Upload throughput in bytes / second; -1 disables throttling. */
+  uploadThroughput: number;
+}
+
+const BPS = 1024; // 1 kilobit in bytes (125 B/s) — keep math readable.
+const KBPS = 1000 * BPS;
+void BPS;
+void KBPS;
+
+export function networkConditionsFor(profile: NetworkProfile): NetworkConditions {
+  switch (profile) {
+    case "offline":
+      return { offline: true, latency: 0, downloadThroughput: 0, uploadThroughput: 0 };
+    case "slow-3g":
+      // ~500 kbps down / ~500 kbps up / 2000 ms RTT — Chrome DevTools "Slow 3G".
+      return {
+        offline: false,
+        latency: 2000,
+        downloadThroughput: Math.floor((500 * 1024) / 8),
+        uploadThroughput: Math.floor((500 * 1024) / 8),
+      };
+    case "fast-3g":
+      // ~1.6 Mbps down / ~750 kbps up / 562 ms RTT — Chrome DevTools "Fast 3G".
+      return {
+        offline: false,
+        latency: 562,
+        downloadThroughput: Math.floor((1.6 * 1024 * 1024) / 8),
+        uploadThroughput: Math.floor((750 * 1024) / 8),
+      };
+  }
+}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -182,21 +182,64 @@ export function formatReport(report: CrawlReport): string {
     }
   }
 
+  if (report.diff) {
+    const d = report.diff;
+    lines.push("");
+    lines.push("-".repeat(40));
+    lines.push(`DIFF vs BASELINE${d.baselinePath ? ` (${d.baselinePath})` : ""}`);
+    lines.push("-".repeat(40));
+    lines.push(
+      `  New clusters: ${d.newClusters.length}   Resolved: ${d.resolvedClusters.length}   Unchanged: ${d.unchangedClusters.length}`
+    );
+    lines.push(
+      `  New failing pages: ${d.newFailedPages.length}   Resolved: ${d.resolvedFailedPages.length}`
+    );
+    if (d.newClusters.length > 0) {
+      lines.push("  NEW clusters:");
+      for (const c of d.newClusters) {
+        lines.push(`    + [${c.type}]×${c.after} ${truncate(c.fingerprint, 72)}`);
+      }
+    }
+    if (d.newFailedPages.length > 0) {
+      lines.push("  NEW failing pages:");
+      for (const p of d.newFailedPages) {
+        const before = p.before ? `${p.before.status}/${p.before.errors}err` : "(new URL)";
+        const after = p.after ? `${p.after.status}/${p.after.errors}err` : "(missing)";
+        lines.push(`    + ${p.url}   ${before} → ${after}`);
+      }
+    }
+    if (d.resolvedClusters.length > 0) {
+      lines.push("  RESOLVED clusters:");
+      for (const c of d.resolvedClusters) {
+        lines.push(`    - [${c.type}]×${c.before} ${truncate(c.fingerprint, 72)}`);
+      }
+    }
+    if (d.resolvedFailedPages.length > 0) {
+      lines.push("  RESOLVED pages:");
+      for (const p of d.resolvedFailedPages) {
+        lines.push(`    - ${p.url}`);
+      }
+    }
+  }
+
   lines.push("");
   lines.push("=".repeat(60));
 
   return lines.join("\n");
 }
 
-export function formatCompactReport(report: CrawlReport, strict = false): string {
+export function formatCompactReport(report: CrawlReport, strict: boolean | ExitCodeOptions = false): string {
   // Use the same rule as getExitCode so the human label matches the exit
   // code. Previously the label ignored strict mode and console errors,
   // producing `[PASS]` runs that exited 1. See #6.
   const status = getExitCode(report, strict) === 0 ? "PASS" : "FAIL";
   const errors = report.summary.consoleErrors + report.summary.networkErrors + report.summary.jsExceptions;
+  const diffSuffix = report.diff
+    ? ` diff=+${report.diff.newClusters.length}c/+${report.diff.newFailedPages.length}p`
+    : "";
 
   return [
-    `[${status}] ${report.pagesVisited} pages, ${errors} errors, ${(report.duration / 1000).toFixed(1)}s (seed=${report.seed})`,
+    `[${status}] ${report.pagesVisited} pages, ${errors} errors, ${(report.duration / 1000).toFixed(1)}s (seed=${report.seed})${diffSuffix}`,
     report.summary.avgMetrics
       ? `  Metrics: TTFB=${report.summary.avgMetrics.ttfb.toFixed(0)}ms, FCP=${report.summary.avgMetrics.fcp.toFixed(0)}ms`
       : "",
@@ -209,7 +252,7 @@ export function saveReport(report: CrawlReport, path: string): void {
   writeFileSync(path, JSON.stringify(report, null, 2));
 }
 
-export function printReport(report: CrawlReport, compact = false, strict = false): void {
+export function printReport(report: CrawlReport, compact = false, strict: boolean | ExitCodeOptions = false): void {
   console.log(compact ? formatCompactReport(report, strict) : formatReport(report));
 }
 
@@ -218,8 +261,18 @@ function truncate(str: string, maxLen: number): string {
   return str.slice(0, maxLen - 3) + "...";
 }
 
-// CI-friendly exit code helper
-export function getExitCode(report: CrawlReport, strict = false): number {
+export interface ExitCodeOptions {
+  /** Treat console errors / JS exceptions as failures. */
+  strict?: boolean;
+  /** Fail when `report.diff` shows new clusters or newly failing pages. */
+  baselineStrict?: boolean;
+}
+
+// CI-friendly exit code helper. The second argument is accepted as either a
+// boolean (legacy `strict`) or an options object so callers can opt into
+// baseline-strict without a larger API change.
+export function getExitCode(report: CrawlReport, strict: boolean | ExitCodeOptions = false): number {
+  const opts: ExitCodeOptions = typeof strict === "boolean" ? { strict } : strict;
   if (report.summary.errorPages > 0 || report.summary.timeoutPages > 0) {
     return 1;
   }
@@ -227,8 +280,13 @@ export function getExitCode(report: CrawlReport, strict = false): number {
   if (report.summary.invariantViolations > 0) {
     return 1;
   }
-  if (strict && (report.summary.consoleErrors > 0 || report.summary.jsExceptions > 0)) {
+  if (opts.strict && (report.summary.consoleErrors > 0 || report.summary.jsExceptions > 0)) {
     return 1;
+  }
+  if (opts.baselineStrict && report.diff) {
+    if (report.diff.newClusters.length > 0 || report.diff.newFailedPages.length > 0) {
+      return 1;
+    }
   }
   return 0;
 }

--- a/src/sitemap.test.ts
+++ b/src/sitemap.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { fetchSitemapUrls, isSitemapIndex, parseSitemap } from "./sitemap.js";
+
+const URLSET = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://x/a</loc></url>
+  <url><loc>  http://x/b  </loc></url>
+  <url><loc>http://x/q?x=1&amp;y=2</loc></url>
+</urlset>`;
+
+const INDEX = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://x/sub1.xml</loc></sitemap>
+  <sitemap><loc>http://x/sub2.xml</loc></sitemap>
+</sitemapindex>`;
+
+describe("parseSitemap", () => {
+  it("extracts URLs from <loc> entries and trims whitespace", () => {
+    expect(parseSitemap(URLSET)).toEqual(["http://x/a", "http://x/b", "http://x/q?x=1&y=2"]);
+  });
+
+  it("returns an empty list when there are no locs", () => {
+    expect(parseSitemap("<urlset></urlset>")).toEqual([]);
+  });
+});
+
+describe("isSitemapIndex", () => {
+  it("is true for a <sitemapindex> document", () => {
+    expect(isSitemapIndex(INDEX)).toBe(true);
+  });
+
+  it("is false for a plain <urlset>", () => {
+    expect(isSitemapIndex(URLSET)).toBe(false);
+  });
+});
+
+describe("fetchSitemapUrls", () => {
+  it("returns the URLs from a plain sitemap", async () => {
+    const urls = await fetchSitemapUrls("http://x/sitemap.xml", {
+      fetcher: async () => URLSET,
+    });
+    expect(urls).toEqual(["http://x/a", "http://x/b", "http://x/q?x=1&y=2"]);
+  });
+
+  it("flattens a sitemap index, fetching each sub-sitemap once", async () => {
+    const fetched: string[] = [];
+    const urls = await fetchSitemapUrls("http://x/index.xml", {
+      fetcher: async (src) => {
+        fetched.push(src);
+        if (src === "http://x/index.xml") return INDEX;
+        if (src === "http://x/sub1.xml") {
+          return `<urlset><url><loc>http://x/p1</loc></url></urlset>`;
+        }
+        return `<urlset><url><loc>http://x/p2</loc></url></urlset>`;
+      },
+    });
+    expect(urls).toEqual(["http://x/p1", "http://x/p2"]);
+    expect(fetched).toEqual(["http://x/index.xml", "http://x/sub1.xml", "http://x/sub2.xml"]);
+  });
+
+  it("deduplicates URLs that appear in multiple sub-sitemaps", async () => {
+    const urls = await fetchSitemapUrls("http://x/index.xml", {
+      fetcher: async (src) => {
+        if (src === "http://x/index.xml") return INDEX;
+        return `<urlset><url><loc>http://x/same</loc></url></urlset>`;
+      },
+    });
+    expect(urls).toEqual(["http://x/same"]);
+  });
+
+  it("throws when expansion exceeds maxSitemaps", async () => {
+    // A sitemap that references itself would cycle without this guard; we
+    // simulate blow-up with a chain of 3 indexes and a limit of 2.
+    const chain: Record<string, string> = {
+      "http://x/i0.xml": `<sitemapindex><sitemap><loc>http://x/i1.xml</loc></sitemap></sitemapindex>`,
+      "http://x/i1.xml": `<sitemapindex><sitemap><loc>http://x/i2.xml</loc></sitemap></sitemapindex>`,
+      "http://x/i2.xml": `<urlset><url><loc>http://x/end</loc></url></urlset>`,
+    };
+    await expect(
+      fetchSitemapUrls("http://x/i0.xml", {
+        fetcher: async (src) => chain[src]!,
+        maxSitemaps: 2,
+      })
+    ).rejects.toThrow(/maxSitemaps=2/);
+  });
+});

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -1,0 +1,118 @@
+/**
+ * Sitemap URL extraction. Seeds the crawler with every URL in a site's
+ * sitemap.xml (or sitemap index), so a chaos run is comprehensive even on
+ * sites that bury pages behind JS-rendered nav where link discovery misses
+ * them.
+ *
+ * Parsing is regex-based on purpose: sitemap.xml is a narrow format, has no
+ * attributes we care about, and we avoid an XML dependency. Entries are
+ * decoded for the five XML predefined entities only — enough for the URLs
+ * that real sitemaps actually produce.
+ */
+
+import { readFile } from "node:fs/promises";
+
+const LOC_RE = /<loc>\s*([^<]+?)\s*<\/loc>/gi;
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+function extractLocs(xml: string): string[] {
+  const out: string[] = [];
+  let match: RegExpExecArray | null;
+  LOC_RE.lastIndex = 0;
+  while ((match = LOC_RE.exec(xml)) !== null) {
+    const raw = match[1]!.trim();
+    if (raw.length === 0) continue;
+    out.push(decodeXmlEntities(raw));
+  }
+  return out;
+}
+
+/**
+ * True when the XML looks like a sitemap index (wraps `<sitemap>` entries
+ * instead of `<url>` entries). Both forms use `<loc>`, so we inspect the
+ * wrapper element to decide whether recursion is needed.
+ */
+export function isSitemapIndex(xml: string): boolean {
+  return /<sitemapindex[\s>]/i.test(xml);
+}
+
+/**
+ * Parse a single sitemap document. Returns the URLs it lists, without
+ * recursing into referenced sub-sitemaps; use `fetchSitemapUrls` for that.
+ */
+export function parseSitemap(xml: string): string[] {
+  return extractLocs(xml);
+}
+
+export interface FetchSitemapOptions {
+  /**
+   * Override how a URL or path is read. Primarily a seam for tests — the
+   * default fetches `http(s)://` URLs via `fetch` and reads everything else
+   * with `fs.readFile`.
+   */
+  fetcher?: (source: string) => Promise<string>;
+  /** Guard against cycles / runaway recursion. Default 20. */
+  maxSitemaps?: number;
+}
+
+async function defaultFetcher(source: string): Promise<string> {
+  if (/^https?:\/\//i.test(source)) {
+    const res = await fetch(source);
+    if (!res.ok) {
+      throw new Error(`sitemap fetch ${source} failed: HTTP ${res.status}`);
+    }
+    return await res.text();
+  }
+  return await readFile(source, "utf-8");
+}
+
+/**
+ * Fetch a sitemap (or sitemap index) and return the flattened list of URLs it
+ * ultimately points at. Indexes are followed breadth-first. Duplicates are
+ * collapsed preserving first-seen order.
+ */
+export async function fetchSitemapUrls(
+  source: string,
+  options: FetchSitemapOptions = {}
+): Promise<string[]> {
+  const fetcher = options.fetcher ?? defaultFetcher;
+  const maxSitemaps = options.maxSitemaps ?? 20;
+  const queue: string[] = [source];
+  const seenSitemaps = new Set<string>();
+  const urls: string[] = [];
+  const seenUrls = new Set<string>();
+  let processed = 0;
+
+  while (queue.length > 0) {
+    if (processed >= maxSitemaps) {
+      throw new Error(
+        `sitemap expansion exceeded maxSitemaps=${maxSitemaps} — suspected cycle or too many sub-sitemaps`
+      );
+    }
+    const current = queue.shift()!;
+    if (seenSitemaps.has(current)) continue;
+    seenSitemaps.add(current);
+    processed++;
+    const xml = await fetcher(current);
+    const locs = extractLocs(xml);
+    if (isSitemapIndex(xml)) {
+      for (const loc of locs) queue.push(loc);
+    } else {
+      for (const loc of locs) {
+        if (seenUrls.has(loc)) continue;
+        seenUrls.add(loc);
+        urls.push(loc);
+      }
+    }
+  }
+
+  return urls;
+}

--- a/src/trace.test.ts
+++ b/src/trace.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRACE_FORMAT_VERSION,
+  actionToTraceEntry,
+  groupTrace,
+  metaOf,
+  parseTrace,
+  serializeTrace,
+  type TraceEntry,
+} from "./trace.js";
+import type { ActionResult } from "./types.js";
+
+const META: TraceEntry = {
+  kind: "meta",
+  v: TRACE_FORMAT_VERSION,
+  seed: 42,
+  baseUrl: "http://x/",
+  startTime: 0,
+};
+
+describe("actionToTraceEntry", () => {
+  it("copies optional fields only when set", () => {
+    const action: ActionResult = {
+      type: "click",
+      target: "Home",
+      selector: "a[href='/']",
+      success: true,
+      timestamp: 123,
+    };
+    expect(actionToTraceEntry(action, "http://x/")).toEqual({
+      kind: "action",
+      url: "http://x/",
+      type: "click",
+      target: "Home",
+      selector: "a[href='/']",
+      success: true,
+    });
+  });
+
+  it("drops undefined optional fields", () => {
+    const action: ActionResult = {
+      type: "scroll",
+      target: "scrollY: 200",
+      success: true,
+      timestamp: 0,
+    };
+    const entry = actionToTraceEntry(action, "http://x/");
+    expect(entry).not.toHaveProperty("selector");
+    expect(entry).not.toHaveProperty("error");
+    expect(entry).not.toHaveProperty("blockedExternal");
+  });
+});
+
+describe("serializeTrace / parseTrace", () => {
+  it("round-trips a simple trace", () => {
+    const entries: TraceEntry[] = [
+      META,
+      { kind: "visit", url: "http://x/" },
+      {
+        kind: "action",
+        url: "http://x/",
+        type: "click",
+        target: "Home",
+        selector: "a",
+        success: true,
+      },
+    ];
+    const parsed = parseTrace(serializeTrace(entries));
+    expect(parsed).toEqual(entries);
+  });
+
+  it("rejects a serialize call that lacks a leading meta", () => {
+    expect(() => serializeTrace([{ kind: "visit", url: "http://x/" }])).toThrow(/meta/);
+  });
+
+  it("ignores blank lines but rejects malformed JSON", () => {
+    const ok = `${JSON.stringify(META)}\n\n${JSON.stringify({ kind: "visit", url: "/" })}\n`;
+    expect(parseTrace(ok)).toHaveLength(2);
+
+    const bad = `${JSON.stringify(META)}\nnot-json\n`;
+    expect(() => parseTrace(bad)).toThrow(/line 2/);
+  });
+
+  it("rejects entries with unknown kinds", () => {
+    const raw = `${JSON.stringify(META)}\n${JSON.stringify({ kind: "oops" })}\n`;
+    expect(() => parseTrace(raw)).toThrow(/unknown kind/);
+  });
+
+  it("rejects traces missing the leading meta", () => {
+    expect(() => parseTrace(`${JSON.stringify({ kind: "visit", url: "/" })}\n`)).toThrow(/meta/);
+  });
+
+  it("rejects traces with an unsupported format version", () => {
+    const wrong = { ...META, v: TRACE_FORMAT_VERSION + 99 };
+    expect(() => parseTrace(`${JSON.stringify(wrong)}\n`)).toThrow(/unsupported trace format/);
+  });
+});
+
+describe("groupTrace", () => {
+  it("splits actions by their preceding visit", () => {
+    const groups = groupTrace([
+      META,
+      { kind: "visit", url: "http://x/a" },
+      { kind: "action", url: "http://x/a", type: "click", success: true },
+      { kind: "action", url: "http://x/a", type: "scroll", success: true },
+      { kind: "visit", url: "http://x/b" },
+      { kind: "action", url: "http://x/b", type: "input", success: true },
+    ]);
+    expect(groups).toEqual([
+      {
+        url: "http://x/a",
+        actions: [
+          { kind: "action", url: "http://x/a", type: "click", success: true },
+          { kind: "action", url: "http://x/a", type: "scroll", success: true },
+        ],
+      },
+      {
+        url: "http://x/b",
+        actions: [{ kind: "action", url: "http://x/b", type: "input", success: true }],
+      },
+    ]);
+  });
+
+  it("ignores actions that appear before any visit", () => {
+    const groups = groupTrace([
+      META,
+      { kind: "action", url: "http://x/?", type: "click", success: true },
+      { kind: "visit", url: "http://x/a" },
+    ]);
+    expect(groups).toEqual([{ url: "http://x/a", actions: [] }]);
+  });
+});
+
+describe("metaOf", () => {
+  it("returns the first entry when it is a meta", () => {
+    expect(metaOf([META])).toBe(META);
+  });
+
+  it("throws when the trace is empty or starts with something else", () => {
+    expect(() => metaOf([])).toThrow(/meta/);
+    expect(() => metaOf([{ kind: "visit", url: "/" } as TraceEntry])).toThrow(/meta/);
+  });
+});

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,0 +1,150 @@
+/**
+ * Trace file format. A trace is a JSONL log of everything the crawler did on
+ * a run — enough to reconstruct the same sequence of navigations + actions
+ * without re-rolling the RNG. Used as input to replay mode and to the
+ * `minimize` subcommand.
+ *
+ * Line 1 is always a `meta` entry; every subsequent line is either a `visit`
+ * (the crawler loaded that URL) or an `action` (what it did on the page).
+ * Actions are grouped implicitly by the most recent preceding `visit`.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import type { ActionResult } from "./types.js";
+
+/** Incremented when the on-disk layout changes in a way replay cares about. */
+export const TRACE_FORMAT_VERSION = 1;
+
+export interface TraceMeta {
+  kind: "meta";
+  v: number;
+  seed: number;
+  baseUrl: string;
+  /** Epoch ms of the run. Informational only — replay does not use it. */
+  startTime: number;
+}
+
+export interface TraceVisit {
+  kind: "visit";
+  url: string;
+}
+
+/**
+ * A performed action. Mirrors ActionResult but always carries the URL it
+ * ran on, which is what replay needs to correlate actions with pages.
+ */
+export interface TraceAction {
+  kind: "action";
+  url: string;
+  type: ActionResult["type"];
+  target?: string;
+  selector?: string;
+  success: boolean;
+  error?: string;
+  blockedExternal?: boolean;
+}
+
+export type TraceEntry = TraceMeta | TraceVisit | TraceAction;
+
+/**
+ * Convert a recorded ActionResult + its URL into a TraceAction. Kept pure so
+ * the crawler can serialize without importing node:fs in the hot path.
+ */
+export function actionToTraceEntry(action: ActionResult, url: string): TraceAction {
+  const out: TraceAction = {
+    kind: "action",
+    url,
+    type: action.type,
+    success: action.success,
+  };
+  if (action.target !== undefined) out.target = action.target;
+  if (action.selector !== undefined) out.selector = action.selector;
+  if (action.error !== undefined) out.error = action.error;
+  if (action.blockedExternal !== undefined) out.blockedExternal = action.blockedExternal;
+  return out;
+}
+
+/** Render a trace as JSONL. Meta must be present and must come first. */
+export function serializeTrace(entries: readonly TraceEntry[]): string {
+  if (entries.length === 0 || entries[0]!.kind !== "meta") {
+    throw new Error("serializeTrace: first entry must be kind=meta");
+  }
+  return entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+/**
+ * Parse JSONL back into entries. Blank lines are ignored; any other malformed
+ * line throws — silently skipping would make minimize decisions uninterpretable.
+ */
+export function parseTrace(raw: string): TraceEntry[] {
+  const out: TraceEntry[] = [];
+  const lines = raw.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trim().length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (err) {
+      throw new Error(`parseTrace: line ${i + 1} is not valid JSON: ${(err as Error).message}`);
+    }
+    if (!parsed || typeof parsed !== "object" || !("kind" in parsed)) {
+      throw new Error(`parseTrace: line ${i + 1} is missing "kind"`);
+    }
+    const kind = (parsed as { kind: unknown }).kind;
+    if (kind !== "meta" && kind !== "visit" && kind !== "action") {
+      throw new Error(`parseTrace: line ${i + 1} has unknown kind ${JSON.stringify(kind)}`);
+    }
+    out.push(parsed as TraceEntry);
+  }
+  if (out.length === 0 || out[0]!.kind !== "meta") {
+    throw new Error("parseTrace: trace is missing a leading meta entry");
+  }
+  const meta = out[0] as TraceMeta;
+  if (meta.v !== TRACE_FORMAT_VERSION) {
+    throw new Error(
+      `parseTrace: unsupported trace format v=${meta.v} (this build understands v=${TRACE_FORMAT_VERSION})`
+    );
+  }
+  return out;
+}
+
+export function writeTrace(path: string, entries: readonly TraceEntry[]): void {
+  writeFileSync(path, serializeTrace(entries));
+}
+
+export function readTrace(path: string): TraceEntry[] {
+  return parseTrace(readFileSync(path, "utf-8"));
+}
+
+/**
+ * Group a trace into (visit, actions[]) pairs in encounter order. Useful for
+ * replay: each group is one page visit plus the actions performed on it.
+ * Actions that appear before any visit (malformed trace) are discarded — the
+ * parser already rejects those cases, but double-check here for safety.
+ */
+export interface TraceGroup {
+  url: string;
+  actions: TraceAction[];
+}
+
+export function groupTrace(entries: readonly TraceEntry[]): TraceGroup[] {
+  const groups: TraceGroup[] = [];
+  let current: TraceGroup | null = null;
+  for (const entry of entries) {
+    if (entry.kind === "meta") continue;
+    if (entry.kind === "visit") {
+      current = { url: entry.url, actions: [] };
+      groups.push(current);
+    } else if (entry.kind === "action" && current) {
+      current.actions.push(entry);
+    }
+  }
+  return groups;
+}
+
+export function metaOf(entries: readonly TraceEntry[]): TraceMeta {
+  const first = entries[0];
+  if (!first || first.kind !== "meta") throw new Error("trace is missing a meta entry");
+  return first;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,14 @@ export interface CrawlerOptions {
   faultInjection?: FaultRule[];
   /** HAR record/replay configuration for deterministic network state. */
   har?: HarConfig;
+  /**
+   * Path to a Playwright storage state file (cookies + localStorage) to
+   * preload into the browser context. Lets the crawler start a run as an
+   * already-authenticated user — generate the file with
+   * `await context.storageState({ path })` in a login script, then point
+   * this at it. The file is not modified by the crawl.
+   */
+  storageState?: string;
 }
 
 /** `record` captures responses to a HAR file; `replay` serves them back. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,12 @@ export interface CrawlerOptions {
   /** HAR record/replay configuration for deterministic network state. */
   har?: HarConfig;
   /**
+   * Per-metric performance budget (in ms). Keys match PerformanceMetrics;
+   * omitted keys are not enforced. A breach is recorded as an invariant
+   * violation, so it always fails the run.
+   */
+  performanceBudget?: PerformanceBudget;
+  /**
    * Path to a Playwright storage state file (cookies + localStorage) to
    * preload into the browser context. Lets the crawler start a run as an
    * already-authenticated user — generate the file with
@@ -177,6 +183,32 @@ export interface PerformanceMetrics {
   /** Full page load */
   load?: number;
 }
+
+/**
+ * Per-metric budget (in ms). A page whose measured metric exceeds the budget
+ * is recorded as an invariant violation named `perf-budget.<metric>`, which
+ * forces a non-zero exit and shows up in the diff section.
+ */
+export interface PerformanceBudget {
+  ttfb?: number;
+  fcp?: number;
+  lcp?: number;
+  tbt?: number;
+  domContentLoaded?: number;
+  load?: number;
+}
+
+/** Keys of PerformanceMetrics that a budget can target. */
+export const PERF_BUDGET_KEYS = [
+  "ttfb",
+  "fcp",
+  "lcp",
+  "tbt",
+  "domContentLoaded",
+  "load",
+] as const satisfies ReadonlyArray<keyof PerformanceMetrics>;
+
+export type PerfBudgetKey = (typeof PERF_BUDGET_KEYS)[number];
 
 export interface PageResult {
   url: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,14 @@ export interface CrawlerOptions {
    */
   traceReplay?: string;
   /**
+   * URL or filesystem path to a sitemap.xml (or sitemap index). Every URL
+   * listed — including URLs resolved via nested indexes — is prepended to
+   * the crawl queue before discovered links, filtered to the same origin
+   * as `baseUrl`. Useful for sites whose nav is JS-rendered and so missed
+   * by the crawler's link extraction.
+   */
+  seedFromSitemap?: string;
+  /**
    * Name of a Playwright device descriptor to emulate (e.g. "iPhone 14",
    * "Pixel 7", "iPad Pro 11"). Applied to the browser context — sets
    * viewport, userAgent, deviceScaleFactor, isMobile, and hasTouch.

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,18 @@ export interface CrawlerOptions {
    */
   performanceBudget?: PerformanceBudget;
   /**
+   * Path to write a JSONL trace of every navigation + action performed. Used
+   * as input to replay mode and to the `minimize` subcommand — the exact
+   * crawl can be replayed without rerolling the RNG.
+   */
+  traceOut?: string;
+  /**
+   * Path to a trace file produced by `traceOut`. When set, the crawler
+   * ignores its weighted-random driver and plays back the recorded visits
+   * and actions verbatim.
+   */
+  traceReplay?: string;
+  /**
    * Path to a Playwright storage state file (cookies + localStorage) to
    * preload into the browser context. Lets the crawler start a run as an
    * already-authenticated user — generate the file with

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,17 @@ export interface CrawlerOptions {
    */
   traceReplay?: string;
   /**
+   * Name of a Playwright device descriptor to emulate (e.g. "iPhone 14",
+   * "Pixel 7", "iPad Pro 11"). Applied to the browser context — sets
+   * viewport, userAgent, deviceScaleFactor, isMobile, and hasTouch.
+   */
+  device?: string;
+  /**
+   * Network throttling preset applied via CDP on every page. Supported:
+   * "slow-3g" / "fast-3g" / "offline". Omit to use the default network.
+   */
+  network?: NetworkProfile;
+  /**
    * Path to a Playwright storage state file (cookies + localStorage) to
    * preload into the browser context. Lets the crawler start a run as an
    * already-authenticated user — generate the file with
@@ -209,6 +220,11 @@ export interface PerformanceBudget {
   domContentLoaded?: number;
   load?: number;
 }
+
+/** Supported network throttling presets applied via CDP. */
+export type NetworkProfile = "slow-3g" | "fast-3g" | "offline";
+
+export const NETWORK_PROFILES = ["slow-3g", "fast-3g", "offline"] as const satisfies ReadonlyArray<NetworkProfile>;
 
 /** Keys of PerformanceMetrics that a budget can target. */
 export const PERF_BUDGET_KEYS = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,54 @@ export interface ActionResult {
   timestamp: number;
 }
 
+/**
+ * One entry in a cluster-level diff between two runs. `before` is the count in
+ * the baseline report; `after` is the count in the current report. New clusters
+ * have `before: 0`; resolved clusters have `after: 0`.
+ */
+export interface ClusterDiffEntry {
+  key: string;
+  type: PageError["type"];
+  fingerprint: string;
+  before: number;
+  after: number;
+}
+
+/**
+ * One entry in a page-level diff. A page is considered "failed" when it has
+ * any errors, or its navigation ended in `error` / `timeout`. Pages appear in
+ * the diff only when their failed/clean state differs between runs.
+ */
+export interface PageDiffEntry {
+  url: string;
+  /** null when the page did not exist in the baseline. */
+  before: { errors: number; status: PageResult["status"] } | null;
+  /** null when the page was not visited in the current run. */
+  after: { errors: number; status: PageResult["status"] } | null;
+}
+
+/**
+ * Diff between a baseline report and the current report. Produced by
+ * `diffReports(prev, curr)`, attached to the current report as `report.diff`
+ * when a baseline was supplied.
+ */
+export interface ReportDiff {
+  /** Path the baseline was loaded from, if known. */
+  baselinePath?: string;
+  /** Seed of the baseline run — useful for asserting like-vs-like. */
+  baselineSeed: number;
+  /** Clusters present in the current run but not the baseline. */
+  newClusters: ClusterDiffEntry[];
+  /** Clusters present in the baseline but not the current run. */
+  resolvedClusters: ClusterDiffEntry[];
+  /** Clusters present in both runs (with potentially different counts). */
+  unchangedClusters: ClusterDiffEntry[];
+  /** Pages that are failing in the current run but were clean in the baseline (or not visited). */
+  newFailedPages: PageDiffEntry[];
+  /** Pages that were failing in the baseline but are clean / absent in the current run. */
+  resolvedFailedPages: PageDiffEntry[];
+}
+
 export interface CrawlReport {
   baseUrl: string;
   /** Seed used for random action selection (for reproducibility). */
@@ -263,6 +311,8 @@ export interface CrawlReport {
   errorClusters: ErrorCluster[];
   /** Echo of the HAR config used for this run, if any. */
   har?: HarConfig;
+  /** Diff against a baseline report, present only when a baseline was supplied. */
+  diff?: ReportDiff;
 }
 
 export interface CrawlSummary {

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -164,4 +164,24 @@ describe("validateOptions", () => {
   it("rejects an empty traceReplay path", () => {
     expect(() => validateOptions(base({ traceReplay: "" }))).toThrow(/traceReplay/);
   });
+
+  it("accepts a known Playwright device name", () => {
+    expect(() => validateOptions(base({ device: "iPhone 14" }))).not.toThrow();
+  });
+
+  it("rejects an unknown Playwright device name", () => {
+    expect(() => validateOptions(base({ device: "NotAPhone 42" }))).toThrow(/device/);
+  });
+
+  it("rejects an empty device name", () => {
+    expect(() => validateOptions(base({ device: "" }))).toThrow(/device/);
+  });
+
+  it("accepts a known network profile", () => {
+    expect(() => validateOptions(base({ network: "slow-3g" }))).not.toThrow();
+  });
+
+  it("rejects an unknown network profile", () => {
+    expect(() => validateOptions(base({ network: "turbo" as any }))).toThrow(/network/);
+  });
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -129,4 +129,31 @@ describe("validateOptions", () => {
       /storageState/
     );
   });
+
+  it("accepts a well-formed performanceBudget", () => {
+    expect(() =>
+      validateOptions(base({ performanceBudget: { ttfb: 200, fcp: 1800, lcp: 2500 } }))
+    ).not.toThrow();
+  });
+
+  it("rejects unknown keys in performanceBudget", () => {
+    expect(() =>
+      validateOptions(base({ performanceBudget: { wat: 100 } as any }))
+    ).toThrow(/performanceBudget\.wat/);
+  });
+
+  it("rejects non-positive performanceBudget values", () => {
+    expect(() =>
+      validateOptions(base({ performanceBudget: { ttfb: 0 } }))
+    ).toThrow(/performanceBudget\.ttfb/);
+    expect(() =>
+      validateOptions(base({ performanceBudget: { ttfb: -1 } }))
+    ).toThrow(/performanceBudget\.ttfb/);
+  });
+
+  it("rejects non-object performanceBudget", () => {
+    expect(() =>
+      validateOptions(base({ performanceBudget: 500 as any }))
+    ).toThrow(/performanceBudget/);
+  });
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -156,4 +156,12 @@ describe("validateOptions", () => {
       validateOptions(base({ performanceBudget: 500 as any }))
     ).toThrow(/performanceBudget/);
   });
+
+  it("rejects an empty traceOut path", () => {
+    expect(() => validateOptions(base({ traceOut: "" }))).toThrow(/traceOut/);
+  });
+
+  it("rejects an empty traceReplay path", () => {
+    expect(() => validateOptions(base({ traceReplay: "" }))).toThrow(/traceReplay/);
+  });
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -115,4 +115,18 @@ describe("validateOptions", () => {
       )
     ).not.toThrow();
   });
+
+  it("accepts a storageState path string", () => {
+    expect(() => validateOptions(base({ storageState: "./auth.json" }))).not.toThrow();
+  });
+
+  it("rejects an empty storageState", () => {
+    expect(() => validateOptions(base({ storageState: "" }))).toThrow(/storageState/);
+  });
+
+  it("rejects a non-string storageState", () => {
+    expect(() => validateOptions(base({ storageState: 42 as unknown as string }))).toThrow(
+      /storageState/
+    );
+  });
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -184,4 +184,12 @@ describe("validateOptions", () => {
   it("rejects an unknown network profile", () => {
     expect(() => validateOptions(base({ network: "turbo" as any }))).toThrow(/network/);
   });
+
+  it("accepts a seedFromSitemap path", () => {
+    expect(() => validateOptions(base({ seedFromSitemap: "http://x/sitemap.xml" }))).not.toThrow();
+  });
+
+  it("rejects an empty seedFromSitemap", () => {
+    expect(() => validateOptions(base({ seedFromSitemap: "" }))).toThrow(/seedFromSitemap/);
+  });
 });


### PR DESCRIPTION
## Summary

Seven new features, each its own commit. Each is additive — existing behaviour is unchanged unless you opt in.

- **Baseline diff** (`24774e1`) — `--baseline prev-report.json` surfaces new clusters and newly failing pages vs a previous report; `--baseline-strict` fails the run on regression.
- **Authenticated crawls** (`b5e9b31`) — `--storage-state auth.json` forwards a Playwright storageState file into `newContext()`, unblocking dashboards behind a login.
- **Performance budget** (`59bb0a3`) — `--budget ttfb=200,fcp=1800,lcp=2500` emits `perf-budget.<metric>` invariant violations. Pure checker, unit-tested without a browser.
- **axe-core a11y preset** (`88415cb`) — `invariants.axe()` / `--axe` / `--axe-tags`. axe-core is an optional peer dep; missing-install hint is raised at check time.
- **Trace record** (`94cd800`) — `--trace-out trace.jsonl` captures every visit + action as versioned JSONL.
- **Trace replay** (`fdc9e8a`) — `--trace-replay trace.jsonl` bypasses the RNG / discovery and plays back exactly the recorded sequence, locating elements by their recorded selector.
- **Minimize subcommand** (`8b1fcd5`) — `chaosbringer minimize --url ... --trace in.jsonl --match <regex>` runs ddmin (delta debugging) over the action list to produce the shortest reproducer.

All pure helpers (diff, budget, axe payload/formatter, trace parse/serialize/group, ddmin, traceWithActions, reportMatches) are unit-tested.

## Test plan

- [x] `pnpm exec vitest run src/` — 163/163 pass (was 113 before this branch).
- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] Manual end-to-end:
  - [ ] `chaosbringer --url <app> --trace-out t.jsonl` writes a trace.
  - [ ] `chaosbringer --url <app> --trace-replay t.jsonl` reproduces the same navigation + action sequence.
  - [ ] `chaosbringer minimize --url <app> --trace t.jsonl --match "<regex>"` shrinks the trace.
  - [ ] `chaosbringer --url <app> --baseline prev.json --baseline-strict` — clean run passes; injecting a new console.error fails.
  - [ ] `chaosbringer --url <app> --storage-state auth.json` loads as the authenticated user.
  - [ ] `chaosbringer --url <app> --budget ttfb=50` on a slow page produces a `perf-budget.ttfb` violation.
  - [ ] `chaosbringer --url <app> --axe` reports a11y violations as `[a11y-axe] ...`.
- [ ] Run existing `fixtures/runner/e2e.test.ts` locally with Playwright chromium installed (unavailable in this sandbox).

## Notes

- `getExitCode(report, strict)` now also accepts an options object `{ strict, baselineStrict }`; the bare-boolean form still works unchanged.
- `axe-core` is added as an optional peer + dev dependency; consumers who don't opt into `--axe` / `invariants.axe()` never pay for it.
- `traceOut` and `traceReplay` are echoed in `reproCommand`, so failing replays reproduce end-to-end.
- The `minimize` subcommand is dispatched before `parseArgs` runs, so its flags can differ from the main CLI's.
