### PR TITLE
ci: import chaos baseline into flaker storage

### DIFF
--- a/.github/workflows/chaos-baseline.yml
+++ b/.github/workflows/chaos-baseline.yml
@@ -69,6 +69,35 @@ jobs:
         if: always()
         run: kill "$(cat .fixture.pid)" 2>/dev/null || true
 
+      # Persist chaos signals into the same flaker storage that
+      # `flaker-nightly.yml` writes — same cache key shape so reads / writes
+      # interleave naturally. Each baseline run becomes one set of
+      # TestCaseResults in flaker (one per visited page + one per invariant
+      # violation), keyed by the merge commit. Over enough runs flaker can
+      # tell which chaos errors are real, flaky, or intermittent.
+      - name: Cache flaker data
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: .flaker/data
+          key: flaker-data-${{ github.run_id }}
+          restore-keys: |
+            flaker-data-
+
+      - name: Import chaos report into flaker
+        if: always()
+        run: |
+          # Adapter landed in @mizchi/flaker 0.11.0; this repo pins ^0.11.0.
+          # The repo's `pnpm flaker:*` aliases set NODE_OPTIONS=--preserve-symlinks-main
+          # — that env var is a leftover workaround for a pnpm symlink resolution
+          # bug fixed in flaker 0.10.7, and it now silently breaks the CLI under
+          # 0.11.0. Invoke without the env var here.
+          pnpm exec flaker import chaos-report.json \
+            --adapter chaosbringer \
+            --commit "${{ github.sha }}" \
+            --branch "${{ github.ref_name }}" \
+            --source ci
+
       - name: Upload baseline
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Closes the chaos → flaker loop that \`@mizchi/flaker@0.11.0\` (mizchi/flaker#79) just enabled.

After every chaos baseline run (push to main + nightly cron), the produced \`chaos-report.json\` is fed straight into flaker storage via \`flaker import --adapter chaosbringer\`:

- Each visited page becomes one TestCaseResult row keyed \`(suite=chaosbringer:pages, testName=<pathname>)\`.
- Each invariant violation becomes its own row keyed \`(suite=chaosbringer:invariants, taskId=<pathname>)\`.
- The merge commit + branch are recorded so flaker's flaky detector can compare runs over time.

Storage cache uses the same key shape (\`flaker-data-\${run_id}\` save, \`flaker-data-\` restore) as \`flaker-nightly.yml\` so reads / writes interleave cleanly between the chaos-side and the vitest-side ingestion paths. \`if: always()\` so a failed chaos crawl still records what it saw before the failure.

## Side finding (worth a follow-up)

Invoked WITHOUT \`NODE_OPTIONS=--preserve-symlinks-main\`. The repo's \`pnpm flaker:*\` aliases set that env var as a leftover workaround for a pnpm symlink resolution bug fixed in flaker 0.10.7. Under @mizchi/flaker@0.11.0 the flag silently terminates the CLI **without running the command and exit 0** — so any \`pnpm flaker:plan\` / \`flaker:apply\` / \`flaker:status\` / \`flaker:doctor\` / \`flaker:run:*\` invocation here is a no-op today. Worth opening a small follow-up PR to drop the env var from those scripts.

## Test plan

- [x] Local dry-run: \`flaker import dogfood-feedback.json --adapter chaosbringer --commit dryrun-001 --branch local --source local\` → \`Imported 1 test results\`, \`.flaker/data\` populated.
- [x] Confirmed \`@mizchi/flaker@0.11.0\` ships the chaosbringer adapter (verified by \`tar -xzOf\` on the npm tarball: \`src/cli/adapters/chaosbringer.ts\` is in the bundled \`dist/cli/main.js\`).
- [ ] CI baseline run on main after merge: should accumulate one set of TestCaseResults per push / nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)