### PR TITLE
chore: drop NODE_OPTIONS=--preserve-symlinks-main from flaker:* scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "crawl": "tsx src/cli.ts",
     "fixture:serve": "tsx fixtures/site/server.ts",
     "fixture:run": "tsx fixtures/runner/run.ts",
-    "flaker": "NODE_OPTIONS=--preserve-symlinks-main flaker",
-    "flaker:plan": "NODE_OPTIONS=--preserve-symlinks-main flaker plan",
-    "flaker:apply": "NODE_OPTIONS=--preserve-symlinks-main flaker apply",
-    "flaker:status": "NODE_OPTIONS=--preserve-symlinks-main flaker status",
-    "flaker:doctor": "NODE_OPTIONS=--preserve-symlinks-main flaker doctor",
-    "flaker:run:iteration": "NODE_OPTIONS=--preserve-symlinks-main flaker run --gate iteration",
-    "flaker:run:merge": "NODE_OPTIONS=--preserve-symlinks-main flaker run --gate merge"
+    "flaker": "flaker",
+    "flaker:plan": "flaker plan",
+    "flaker:apply": "flaker apply",
+    "flaker:status": "flaker status",
+    "flaker:doctor": "flaker doctor",
+    "flaker:run:iteration": "flaker run --gate iteration",
+    "flaker:run:merge": "flaker run --gate merge"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

The 7 \`pnpm flaker:*\` aliases in \`package.json\` all prefixed the bin invocation with \`NODE_OPTIONS=--preserve-symlinks-main\`. That env var was a workaround for a pnpm symlink resolution bug fixed upstream in flaker 0.10.7 (\`canonicalize argv[1] in isDirectCliExecution\`). Under @mizchi/flaker@0.11.0 (now pinned in this repo), the env var actively breaks invocation: the CLI's \`isDirectCliExecution\` check disagrees with the preserve-symlinks-main module identity, decides it is not the entry point, and **silently no-ops with exit 0**.

End-user symptom: every \`pnpm flaker:plan\` / \`flaker:apply\` / \`flaker:status\` / \`flaker:doctor\` / \`flaker:run:iteration\` / \`flaker:run:merge\` invocation has been a silent no-op since the 0.11.0 bump in #32. The \`flaker-pr.yml\` and \`flaker-nightly.yml\` workflows were technically green but doing nothing.

Surfaced while wiring up #33 (chaos baseline → flaker import); the workaround was the obvious cause once the import step started doing the same silent-exit dance.

## Proof

Before the change, both invocations were silent (exit 0, no output). After:

\`\`\`
$ pnpm flaker --version
0.10.7

$ pnpm flaker:doctor
OK  config    flaker.toml is readable
OK  config ranges  all values within expected ranges
OK  duckdb    DuckDB initialized successfully
OK  moonbit   MoonBit JS build detected

Doctor checks passed.
\`\`\`

(\`flaker --version\` reporting 0.10.7 even on the 0.11.0 npm release is a separate flaker-side bug — the bundled CLI's \`.version("...")\` string was not bumped during the 0.11.0 release. Worth a follow-up over there, out of scope for this PR.)

## Test plan

- [x] \`pnpm flaker --version\` — prints version (was silent).
- [x] \`pnpm flaker:doctor\` — 4 checks pass (was silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)