### PR TITLE
Add visual regression invariant and CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Playwright-based chaos testing for web apps. Crawls the pages you point it at, p
 - **Declarative invariants** evaluated on every page. A violation fails the run regardless of `--strict`.
 - **Accessibility checks** via an `invariants.axe()` preset — axe-core is an optional peer dep.
 - **Performance budgets** per TTFB / FCP / LCP / TBT — budget breaches fail the run.
+- **Visual regression** via pixelmatch — compare per-page screenshots against baselines, fail on diff.
 - **Error detection**: console errors, failed requests, JS exceptions, unhandled rejections, invariant violations.
 - **Recovery from 404 / 5xx** — records what actions preceded the failure.
 - **HAR record / replay** + **trace record / replay / minimize** for fully deterministic runs and delta-debugged repros.
@@ -303,6 +304,46 @@ await chaos({
 
 A failing scan is rendered on one line: `[a11y-axe] 3 a11y violations: color-contrast(×5, serious), image-alt(×2, critical), region(×1)`. Because violations cluster by their fingerprint, a11y regressions show up in the baseline diff just like any other invariant.
 
+## Visual regression
+
+Compare each page's screenshot against a baseline PNG on disk. Differences beyond the configured budget are recorded as invariant violations (`visual-regression`), which fail the run.
+
+```bash
+# First run: baselines don't exist yet — chaosbringer records them and passes.
+chaosbringer --url http://localhost:3000 --visual-baseline ./__snapshots__
+
+# Subsequent runs: compare against the recorded baselines.
+chaosbringer --url http://localhost:3000 --visual-baseline ./__snapshots__ \
+  --visual-max-diff-pixels 100 \
+  --visual-diff-dir ./__diffs__
+
+# After an intentional UI change, overwrite the baselines.
+chaosbringer --url http://localhost:3000 --visual-baseline ./__snapshots__ --visual-update
+```
+
+```ts
+import { chaos, invariants } from "chaosbringer";
+
+await chaos({
+  baseUrl: "http://localhost:3000",
+  invariants: [
+    invariants.visualRegression({
+      baselineDir: "./__snapshots__",
+      threshold: 0.1,          // pixelmatch color distance (0..1)
+      maxDiffPixels: 100,      // absolute tolerance
+      maxDiffRatio: 0.001,     // or proportional tolerance
+      diffDir: "./__diffs__",
+    }),
+  ],
+});
+```
+
+- Baseline filenames are derived from each page's URL (path + query, sanitized) so different routes don't collide.
+- `pixelmatch` and `pngjs` are optional peer deps — install them explicitly (`pnpm add pixelmatch pngjs`). The invariant fails with a clear install hint when they're missing.
+- Dimension mismatches between baseline and current are treated as full-diff failures — resize or re-record the baseline intentionally rather than auto-accepting.
+- Takes `fullPage: true` screenshots by default. Flip to viewport-only via `fullPage: false` in the programmatic API if your layout is sensitive to scroll position.
+- Pair with `--device iPhone 14` to record device-specific baselines; the baseline dir is per-crawl so split baselines across devices by using different dirs.
+
 ## Performance budget
 
 Declare a per-metric budget (in ms). Any page whose measured metric exceeds its limit is recorded as an invariant violation (`perf-budget.<metric>`), which fails the run just like any other invariant.
@@ -535,6 +576,12 @@ const merged = mergeReports([r0, r1, r2, r3]);
 | `--budget <k=ms,...>` | Per-metric performance budget (repeatable) | — |
 | `--axe` | Enable axe-core a11y scan on every page (requires `axe-core` installed) | false |
 | `--axe-tags <list>` | Comma-separated axe tags | `wcag2a,wcag2aa,wcag21a,wcag21aa` |
+| `--visual-baseline <dir>` | Enable visual regression against PNG baselines in `<dir>` (requires `pixelmatch` + `pngjs`) | — |
+| `--visual-threshold <n>` | pixelmatch color distance (0..1) | 0.1 |
+| `--visual-max-diff-pixels <n>` | Absolute pixel budget before failing | 0 |
+| `--visual-max-diff-ratio <n>` | Ratio pixel budget (0..1) | — |
+| `--visual-diff-dir <dir>` | Write diff PNGs here on failure | — |
+| `--visual-update` | Overwrite baselines with current screenshots (for intentional UI updates) | false |
 | `--trace-out <path>` | Write a JSONL trace of visits + actions | — |
 | `--trace-replay <path>` | Replay a previously recorded trace | — |
 | `--device <name>` | Emulate a Playwright device (e.g. `iPhone 14`) | — |

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   "peerDependencies": {
     "@playwright/test": "^1.40.0",
     "axe-core": "^4.0.0",
-    "playwright": "^1.40.0"
+    "pixelmatch": "^5.3.0 || ^6.0.0 || ^7.0.0",
+    "playwright": "^1.40.0",
+    "pngjs": "^7.0.0"
   },
   "peerDependenciesMeta": {
     "@playwright/test": {
@@ -52,13 +54,23 @@
     },
     "axe-core": {
       "optional": true
+    },
+    "pixelmatch": {
+      "optional": true
+    },
+    "pngjs": {
+      "optional": true
     }
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.0.0",
+    "@types/pixelmatch": "^5.2.6",
+    "@types/pngjs": "^6.0.5",
     "axe-core": "^4.11.3",
+    "pixelmatch": "^7.1.0",
     "playwright": "^1.52.0",
+    "pngjs": "^7.0.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vitest": "^3.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,24 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      '@types/pixelmatch':
+        specifier: ^5.2.6
+        version: 5.2.6
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       axe-core:
         specifier: ^4.11.3
         version: 4.11.3
+      pixelmatch:
+        specifier: ^7.1.0
+        version: 7.1.0
       playwright:
         specifier: ^1.52.0
         version: 1.59.1
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
@@ -346,6 +358,12 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/pixelmatch@5.2.6':
+    resolution: {integrity: sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -476,6 +494,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -485,6 +507,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -801,6 +827,14 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pixelmatch@5.2.6':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -936,6 +970,10 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -943,6 +981,8 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.10:
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -257,6 +257,32 @@ if (values.shard) {
   shardCount = parsed.shardCount;
 }
 
+function parseNumberFlag(
+  flag: string,
+  raw: string | undefined,
+  opts: { min?: number; max?: number; integer?: boolean }
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    console.error(`Error: ${flag} must be a finite number (got ${JSON.stringify(raw)})`);
+    process.exit(1);
+  }
+  if (opts.integer && !Number.isInteger(n)) {
+    console.error(`Error: ${flag} must be an integer (got ${n})`);
+    process.exit(1);
+  }
+  if (opts.min !== undefined && n < opts.min) {
+    console.error(`Error: ${flag} must be >= ${opts.min} (got ${n})`);
+    process.exit(1);
+  }
+  if (opts.max !== undefined && n > opts.max) {
+    console.error(`Error: ${flag} must be <= ${opts.max} (got ${n})`);
+    process.exit(1);
+  }
+  return n;
+}
+
 function buildInvariants(): Invariant[] | undefined {
   const list: Invariant[] = [];
   if (values.axe) {
@@ -275,15 +301,20 @@ function buildInvariants(): Invariant[] | undefined {
     list.push(
       visualRegression({
         baselineDir: values["visual-baseline"],
-        threshold: values["visual-threshold"] !== undefined
-          ? Number(values["visual-threshold"])
-          : undefined,
-        maxDiffPixels: values["visual-max-diff-pixels"] !== undefined
-          ? Number(values["visual-max-diff-pixels"])
-          : undefined,
-        maxDiffRatio: values["visual-max-diff-ratio"] !== undefined
-          ? Number(values["visual-max-diff-ratio"])
-          : undefined,
+        threshold: parseNumberFlag("--visual-threshold", values["visual-threshold"], {
+          min: 0,
+          max: 1,
+        }),
+        maxDiffPixels: parseNumberFlag(
+          "--visual-max-diff-pixels",
+          values["visual-max-diff-pixels"],
+          { min: 0, integer: true }
+        ),
+        maxDiffRatio: parseNumberFlag(
+          "--visual-max-diff-ratio",
+          values["visual-max-diff-ratio"],
+          { min: 0, max: 1 }
+        ),
         diffDir: values["visual-diff-dir"],
         updateBaseline: values["visual-update"],
       })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,8 @@ import { printGithubAnnotations } from "./github.js";
 import { axe } from "./invariants.js";
 import { printReport, saveReport, getExitCode } from "./reporter.js";
 import { parseShardArg } from "./shard.js";
-import type { CrawlerOptions } from "./types.js";
+import type { CrawlerOptions, Invariant } from "./types.js";
+import { visualRegression } from "./visual.js";
 
 // Subcommand dispatch. Intercept before parseArgs runs so subcommand-specific
 // flags (e.g. --match for `minimize`) don't trip the main options map.
@@ -91,6 +92,12 @@ const { values, positionals } = parseArgs({
     budget: { type: "string", multiple: true },
     axe: { type: "boolean", default: false },
     "axe-tags": { type: "string" },
+    "visual-baseline": { type: "string" },
+    "visual-threshold": { type: "string" },
+    "visual-max-diff-pixels": { type: "string" },
+    "visual-max-diff-ratio": { type: "string" },
+    "visual-diff-dir": { type: "string" },
+    "visual-update": { type: "boolean", default: false },
     "trace-out": { type: "string" },
     "trace-replay": { type: "string" },
     device: { type: "string" },
@@ -140,6 +147,12 @@ OPTIONS:
   --budget <k=ms,...>   Per-metric performance budget, e.g. ttfb=200,fcp=1800,lcp=2500 (repeatable)
   --axe                 Enable axe-core accessibility scan on every page (requires axe-core installed)
   --axe-tags <list>     Comma-separated axe tags (default: wcag2a,wcag2aa,wcag21a,wcag21aa)
+  --visual-baseline <dir>  Enable visual regression against baseline PNGs in <dir> (requires pixelmatch + pngjs)
+  --visual-threshold <n>   pixelmatch color threshold 0..1 (default 0.1)
+  --visual-max-diff-pixels <n>  Absolute pixel budget; fail when exceeded (default 0)
+  --visual-max-diff-ratio <n>   Ratio pixel budget (0..1); evaluated alongside max-diff-pixels
+  --visual-diff-dir <dir>  Write diff PNGs here on failure
+  --visual-update       Overwrite baselines with current screenshots (for intentional UI updates)
   --trace-out <path>    Write a JSONL trace of visits + actions for replay / minimize
   --trace-replay <path> Replay a previously recorded trace instead of random actions
   --device <name>       Emulate a Playwright device descriptor (e.g. "iPhone 14", "Pixel 7")
@@ -244,6 +257,41 @@ if (values.shard) {
   shardCount = parsed.shardCount;
 }
 
+function buildInvariants(): Invariant[] | undefined {
+  const list: Invariant[] = [];
+  if (values.axe) {
+    list.push(
+      axe({
+        tags: values["axe-tags"]
+          ? values["axe-tags"]
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined,
+      })
+    );
+  }
+  if (values["visual-baseline"]) {
+    list.push(
+      visualRegression({
+        baselineDir: values["visual-baseline"],
+        threshold: values["visual-threshold"] !== undefined
+          ? Number(values["visual-threshold"])
+          : undefined,
+        maxDiffPixels: values["visual-max-diff-pixels"] !== undefined
+          ? Number(values["visual-max-diff-pixels"])
+          : undefined,
+        maxDiffRatio: values["visual-max-diff-ratio"] !== undefined
+          ? Number(values["visual-max-diff-ratio"])
+          : undefined,
+        diffDir: values["visual-diff-dir"],
+        updateBaseline: values["visual-update"],
+      })
+    );
+  }
+  return list.length > 0 ? list : undefined;
+}
+
 const options: CrawlerOptions = {
   baseUrl,
   maxPages: values["max-pages"] ? parseInt(values["max-pages"], 10) : undefined,
@@ -269,18 +317,7 @@ const options: CrawlerOptions = {
   seedFromSitemap: values["seed-from-sitemap"],
   shardIndex,
   shardCount,
-  invariants: values.axe
-    ? [
-        axe({
-          tags: values["axe-tags"]
-            ? values["axe-tags"]
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean)
-            : undefined,
-        }),
-      ]
-    : undefined,
+  invariants: buildInvariants(),
 };
 
 const outputPath = values.output || "chaos-report.json";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,14 @@ export { diffReports, loadBaseline, hasRegressions } from "./diff.js";
 export { checkPerformanceBudget } from "./budget.js";
 export { invariants, axe, buildAxeRunPayload, formatAxeViolations, type AxeInvariantOptions } from "./invariants.js";
 export {
+  compareScreenshotBuffers,
+  formatVisualDiff,
+  screenshotFilename,
+  visualRegression,
+  type CompareResult,
+  type VisualRegressionOptions,
+} from "./visual.js";
+export {
   TRACE_FORMAT_VERSION,
   actionToTraceEntry,
   groupTrace,

--- a/src/invariants.ts
+++ b/src/invariants.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Invariant } from "./types.js";
+import { visualRegression } from "./visual.js";
 
 export interface AxeInvariantOptions {
   /** Display name for reporting. Default: `a11y-axe`. */
@@ -141,4 +142,4 @@ export function axe(options: AxeInvariantOptions = {}): Invariant {
 }
 
 /** Exported as a namespace so consumers can write `invariants.axe(...)`. */
-export const invariants = { axe };
+export const invariants = { axe, visualRegression };

--- a/src/visual.test.ts
+++ b/src/visual.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { PNG } from "pngjs";
+import {
+  compareScreenshotBuffers,
+  formatVisualDiff,
+  screenshotFilename,
+  type CompareResult,
+} from "./visual.js";
+
+/** Build a solid-color PNG buffer of the given size. */
+function solidPng(width: number, height: number, rgba: [number, number, number, number]): Buffer {
+  const png = new PNG({ width, height });
+  for (let i = 0; i < width * height * 4; i += 4) {
+    png.data[i] = rgba[0]!;
+    png.data[i + 1] = rgba[1]!;
+    png.data[i + 2] = rgba[2]!;
+    png.data[i + 3] = rgba[3]!;
+  }
+  return PNG.sync.write(png);
+}
+
+describe("screenshotFilename", () => {
+  it("maps / to index.png", () => {
+    expect(screenshotFilename("http://localhost:3000/")).toBe("index.png");
+  });
+
+  it("maps a nested path", () => {
+    expect(screenshotFilename("http://x/docs/intro/")).toBe("docs_intro.png");
+  });
+
+  it("incorporates the query so different searches don't collide", () => {
+    const a = screenshotFilename("http://x/search?q=foo");
+    const b = screenshotFilename("http://x/search?q=bar");
+    expect(a).not.toBe(b);
+    expect(a.endsWith(".png")).toBe(true);
+  });
+
+  it("sanitizes unsafe characters", () => {
+    const name = screenshotFilename("http://x/a b/c:d?e=1");
+    expect(name).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+
+  it("falls back to index when the URL is unparseable", () => {
+    expect(screenshotFilename("not-a-url")).toBe("not-a-url.png");
+  });
+});
+
+describe("compareScreenshotBuffers", () => {
+  it("reports zero diff for identical images", async () => {
+    const a = solidPng(10, 10, [200, 50, 50, 255]);
+    const b = solidPng(10, 10, [200, 50, 50, 255]);
+    const r = await compareScreenshotBuffers(a, b);
+    expect(r.dimensionsMatch).toBe(true);
+    expect(r.diffPixels).toBe(0);
+    expect(r.totalPixels).toBe(100);
+  });
+
+  it("reports every pixel as diff when colors differ fully", async () => {
+    const a = solidPng(4, 4, [0, 0, 0, 255]);
+    const b = solidPng(4, 4, [255, 255, 255, 255]);
+    const r = await compareScreenshotBuffers(a, b, { threshold: 0.1 });
+    expect(r.diffPixels).toBe(16);
+  });
+
+  it("flags dimension mismatch without running pixelmatch", async () => {
+    const a = solidPng(10, 10, [0, 0, 0, 255]);
+    const b = solidPng(5, 10, [0, 0, 0, 255]);
+    const r = await compareScreenshotBuffers(a, b);
+    expect(r.dimensionsMatch).toBe(false);
+    expect(r.totalPixels).toBe(0);
+    expect(r.diffPixels).toBeGreaterThan(0);
+  });
+
+  it("emits a diff PNG when requested", async () => {
+    const a = solidPng(4, 4, [0, 0, 0, 255]);
+    const b = solidPng(4, 4, [255, 255, 255, 255]);
+    const r = await compareScreenshotBuffers(a, b, { emitDiff: true });
+    expect(r.diffBuffer).toBeDefined();
+    // Verify the diff is itself a readable PNG.
+    const decoded = PNG.sync.read(r.diffBuffer!);
+    expect(decoded.width).toBe(4);
+    expect(decoded.height).toBe(4);
+  });
+
+  it("omits the diff PNG when emitDiff is false (default)", async () => {
+    const a = solidPng(4, 4, [0, 0, 0, 255]);
+    const b = solidPng(4, 4, [255, 255, 255, 255]);
+    const r = await compareScreenshotBuffers(a, b);
+    expect(r.diffBuffer).toBeUndefined();
+  });
+});
+
+describe("formatVisualDiff", () => {
+  const ok = (diffPixels: number, totalPixels: number): CompareResult => ({
+    width: 100,
+    height: 100,
+    diffPixels,
+    totalPixels,
+    dimensionsMatch: true,
+  });
+
+  it("reports px + percentage", () => {
+    const s = formatVisualDiff(ok(50, 10000), 0);
+    expect(s).toContain("50 px differ");
+    expect(s).toContain("0.500%");
+  });
+
+  it("annotates when maxDiffPixels is exceeded", () => {
+    const s = formatVisualDiff(ok(50, 10000), 10);
+    expect(s).toContain("> maxDiffPixels=10");
+  });
+
+  it("annotates when maxDiffRatio is exceeded", () => {
+    const s = formatVisualDiff(ok(200, 10000), 0, 0.01);
+    expect(s).toContain("> maxDiffRatio=0.01");
+  });
+
+  it("describes dimension mismatch explicitly", () => {
+    const s = formatVisualDiff(
+      { width: 0, height: 0, diffPixels: 100, totalPixels: 0, dimensionsMatch: false },
+      0
+    );
+    expect(s).toContain("dimensions mismatch");
+  });
+});

--- a/src/visual.test.ts
+++ b/src/visual.test.ts
@@ -20,12 +20,14 @@ function solidPng(width: number, height: number, rgba: [number, number, number, 
 }
 
 describe("screenshotFilename", () => {
-  it("maps / to index.png", () => {
-    expect(screenshotFilename("http://localhost:3000/")).toBe("index.png");
+  it("produces a readable prefix for / -> index", () => {
+    expect(screenshotFilename("http://localhost:3000/")).toMatch(/^index__[0-9a-f]{8}\.png$/);
   });
 
-  it("maps a nested path", () => {
-    expect(screenshotFilename("http://x/docs/intro/")).toBe("docs_intro.png");
+  it("includes the nested path as the prefix", () => {
+    expect(screenshotFilename("http://x/docs/intro/")).toMatch(
+      /^docs_intro__[0-9a-f]{8}\.png$/
+    );
   });
 
   it("incorporates the query so different searches don't collide", () => {
@@ -40,8 +42,19 @@ describe("screenshotFilename", () => {
     expect(name).toMatch(/^[A-Za-z0-9._-]+$/);
   });
 
-  it("falls back to index when the URL is unparseable", () => {
-    expect(screenshotFilename("not-a-url")).toBe("not-a-url.png");
+  it("disambiguates URLs that sanitize to the same prefix (injective via hash)", () => {
+    // Before the hash suffix, both of these flattened to "a_b.png".
+    const ab = screenshotFilename("http://x/a/b");
+    const a_b = screenshotFilename("http://x/a_b");
+    expect(ab).not.toBe(a_b);
+  });
+
+  it("is deterministic", () => {
+    expect(screenshotFilename("http://x/foo")).toBe(screenshotFilename("http://x/foo"));
+  });
+
+  it("handles unparseable input by hashing the raw string", () => {
+    expect(screenshotFilename("not-a-url")).toMatch(/^not-a-url__[0-9a-f]{8}\.png$/);
   });
 });
 

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -1,0 +1,254 @@
+/**
+ * Visual regression invariant.
+ *
+ * Per page: compare the current screenshot to a baseline image on disk. If
+ * the pixel diff exceeds the configured budget, fail with a one-line summary
+ * and optionally write a diff PNG so CI artefacts can show what changed.
+ *
+ * `pixelmatch` and `pngjs` are optional peer deps — a clear install-hint
+ * error is thrown if they're missing when the invariant actually runs.
+ *
+ * The pure helpers (`screenshotFilename`, `compareScreenshotBuffers`) are
+ * unit-testable without a browser.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Invariant, UrlMatcher } from "./types.js";
+
+export interface VisualRegressionOptions {
+  /** Directory containing baseline PNGs (one per page URL, filename derived from the URL). Required. */
+  baselineDir: string;
+  /**
+   * Per-pixel color distance threshold forwarded to pixelmatch. 0 = exact,
+   * 1 = maximum. Default 0.1 — tolerant of minor antialiasing.
+   */
+  threshold?: number;
+  /** Absolute allowance: fail only if diffPixels exceeds this. Default 0. */
+  maxDiffPixels?: number;
+  /** Ratio allowance: fail if diffPixels / totalPixels exceeds this. Evaluated alongside `maxDiffPixels`. */
+  maxDiffRatio?: number;
+  /** Directory to write diff PNGs on failure. Skipped if unset. */
+  diffDir?: string;
+  /**
+   * Overwrite the baseline with the current screenshot on every page. Use
+   * once after an intentional UI change, then disable.
+   */
+  updateBaseline?: boolean;
+  /** Full-page screenshot (default true) vs viewport-only. */
+  fullPage?: boolean;
+  /** Invariant name in the report. Default `visual-regression`. */
+  name?: string;
+  /** Restrict to matching URLs. */
+  urlPattern?: UrlMatcher;
+  /** Phase. Default `afterLoad` — post-action frames are much noisier. */
+  when?: Invariant["when"];
+}
+
+/**
+ * Derive a filename-safe key from a URL. Encodes the path and query so two
+ * different routes don't collide; strips the scheme/host since baselines
+ * are per-site anyway.
+ */
+export function screenshotFilename(url: string): string {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    // Not a URL — treat the whole string as a path.
+    return sanitize(url) + ".png";
+  }
+  const path = u.pathname === "/" || u.pathname === "" ? "index" : u.pathname;
+  const query = u.search ? `__${u.search.slice(1)}` : "";
+  return sanitize(path + query) + ".png";
+}
+
+function sanitize(s: string): string {
+  return s
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "")
+    || "index";
+}
+
+export interface CompareResult {
+  /** Pixel width of the comparison (0 if dimensions differ). */
+  width: number;
+  /** Pixel height of the comparison (0 if dimensions differ). */
+  height: number;
+  /** Pixels that differ. */
+  diffPixels: number;
+  /** width*height. 0 when dimensions mismatched. */
+  totalPixels: number;
+  /** True when the images have matching dimensions and pixelmatch was run. */
+  dimensionsMatch: boolean;
+  /** Diff PNG as a Buffer (only when dimensions matched and an imageFactory was available). */
+  diffBuffer?: Buffer;
+}
+
+/**
+ * Compare two PNG buffers. Returns diff metrics and an optional diff image.
+ * Dimension mismatches count as a full diff without per-pixel matching.
+ *
+ * `pixelmatch` and `pngjs` are resolved lazily so the helper can be imported
+ * in environments without those peer deps — errors only surface when you
+ * actually call this function without them installed.
+ */
+export async function compareScreenshotBuffers(
+  current: Buffer,
+  baseline: Buffer,
+  options: { threshold?: number; emitDiff?: boolean } = {}
+): Promise<CompareResult> {
+  const { PNG } = await loadPngjs();
+  const pixelmatch = await loadPixelmatch();
+
+  const currImg = PNG.sync.read(current);
+  const baseImg = PNG.sync.read(baseline);
+
+  if (currImg.width !== baseImg.width || currImg.height !== baseImg.height) {
+    return {
+      width: 0,
+      height: 0,
+      diffPixels: Math.max(currImg.width * currImg.height, baseImg.width * baseImg.height),
+      totalPixels: 0,
+      dimensionsMatch: false,
+    };
+  }
+
+  const { width, height } = currImg;
+  const diffPng = options.emitDiff ? new PNG({ width, height }) : null;
+  const diffPixels = pixelmatch(
+    currImg.data,
+    baseImg.data,
+    diffPng ? diffPng.data : null,
+    width,
+    height,
+    { threshold: options.threshold ?? 0.1 }
+  );
+
+  return {
+    width,
+    height,
+    diffPixels,
+    totalPixels: width * height,
+    dimensionsMatch: true,
+    diffBuffer: diffPng ? PNG.sync.write(diffPng) : undefined,
+  };
+}
+
+interface PixelmatchFn {
+  (
+    img1: Uint8Array,
+    img2: Uint8Array,
+    output: Uint8Array | null,
+    width: number,
+    height: number,
+    options?: { threshold?: number }
+  ): number;
+}
+
+async function loadPixelmatch(): Promise<PixelmatchFn> {
+  try {
+    const mod = (await import("pixelmatch")) as unknown as {
+      default?: PixelmatchFn;
+    } & PixelmatchFn;
+    return (mod.default ?? mod) as PixelmatchFn;
+  } catch {
+    throw new Error(
+      "chaosbringer: invariants.visualRegression() requires the `pixelmatch` package. Install it with `pnpm add pixelmatch pngjs`."
+    );
+  }
+}
+
+interface PngCtor {
+  new (opts: { width: number; height: number }): { data: Buffer; width: number; height: number };
+  sync: {
+    read: (buf: Buffer) => { data: Buffer; width: number; height: number };
+    write: (png: { data: Buffer; width: number; height: number }) => Buffer;
+  };
+}
+
+async function loadPngjs(): Promise<{ PNG: PngCtor }> {
+  try {
+    const mod = (await import("pngjs")) as unknown as { PNG: PngCtor };
+    return { PNG: mod.PNG };
+  } catch {
+    throw new Error(
+      "chaosbringer: invariants.visualRegression() requires the `pngjs` package. Install it with `pnpm add pixelmatch pngjs`."
+    );
+  }
+}
+
+/** Format the diff outcome into a one-line invariant failure message. */
+export function formatVisualDiff(result: CompareResult, maxDiffPixels: number, maxDiffRatio?: number): string {
+  if (!result.dimensionsMatch) {
+    return `visual diff: dimensions mismatch (baseline differs in size)`;
+  }
+  const ratio = result.totalPixels > 0 ? result.diffPixels / result.totalPixels : 0;
+  const parts = [`${result.diffPixels} px differ`];
+  parts.push(`${(ratio * 100).toFixed(3)}%`);
+  if (result.diffPixels > maxDiffPixels) parts.push(`> maxDiffPixels=${maxDiffPixels}`);
+  if (maxDiffRatio !== undefined && ratio > maxDiffRatio) {
+    parts.push(`> maxDiffRatio=${maxDiffRatio}`);
+  }
+  return `visual diff: ${parts.join(", ")}`;
+}
+
+/**
+ * Visual-regression invariant. On first run (or `updateBaseline: true`),
+ * saves the current screenshot as the baseline and passes. On subsequent
+ * runs, compares against the baseline and fails when the diff exceeds the
+ * configured budget.
+ */
+export function visualRegression(options: VisualRegressionOptions): Invariant {
+  const threshold = options.threshold ?? 0.1;
+  const maxDiffPixels = options.maxDiffPixels ?? 0;
+  const maxDiffRatio = options.maxDiffRatio;
+  const fullPage = options.fullPage ?? true;
+  const baselineDir = options.baselineDir;
+  const diffDir = options.diffDir;
+  const updateBaseline = options.updateBaseline ?? false;
+
+  return {
+    name: options.name ?? "visual-regression",
+    urlPattern: options.urlPattern,
+    when: options.when ?? "afterLoad",
+    async check({ page, url }) {
+      const filename = screenshotFilename(url);
+      const baselinePath = join(baselineDir, filename);
+
+      const screenshot = await page.screenshot({ fullPage, type: "png" });
+      const current = screenshot as Buffer;
+
+      if (!existsSync(baselinePath) || updateBaseline) {
+        mkdirSync(dirname(baselinePath), { recursive: true });
+        writeFileSync(baselinePath, current);
+        return true;
+      }
+
+      const baseline = readFileSync(baselinePath);
+      const result = await compareScreenshotBuffers(current, baseline, {
+        threshold,
+        emitDiff: Boolean(diffDir),
+      });
+
+      const ratioExceeded =
+        maxDiffRatio !== undefined &&
+        result.totalPixels > 0 &&
+        result.diffPixels / result.totalPixels > maxDiffRatio;
+      const pixelsExceeded = result.diffPixels > maxDiffPixels;
+      const failed = !result.dimensionsMatch || pixelsExceeded || ratioExceeded;
+
+      if (failed && diffDir && result.diffBuffer) {
+        const diffPath = join(diffDir, filename);
+        mkdirSync(dirname(diffPath), { recursive: true });
+        writeFileSync(diffPath, result.diffBuffer);
+      }
+
+      if (!failed) return true;
+      return formatVisualDiff(result, maxDiffPixels, maxDiffRatio);
+    },
+  };
+}

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -14,6 +14,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fnv1a } from "./shard.js";
 import type { Invariant, UrlMatcher } from "./types.js";
 
 export interface VisualRegressionOptions {
@@ -46,21 +47,25 @@ export interface VisualRegressionOptions {
 }
 
 /**
- * Derive a filename-safe key from a URL. Encodes the path and query so two
- * different routes don't collide; strips the scheme/host since baselines
- * are per-site anyway.
+ * Derive a filename-safe key from a URL. The readable prefix carries the
+ * path + query (sanitized), and an 8-hex-char hash of the full URL is
+ * appended so collisions between routes that sanitize to the same prefix
+ * (e.g. `/a/b` and `/a_b` both flatten to `a_b`) are impossible in
+ * practice. The hash is FNV-1a — non-cryptographic, just deterministic
+ * and uniformly distributed enough for filename disambiguation.
  */
 export function screenshotFilename(url: string): string {
-  let u: URL;
+  let prefix: string;
   try {
-    u = new URL(url);
+    const u = new URL(url);
+    const path = u.pathname === "/" || u.pathname === "" ? "index" : u.pathname;
+    const query = u.search ? `__${u.search.slice(1)}` : "";
+    prefix = sanitize(path + query);
   } catch {
-    // Not a URL — treat the whole string as a path.
-    return sanitize(url) + ".png";
+    prefix = sanitize(url);
   }
-  const path = u.pathname === "/" || u.pathname === "" ? "index" : u.pathname;
-  const query = u.search ? `__${u.search.slice(1)}` : "";
-  return sanitize(path + query) + ".png";
+  const hash = fnv1a(url).toString(16).padStart(8, "0");
+  return `${prefix}__${hash}.png`;
 }
 
 function sanitize(s: string): string {


### PR DESCRIPTION
## Summary

Visual regression testing wired as an invariant preset — slots into the existing invariant pipeline so failures go through the same cluster / baseline-diff / GitHub-annotation paths as axe or perf budget violations.

- **API**: `invariants.visualRegression({ baselineDir, threshold, maxDiffPixels, maxDiffRatio, diffDir, updateBaseline, fullPage })`. On first run records the baseline and passes; on later runs compares via `pixelmatch` and fails when diff exceeds the budget.
- **CLI**: `--visual-baseline <dir>` turns it on with defaults; tunable via `--visual-threshold`, `--visual-max-diff-pixels`, `--visual-max-diff-ratio`, `--visual-diff-dir`, `--visual-update`.
- **Deps**: `pixelmatch` and `pngjs` added as optional peer deps + devDeps. Dynamic-imported with install-hint errors, so users who don't opt in pay nothing.
- **Pure helpers**: `screenshotFilename`, `compareScreenshotBuffers`, `formatVisualDiff` — exported for reuse and unit-tested with synthetic PNG buffers (pngjs generates solid-color PNGs in tests).

Baseline filenames are derived from URL path + query (sanitized) so different routes don't collide. Dimension mismatches count as full-diff failures rather than silently resizing — the user should re-record the baseline intentionally.

## Test plan

- [x] `pnpm build` — clean.
- [x] `pnpm vitest run --exclude 'fixtures/**'` — 248/248 pass (14 new in `src/visual.test.ts`).
- [x] README: feature-list bullet, new `## Visual regression` section, CLI reference rows.
- [ ] End-to-end smoke test against the fixture site (skipped — Playwright chromium not installed in sandbox).

https://claude.ai/code/session_01AQUdaSBMCaR9n3UKLuVQin

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQUdaSBMCaR9n3UKLuVQin)_