### PR TITLE
fix(ci): pass --changed file list into flaker run --gate merge

### DIFF
--- a/.github/workflows/flaker-pr.yml
+++ b/.github/workflows/flaker-pr.yml
@@ -18,6 +18,12 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need history to compute the --changed file list against the PR base.
+          # Without this, `git diff --name-only origin/<base>...HEAD` would
+          # return nothing and `flaker run --gate merge` (hybrid strategy)
+          # would error out with `hybrid mode requires resolver and changedFiles`.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -47,6 +53,15 @@ jobs:
             flaker-data-
 
       - name: flaker run --gate merge
-        run: pnpm flaker:run:merge
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # Hybrid strategy needs the changed-file set; flaker doesn't compute
+          # it itself when invoked from CI. We diff against the PR base ref —
+          # `actions/checkout@v4` fetched it under refs/remotes/origin/<base>
+          # because of fetch-depth: 0 above. Empty diff (config-only PR, etc.)
+          # is valid: hybrid will fall back to the configured fallback strategy.
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" | tr '\n' ',' | sed 's/,$//')
+          echo "Changed files passed to flaker: ${changed:-(none)}"
+          pnpm flaker:run:merge --changed "$changed"


### PR DESCRIPTION
## Summary

Surfaced by #34 (the env-var cleanup): once \`flaker run --gate merge\` actually runs instead of being a silent no-op, it errors with \`hybrid mode requires resolver and changedFiles\` because the merge gate's hybrid strategy expects an explicit changed-file list and the workflow wasn't passing one.

Two changes in \`flaker-pr.yml\`:

- \`actions/checkout@v4\` now uses \`fetch-depth: 0\`. Without history, the PR base ref isn't local and \`git diff origin/<base>...HEAD\` returns empty.
- The \`flaker run --gate merge\` step derives the changed-file set from \`git diff --name-only origin/\${{ github.event.pull_request.base.ref }}...HEAD\` and passes it via \`--changed\` (comma-joined). Empty diff is fine — hybrid strategy falls back to the configured fallback.

The job is already \`continue-on-error: true\`, so this is advisory; the goal is to make the advisory actually do something instead of crashing on every PR with the same error.

## Test plan

- [ ] CI on this PR: \`flaker-merge\` should now reach the actual selection / run phase instead of bailing at the strategy validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)