### PR TITLE
chore(deps): bump @mizchi/flaker to ^0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     ]
   },
   "devDependencies": {
-    "@mizchi/flaker": "^0.10.6",
+    "@mizchi/flaker": "^0.11.0",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.0.0",
     "@types/pixelmatch": "^5.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@mizchi/flaker':
-        specifier: ^0.10.6
-        version: 0.10.6(encoding@0.1.13)
+        specifier: ^0.11.0
+        version: 0.11.0(encoding@0.1.13)
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.59.1
@@ -218,8 +218,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@mizchi/flaker@0.10.6':
-    resolution: {integrity: sha512-T+9hWPQVLl+Y6XCt2GXwy7P8NbsUTJ7SwTV48UNLXiKSq8pBnRTNrmH+mr9J+jQ7CIozdmPPSvN1yD+80/x3HQ==}
+  '@mizchi/flaker@0.11.0':
+    resolution: {integrity: sha512-LuR4LMF2ETsircym+ctQEDhpxx1zzv19j6EKfTJJMnrBb3PFjsmndFRTKG8dPvr3iH2IjujNFhJuVvj6n9ZaEA==}
     engines: {node: '>=24'}
     hasBin: true
 
@@ -1267,7 +1267,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mizchi/flaker@0.10.6(encoding@0.1.13)':
+  '@mizchi/flaker@0.11.0(encoding@0.1.13)':
     dependencies:
       '@octokit/rest': 22.0.1
       adm-zip: 0.5.17


### PR DESCRIPTION
## Summary

- Bumps \`@mizchi/flaker\` from \`^0.10.6\` to \`^0.11.0\`.
- Resolves the \`flaker-merge\` CI check that has been failing on every PR with \`Cannot find module '.../node_modules/moonbit/flaker.js'\` — a pnpm isolated-store resolution bug fixed upstream in 0.10.7 (canonicalize argv[1] in isDirectCliExecution).
- 0.11.0 also bundles flaker's new \`chaosbringer\` adapter, so a downstream commit can wire \`flaker import <chaos-report.json> --adapter chaosbringer\` into chaosbringer-automation without another bump.

## Test plan

- [x] \`pnpm install\` — clean.
- [x] \`pnpm flaker:run:merge\` — exits 0 against the current working tree (was crashing immediately with \`ERR_MODULE_NOT_FOUND\` before the bump).
- [ ] CI \`flaker-merge\` should now pass on this PR — that's the actual proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)