### PR TITLE
Add JS-runtime fault injection (flaky-fetch, clock-skew)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Playwright-based chaos testing for web apps. Crawls the pages you point it at, p
 - **Seeded reproducibility** — same seed, same action order. Every report prints a `Repro:` line you can paste into CI logs.
 - **Network fault injection** via Playwright's route API: serve a 500, abort, or add latency to any URL pattern.
 - **Lifecycle fault injection** — CDP CPU throttling, storage wipe (localStorage / sessionStorage / cookies / IndexedDB), Service Worker cache eviction, and key/value tampering, applied at named stages of every page visit (`beforeNavigation` / `afterLoad` / `beforeActions` / `betweenActions`).
+- **Runtime fault injection** — persistent in-page monkey-patches (`flaky-fetch`, `clock-skew`) installed via `addInitScript` on every navigation; subverts JS APIs that no network mock can reach (e.g. `fetch` rejection before any request goes out).
 - **Coverage-guided action selection** — opt-in V8 precise coverage feedback (CDP `Profiler.takePreciseCoverage`) attributes per-action coverage deltas to the target that fired them and biases subsequent action weights toward targets that historically delivered new code paths.
 - **Declarative invariants** evaluated on every page. A violation fails the run regardless of `--strict`. Trans-page state — e.g. state-machine transitions — is supported via a run-scoped `ctx.state` Map and an `invariants.stateMachine()` helper.
 - **Accessibility checks** via an `invariants.axe()` preset — axe-core is an optional peer dep.
@@ -247,6 +248,46 @@ Every fault gets one row in `report.lifecycleFaults` with `matched` (URL-pattern
 ```
 
 Like network-side fault injection, lifecycle faults are programmatic-only — they're not expressible as flat shell flags and so are absent from the CLI.
+
+## Runtime faults (in-page monkey-patches)
+
+`runtimeFaults` is a third fault layer, distinct from request-scoped `faultInjection` and stage-scoped `lifecycleFaults`. Each entry is a persistent monkey-patch installed via `addInitScript` on every page navigation, subverting in-page JS APIs so the app sees client-side failures that no network mock would expose.
+
+```ts
+import { chaos, faults } from "chaosbringer";
+
+await chaos({
+  baseUrl: "http://localhost:3000",
+  seed: 42,
+  runtimeFaults: [
+    // 30% of fetch() calls reject with "Failed to fetch" before any
+    // network round-trip — exposes Service Worker fallbacks, retry
+    // logic, and "offline indicator" code paths.
+    faults.flakyFetch({
+      urlPattern: /\/api\//,
+      probability: 0.3,
+      rejectionMessage: "simulated network failure",
+    }),
+    // Skew the clock 25 minutes forward on /dashboard pages — surfaces
+    // token-expiry and cache-bust bugs without waiting real time.
+    faults.clockSkew(25 * 60_000, { urlPattern: /\/dashboard/ }),
+  ],
+});
+```
+
+The probability roll is deterministic given the same `(seed, runtimeFaults)` pair — the in-page LCG is seeded from `seed` so two runs roll identically.
+
+Layer comparison:
+
+| Layer | Where it runs | Targets | Example |
+| --- | --- | --- | --- |
+| `faultInjection` | Playwright `route()` (Node side) | individual network requests | serve 500 on `/api/*` |
+| `lifecycleFaults` | per-page hook (CDP / page eval) | one-shot at named stages | wipe localStorage `afterLoad` |
+| `runtimeFaults` | `addInitScript` (in-page) | persistent JS API patches | reject `fetch()`, skew `Date.now` |
+
+Stats land in `report.runtimeFaults` — one row per fault with `matched` (URL filtered ok, probability about to roll) and `fired` (actually triggered) counts.
+
+Like the other fault layers, `runtimeFaults` is programmatic-only.
 
 ## Invariants
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -47,6 +47,12 @@ import {
   type CompiledLifecycleFault,
 } from "./lifecycle-faults.js";
 import {
+  buildRuntimeFaultsScript,
+  compileRuntimeFaults,
+  mergeRuntimeStats,
+  type CompiledRuntimeFault,
+} from "./runtime-faults.js";
+import {
   CoverageCollector,
   coverageDelta,
   noveltyMultiplier,
@@ -122,6 +128,7 @@ const DEFAULT_OPTIONS: Required<
   invariants: [],
   faultInjection: [],
   lifecycleFaults: [],
+  runtimeFaults: [],
 };
 
 const DEFAULT_ACTION_WEIGHTS: Required<ActionWeights> = {
@@ -203,6 +210,8 @@ export class ChaosCrawler {
   }> = [];
   /** Page-lifecycle faults compiled once at construction time. */
   private compiledLifecycleFaults: CompiledLifecycleFault[] = [];
+  /** Compiled runtime faults — installed once at context level via init script. */
+  private compiledRuntimeFaults: CompiledRuntimeFault[] = [];
   /**
    * Per-page lifecycle executor — created on `applyLifecycleStage` first
    * call for each page and dropped when the page is closed.
@@ -246,6 +255,7 @@ export class ChaosCrawler {
     this.options.seed = this.rng.seed;
     this.compiledFaultRules = compileFaultRules(options.faultInjection);
     this.compiledLifecycleFaults = compileLifecycleFaults(options.lifecycleFaults);
+    this.compiledRuntimeFaults = compileRuntimeFaults(options.runtimeFaults);
     if (options.coverageFeedback?.enabled) {
       this.coverageFeedback = {
         enabled: true,
@@ -477,6 +487,17 @@ export class ChaosCrawler {
       storageState: this.options.storageState || undefined,
     });
 
+    // Runtime fault init script: monkey-patches in-page JS APIs (fetch / Date /
+    // …) on every navigation. Installed at the context level so every page
+    // (including ones opened via window.open later) inherits the patches.
+    if (this.compiledRuntimeFaults.length > 0) {
+      const script = buildRuntimeFaultsScript(
+        this.compiledRuntimeFaults.map((c) => c.fault),
+        this.rng.seed,
+      );
+      await this.context.addInitScript({ content: script });
+    }
+
     // Replay mode: serve every matching request from the HAR before it hits
     // the network. Fault injection (installed per-page) still wins because
     // page.route runs before context.route in Playwright.
@@ -628,6 +649,27 @@ export class ChaosCrawler {
    * Errors here are intentionally swallowed: the bundle is diagnostic, not
    * load-bearing — losing one bundle shouldn't take the crawler down.
    */
+  /**
+   * Read `window.__chaosbringerRuntimeStats` and accumulate into the
+   * compiled runtime-fault counters. Errors are swallowed: the in-page
+   * counter is best-effort diagnostics, not load-bearing.
+   */
+  private async collectRuntimeFaultStats(page: Page): Promise<void> {
+    if (this.compiledRuntimeFaults.length === 0) return;
+    try {
+      const pageStats = (await page.evaluate(
+        () =>
+          (globalThis as { __chaosbringerRuntimeStats?: Record<string, { matched: number; fired: number }> })
+            .__chaosbringerRuntimeStats ?? {},
+      )) as Record<string, { matched: number; fired: number }>;
+      mergeRuntimeStats(this.compiledRuntimeFaults, pageStats);
+    } catch (err) {
+      this.logger.warn("runtime_fault_stats_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   private async maybeWriteFailureBundle(page: Page, result: PageResult): Promise<void> {
     const opts = this.options.failureArtifacts;
     if (!opts) return;
@@ -972,6 +1014,10 @@ export class ChaosCrawler {
       // page away — otherwise the screenshot would show the recovered URL
       // rather than the failing one.
       await this.maybeWriteFailureBundle(page, result);
+
+      // Merge runtime-fault stats from the in-page counter. Recovery
+      // navigates away, so we collect before that path runs.
+      await this.collectRuntimeFaultStats(page);
 
       // Handle recovery from 404 or error status
       if (
@@ -1858,6 +1904,14 @@ export class ChaosCrawler {
         this.compiledLifecycleFaults.length > 0
           ? lifecycleStatsFrom(this.compiledLifecycleFaults)
           : undefined,
+      runtimeFaults:
+        this.compiledRuntimeFaults.length > 0
+          ? this.compiledRuntimeFaults.map((c) => ({
+              rule: c.name,
+              matched: c.matched,
+              fired: c.fired,
+            }))
+          : undefined,
       coverage: this.coverageFeedback
         ? summarizeCoverage({
             globalCovered: this.globalCoverage,
@@ -2086,6 +2140,37 @@ export function validateOptions(options: CrawlerOptions): void {
       if (a.cacheNames !== undefined && !Array.isArray(a.cacheNames)) {
         throw new Error(`chaosbringer: ${label} evict-cache cacheNames must be an array of strings`);
       }
+    }
+  }
+
+  for (const fault of options.runtimeFaults ?? []) {
+    const label = fault.name
+      ? `runtimeFaults entry "${fault.name}"`
+      : `runtimeFaults entry`;
+    assertMatcher(`${label} urlPattern`, fault.urlPattern);
+    if (fault.probability !== undefined) {
+      const p = fault.probability;
+      if (!Number.isFinite(p) || p < 0 || p > 1) {
+        throw new Error(
+          `chaosbringer: ${label} probability must be in [0, 1] (got ${JSON.stringify(p)})`
+        );
+      }
+    }
+    const a = fault.action;
+    if (a.kind === "flaky-fetch") {
+      if (a.rejectionMessage !== undefined && typeof a.rejectionMessage !== "string") {
+        throw new Error(`chaosbringer: ${label} flaky-fetch rejectionMessage must be a string`);
+      }
+    } else if (a.kind === "clock-skew") {
+      if (!Number.isFinite(a.skewMs) || !Number.isInteger(a.skewMs)) {
+        throw new Error(
+          `chaosbringer: ${label} clock-skew skewMs must be a finite integer (got ${JSON.stringify(a.skewMs)})`
+        );
+      }
+    } else {
+      throw new Error(
+        `chaosbringer: ${label} action.kind is not recognized (got ${JSON.stringify((a as { kind: unknown }).kind)})`
+      );
     }
   }
 

--- a/src/faults.ts
+++ b/src/faults.ts
@@ -14,6 +14,7 @@ import type {
   FaultRule,
   LifecycleFault,
   LifecycleStage,
+  RuntimeFault,
   StorageScope,
   UrlMatcher,
 } from "./types.js";
@@ -170,4 +171,55 @@ export const faults = {
     };
     return applyLifecycleCommon(fault, opts, "afterLoad");
   },
+
+  /**
+   * Reject `window.fetch` calls before any network round-trip. Different
+   * from `faults.abort()` (request-scoped, applied via Playwright `route`):
+   * `flakyFetch` rejects the Promise client-side with a TypeError, so any
+   * `try/catch` and Service-Worker fallbacks downstream of `fetch` engage
+   * just like a real "Failed to fetch" event.
+   */
+  flakyFetch(opts?: RuntimeHelperOptions & { rejectionMessage?: string }): RuntimeFault {
+    const fault: RuntimeFault = {
+      action: {
+        kind: "flaky-fetch",
+        ...(opts?.rejectionMessage !== undefined
+          ? { rejectionMessage: opts.rejectionMessage }
+          : {}),
+      },
+    };
+    return applyRuntimeCommon(fault, opts);
+  },
+
+  /**
+   * Skew `Date.now()`, `performance.now()`, and the no-arg `Date`
+   * constructor forward by `skewMs`. Use to surface token-expiry,
+   * cache-bust, and "clock drift" code paths without waiting real time.
+   */
+  clockSkew(skewMs: number, opts?: RuntimeHelperOptions): RuntimeFault {
+    if (!Number.isFinite(skewMs) || !Number.isInteger(skewMs)) {
+      throw new Error(`faults.clockSkew: skewMs must be a finite integer (got ${skewMs})`);
+    }
+    const fault: RuntimeFault = { action: { kind: "clock-skew", skewMs } };
+    return applyRuntimeCommon(fault, opts);
+  },
 };
+
+export interface RuntimeHelperOptions {
+  /** Restrict the fault to pages whose URL matches this matcher. */
+  urlPattern?: UrlMatcher;
+  /** 0..1, default 1.0. Rolled per call against the in-page seeded RNG. */
+  probability?: number;
+  /** Override the auto-derived stats name. */
+  name?: string;
+}
+
+function applyRuntimeCommon(
+  fault: RuntimeFault,
+  opts: RuntimeHelperOptions | undefined,
+): RuntimeFault {
+  if (opts?.urlPattern !== undefined) fault.urlPattern = opts.urlPattern;
+  if (opts?.probability !== undefined) fault.probability = opts.probability;
+  if (opts?.name !== undefined) fault.name = opts.name;
+  return fault;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,20 @@ export { ChaosCrawler, COMMON_IGNORE_PATTERNS, validateOptions } from "./crawler
 export { formatReport, formatCompactReport, saveReport, printReport, getExitCode, type ExitCodeOptions } from "./reporter.js";
 export { Logger, createNullLogger, type LogEntry, type LogLevel, type LoggerOptions } from "./logger.js";
 export { chaos, type ChaosResult, type ChaosRunOptions } from "./chaos.js";
-export { faults, type FaultHelperOptions, type LifecycleHelperOptions } from "./faults.js";
+export {
+  faults,
+  type FaultHelperOptions,
+  type LifecycleHelperOptions,
+  type RuntimeHelperOptions,
+} from "./faults.js";
+export {
+  buildRuntimeFaultsScript,
+  compileRuntimeFaults,
+  mergeRuntimeStats,
+  runtimeFaultName,
+  runtimeMatchesUrl,
+  type CompiledRuntimeFault,
+} from "./runtime-faults.js";
 export {
   compileLifecycleFaults,
   executeLifecycleAction,
@@ -128,6 +141,9 @@ export type {
   LifecycleFaultStats,
   LifecycleStage,
   StorageScope,
+  RuntimeAction,
+  RuntimeFault,
+  RuntimeFaultStats,
   CoverageFeedbackOptions,
   CoverageReport,
   UrlMatcher,

--- a/src/runtime-faults.test.ts
+++ b/src/runtime-faults.test.ts
@@ -156,13 +156,35 @@ describe("buildRuntimeFaultsScript", () => {
     expect(skewed).toContain("Date.now");
   });
 
-  it("uses the fault's auto-derived name as the stats key", () => {
+  it("uses the fault's auto-derived name as a display label", () => {
     const s = buildRuntimeFaultsScript(
       [{ action: { kind: "flaky-fetch" } }, { action: { kind: "clock-skew", skewMs: 1000 } }],
       1,
     );
     expect(s).toContain('"name":"flaky-fetch"');
     expect(s).toContain('"name":"clock-skew:1000ms"');
+  });
+
+  it("assigns sequential id keys so duplicate names don't collide in stats", () => {
+    const s = buildRuntimeFaultsScript(
+      [{ action: { kind: "flaky-fetch" } }, { action: { kind: "flaky-fetch" } }],
+      1,
+    );
+    expect(s).toContain('"id":0');
+    expect(s).toContain('"id":1');
+    // The stats accessor uses String(f.id), not f.name.
+    expect(s).toContain("stats[String(f.id)]");
+  });
+
+  it("does not 32-bit-truncate large skewMs values", () => {
+    // 30 days = 2,592,000,000 ms — exceeds int32 max. The script must
+    // accumulate via Number(...), not `| 0`.
+    const s = buildRuntimeFaultsScript(
+      [{ action: { kind: "clock-skew", skewMs: 2_592_000_000 } }],
+      1,
+    );
+    expect(s).not.toContain("skewMs | 0");
+    expect(s).toContain("Number(f.action.skewMs)");
   });
 
   it("respects an explicit fault name", () => {
@@ -187,31 +209,62 @@ describe("buildRuntimeFaultsScript", () => {
 });
 
 describe("mergeRuntimeStats", () => {
-  it("accumulates per-page counters into the compiled fault counters", () => {
+  it("accumulates per-page counters by index into the compiled fault counters", () => {
     const compiled = compileRuntimeFaults([
       { name: "f1", action: { kind: "flaky-fetch" } },
       { name: "c1", action: { kind: "clock-skew", skewMs: 100 } },
     ]);
-    mergeRuntimeStats(compiled, { f1: { matched: 3, fired: 2 } });
+    mergeRuntimeStats(compiled, { "0": { matched: 3, fired: 2 } });
     expect(compiled[0]!.matched).toBe(3);
     expect(compiled[0]!.fired).toBe(2);
     expect(compiled[1]!.matched).toBe(0);
     expect(compiled[1]!.fired).toBe(0);
-    mergeRuntimeStats(compiled, { f1: { matched: 1, fired: 1 } });
+    mergeRuntimeStats(compiled, { "0": { matched: 1, fired: 1 } });
     expect(compiled[0]!.matched).toBe(4);
     expect(compiled[0]!.fired).toBe(3);
   });
 
+  it("does not collapse counters when two faults share a name", () => {
+    // Both default to name="flaky-fetch"; index keys keep them apart.
+    const compiled = compileRuntimeFaults([
+      { action: { kind: "flaky-fetch" }, urlPattern: /\/api\/a/ },
+      { action: { kind: "flaky-fetch" }, urlPattern: /\/api\/b/ },
+    ]);
+    mergeRuntimeStats(compiled, {
+      "0": { matched: 5, fired: 5 },
+      "1": { matched: 1, fired: 0 },
+    });
+    expect(compiled[0]!.matched).toBe(5);
+    expect(compiled[0]!.fired).toBe(5);
+    expect(compiled[1]!.matched).toBe(1);
+    expect(compiled[1]!.fired).toBe(0);
+  });
+
   it("ignores stats keys that don't correspond to a compiled fault", () => {
     const compiled = compileRuntimeFaults([{ name: "known", action: { kind: "flaky-fetch" } }]);
-    mergeRuntimeStats(compiled, { ghost: { matched: 99, fired: 99 } });
+    mergeRuntimeStats(compiled, { "99": { matched: 99, fired: 99 } });
     expect(compiled[0]!.matched).toBe(0);
   });
 
   it("returns a stats array shaped like RuntimeFaultStats", () => {
     const compiled = compileRuntimeFaults([{ name: "f", action: { kind: "flaky-fetch" } }]);
-    const out = mergeRuntimeStats(compiled, { f: { matched: 5, fired: 3 } });
+    const out = mergeRuntimeStats(compiled, { "0": { matched: 5, fired: 3 } });
     expect(out).toEqual([{ rule: "f", matched: 5, fired: 3 }]);
+  });
+
+  it("falls back to a name-keyed snapshot for the first matching fault", () => {
+    // Backwards-compat path: when reading legacy snapshots that keyed
+    // by name, the merge applies the count to the first compiled fault
+    // with that name and skips the rest.
+    const compiled = compileRuntimeFaults([
+      { name: "shared", action: { kind: "flaky-fetch" } },
+      { name: "shared", action: { kind: "flaky-fetch" } },
+    ]);
+    mergeRuntimeStats(compiled, { shared: { matched: 4, fired: 2 } });
+    expect(compiled[0]!.matched).toBe(4);
+    expect(compiled[0]!.fired).toBe(2);
+    expect(compiled[1]!.matched).toBe(0);
+    expect(compiled[1]!.fired).toBe(0);
   });
 });
 

--- a/src/runtime-faults.test.ts
+++ b/src/runtime-faults.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import { createRng } from "./random.js";
+import {
+  buildRuntimeFaultsScript,
+  compileRuntimeFaults,
+  mergeRuntimeStats,
+  runtimeFaultName,
+  runtimeMatchesUrl,
+  shouldFireProbability,
+} from "./runtime-faults.js";
+import type { RuntimeFault } from "./types.js";
+
+describe("runtimeFaultName", () => {
+  it("uses an explicit name when set", () => {
+    expect(
+      runtimeFaultName({ name: "custom", action: { kind: "flaky-fetch" } }),
+    ).toBe("custom");
+  });
+
+  it("auto-derives a name for flaky-fetch", () => {
+    expect(runtimeFaultName({ action: { kind: "flaky-fetch" } })).toBe("flaky-fetch");
+  });
+
+  it("auto-derives a name for clock-skew including the skew amount", () => {
+    expect(
+      runtimeFaultName({ action: { kind: "clock-skew", skewMs: 60_000 } }),
+    ).toBe("clock-skew:60000ms");
+  });
+});
+
+describe("compileRuntimeFaults", () => {
+  it("returns empty array for empty input", () => {
+    expect(compileRuntimeFaults(undefined)).toEqual([]);
+    expect(compileRuntimeFaults([])).toEqual([]);
+  });
+
+  it("compiles string urlPattern to RegExp", () => {
+    const compiled = compileRuntimeFaults([
+      { urlPattern: "api", action: { kind: "flaky-fetch" } },
+    ]);
+    expect(compiled[0]!.pattern).toBeInstanceOf(RegExp);
+    expect(compiled[0]!.pattern!.test("http://x/api/users")).toBe(true);
+  });
+
+  it("preserves RegExp urlPattern verbatim", () => {
+    const re = /\/api\//i;
+    const compiled = compileRuntimeFaults([{ urlPattern: re, action: { kind: "flaky-fetch" } }]);
+    expect(compiled[0]!.pattern).toBe(re);
+  });
+
+  it("leaves pattern null when urlPattern is omitted", () => {
+    const compiled = compileRuntimeFaults([{ action: { kind: "flaky-fetch" } }]);
+    expect(compiled[0]!.pattern).toBeNull();
+  });
+
+  it("seeds counters at zero", () => {
+    const compiled = compileRuntimeFaults([{ action: { kind: "flaky-fetch" } }]);
+    expect(compiled[0]!.matched).toBe(0);
+    expect(compiled[0]!.fired).toBe(0);
+  });
+});
+
+describe("runtimeMatchesUrl", () => {
+  it("matches everything when pattern is null", () => {
+    expect(runtimeMatchesUrl({ pattern: null }, "http://x/")).toBe(true);
+  });
+
+  it("matches via the regex", () => {
+    expect(runtimeMatchesUrl({ pattern: /\/api\// }, "http://x/api/users")).toBe(true);
+    expect(runtimeMatchesUrl({ pattern: /\/api\// }, "http://x/static/foo")).toBe(false);
+  });
+});
+
+describe("shouldFireProbability", () => {
+  it("always fires when probability is undefined or >= 1", () => {
+    const rng = createRng(1);
+    expect(shouldFireProbability(undefined, rng)).toBe(true);
+    expect(shouldFireProbability(1, rng)).toBe(true);
+    expect(shouldFireProbability(2, rng)).toBe(true);
+  });
+
+  it("never fires when probability is 0 or negative", () => {
+    const rng = createRng(1);
+    expect(shouldFireProbability(0, rng)).toBe(false);
+    expect(shouldFireProbability(-1, rng)).toBe(false);
+  });
+
+  it("rolls deterministically against the RNG", () => {
+    const a = createRng(42);
+    const b = createRng(42);
+    const aFires: boolean[] = [];
+    const bFires: boolean[] = [];
+    for (let i = 0; i < 20; i++) {
+      aFires.push(shouldFireProbability(0.5, a));
+      bFires.push(shouldFireProbability(0.5, b));
+    }
+    expect(aFires).toEqual(bFires);
+  });
+});
+
+describe("buildRuntimeFaultsScript", () => {
+  it("returns a string starting with an IIFE", () => {
+    const s = buildRuntimeFaultsScript(
+      [{ action: { kind: "flaky-fetch" } }],
+      42,
+    );
+    expect(s.startsWith("(() => {")).toBe(true);
+    expect(s).toContain("__chaosbringerRuntimeFaultsInstalled");
+    expect(s).toContain("__chaosbringerRuntimeStats");
+  });
+
+  it("guards against re-installation", () => {
+    const s = buildRuntimeFaultsScript([{ action: { kind: "flaky-fetch" } }], 42);
+    expect(s).toContain("if (window.__chaosbringerRuntimeFaultsInstalled) return");
+  });
+
+  it("inlines the seed verbatim", () => {
+    const s = buildRuntimeFaultsScript([{ action: { kind: "flaky-fetch" } }], 12345);
+    expect(s).toContain("12345");
+  });
+
+  it("serializes RegExp urlPattern as { source, flags }", () => {
+    const s = buildRuntimeFaultsScript(
+      [{ urlPattern: /\/api\//i, action: { kind: "flaky-fetch" } }],
+      1,
+    );
+    expect(s).toContain('"source":"\\\\/api\\\\/"');
+    expect(s).toContain('"flags":"i"');
+  });
+
+  it("serializes string urlPattern with empty flags", () => {
+    const s = buildRuntimeFaultsScript(
+      [{ urlPattern: "/api/", action: { kind: "flaky-fetch" } }],
+      1,
+    );
+    expect(s).toContain('"source":"/api/"');
+    expect(s).toContain('"flags":""');
+  });
+
+  it("includes the fetch patch only when a flaky-fetch fault is present", () => {
+    const withFetch = buildRuntimeFaultsScript(
+      [{ action: { kind: "flaky-fetch" } }],
+      1,
+    );
+    expect(withFetch).toContain("flaky-fetch");
+    expect(withFetch).toContain("Promise.reject");
+  });
+
+  it("includes the clock-skew patch only when a clock-skew fault is present", () => {
+    const skewed = buildRuntimeFaultsScript(
+      [{ action: { kind: "clock-skew", skewMs: 5000 } }],
+      1,
+    );
+    expect(skewed).toContain("clock-skew");
+    expect(skewed).toContain("performance.now");
+    expect(skewed).toContain("Date.now");
+  });
+
+  it("uses the fault's auto-derived name as the stats key", () => {
+    const s = buildRuntimeFaultsScript(
+      [{ action: { kind: "flaky-fetch" } }, { action: { kind: "clock-skew", skewMs: 1000 } }],
+      1,
+    );
+    expect(s).toContain('"name":"flaky-fetch"');
+    expect(s).toContain('"name":"clock-skew:1000ms"');
+  });
+
+  it("respects an explicit fault name", () => {
+    const s = buildRuntimeFaultsScript(
+      [{ name: "spy", action: { kind: "flaky-fetch" } }],
+      1,
+    );
+    expect(s).toContain('"name":"spy"');
+  });
+
+  it("is a no-op when no faults are configured (still emits the IIFE shell)", () => {
+    const s = buildRuntimeFaultsScript([], 1);
+    expect(s.startsWith("(() => {")).toBe(true);
+    expect(s).toContain("__chaosbringerRuntimeFaultsInstalled");
+  });
+
+  it("accepts negative seed by coercing into an unsigned 32-bit", () => {
+    const s = buildRuntimeFaultsScript([{ action: { kind: "flaky-fetch" } }], -1);
+    // -1 coerced to uint32 is 4294967295.
+    expect(s).toContain("4294967295");
+  });
+});
+
+describe("mergeRuntimeStats", () => {
+  it("accumulates per-page counters into the compiled fault counters", () => {
+    const compiled = compileRuntimeFaults([
+      { name: "f1", action: { kind: "flaky-fetch" } },
+      { name: "c1", action: { kind: "clock-skew", skewMs: 100 } },
+    ]);
+    mergeRuntimeStats(compiled, { f1: { matched: 3, fired: 2 } });
+    expect(compiled[0]!.matched).toBe(3);
+    expect(compiled[0]!.fired).toBe(2);
+    expect(compiled[1]!.matched).toBe(0);
+    expect(compiled[1]!.fired).toBe(0);
+    mergeRuntimeStats(compiled, { f1: { matched: 1, fired: 1 } });
+    expect(compiled[0]!.matched).toBe(4);
+    expect(compiled[0]!.fired).toBe(3);
+  });
+
+  it("ignores stats keys that don't correspond to a compiled fault", () => {
+    const compiled = compileRuntimeFaults([{ name: "known", action: { kind: "flaky-fetch" } }]);
+    mergeRuntimeStats(compiled, { ghost: { matched: 99, fired: 99 } });
+    expect(compiled[0]!.matched).toBe(0);
+  });
+
+  it("returns a stats array shaped like RuntimeFaultStats", () => {
+    const compiled = compileRuntimeFaults([{ name: "f", action: { kind: "flaky-fetch" } }]);
+    const out = mergeRuntimeStats(compiled, { f: { matched: 5, fired: 3 } });
+    expect(out).toEqual([{ rule: "f", matched: 5, fired: 3 }]);
+  });
+});
+
+describe("faults.flakyFetch / faults.clockSkew round-trip via compile", () => {
+  it("compiles a programmatic fault config without errors", () => {
+    const faults: RuntimeFault[] = [
+      { action: { kind: "flaky-fetch", rejectionMessage: "oops" }, probability: 0.5 },
+      { action: { kind: "clock-skew", skewMs: 30_000 } },
+    ];
+    const compiled = compileRuntimeFaults(faults);
+    expect(compiled).toHaveLength(2);
+    expect(compiled[0]!.name).toBe("flaky-fetch");
+    expect(compiled[1]!.name).toBe("clock-skew:30000ms");
+  });
+});

--- a/src/runtime-faults.ts
+++ b/src/runtime-faults.ts
@@ -1,0 +1,232 @@
+/**
+ * JS-runtime fault injection.
+ *
+ * Distinct from `FaultRule` (request-scoped, applied via Playwright `route()`)
+ * and `LifecycleFault` (one-shot at named stages of a page visit). These are
+ * persistent monkey-patches injected into every page via `addInitScript`,
+ * subverting in-page JS APIs (fetch / Date / storage / addEventListener) so
+ * the app sees client-side failures that no network mock would expose.
+ *
+ * Examples:
+ *   - `flaky-fetch`: `window.fetch` rejects with a TypeError before any
+ *     network round-trip — simulates "Failed to fetch" / DNS down / Service
+ *     Worker reject. Different from `faults.status(500)`, which still
+ *     resolves the promise.
+ *   - `clock-skew`: `Date.now` / `performance.now` are shifted forward by N
+ *     ms — exposes token-expiry / cache-bust bugs on long sessions.
+ *
+ * Pure helpers (`buildRuntimeFaultsScript`, `runtimeFaultName`,
+ * `compileRuntimeFaults`) generate / serialize the init script and roll
+ * probability — unit-testable without a browser. Stats are reported by the
+ * in-page script via a known `window.__chaosbringerRuntimeStats` global; the
+ * crawler reads it after each page visit.
+ */
+
+import type { Rng } from "./random.js";
+import type { RuntimeFault, RuntimeFaultStats, UrlMatcher } from "./types.js";
+
+/** Compiled form: regex pre-compiled, name pre-derived. */
+export interface CompiledRuntimeFault {
+  fault: RuntimeFault;
+  /** null when `fault.urlPattern` was omitted. */
+  pattern: RegExp | null;
+  name: string;
+  matched: number;
+  fired: number;
+}
+
+/** Auto-derive a stats label when the user didn't set `fault.name`. */
+export function runtimeFaultName(fault: RuntimeFault): string {
+  if (fault.name) return fault.name;
+  const a = fault.action;
+  switch (a.kind) {
+    case "flaky-fetch":
+      return "flaky-fetch";
+    case "clock-skew":
+      return `clock-skew:${a.skewMs}ms`;
+  }
+}
+
+function compilePattern(matcher: UrlMatcher | undefined): RegExp | null {
+  if (matcher === undefined) return null;
+  return matcher instanceof RegExp ? matcher : new RegExp(matcher);
+}
+
+export function compileRuntimeFaults(
+  faults: RuntimeFault[] | undefined,
+): CompiledRuntimeFault[] {
+  if (!faults || faults.length === 0) return [];
+  return faults.map((fault) => ({
+    fault,
+    pattern: compilePattern(fault.urlPattern),
+    name: runtimeFaultName(fault),
+    matched: 0,
+    fired: 0,
+  }));
+}
+
+/** True when `compiled.pattern` matches `url` (or no pattern was set). */
+export function runtimeMatchesUrl(
+  compiled: Pick<CompiledRuntimeFault, "pattern">,
+  url: string,
+): boolean {
+  return compiled.pattern === null || compiled.pattern.test(url);
+}
+
+/**
+ * Decide whether a probabilistic fault fires this time. Mirrors the
+ * lifecycle / network helpers so all three layers share a deterministic
+ * roll behaviour given the same RNG.
+ */
+export function shouldFireProbability(probability: number | undefined, rng: Rng): boolean {
+  const p = probability ?? 1;
+  if (p >= 1) return true;
+  if (p <= 0) return false;
+  return rng.next() < p;
+}
+
+/**
+ * Serialize a UrlMatcher into a structure the in-page script can rebuild
+ * without `eval`. Strings stay strings; RegExp becomes `{ source, flags }`.
+ */
+function serializeMatcher(m: UrlMatcher | undefined): { source: string; flags: string } | null {
+  if (m === undefined) return null;
+  if (m instanceof RegExp) return { source: m.source, flags: m.flags };
+  return { source: m, flags: "" };
+}
+
+/**
+ * Build the init script body. Self-contained IIFE — no closure over the
+ * caller's scope, no external imports — because Playwright serializes init
+ * scripts as plain text and runs them in a fresh frame on every navigation.
+ *
+ * `seed` lets each page roll deterministic probabilities. Pass the
+ * crawler's seed so a `(seed, runtimeFaults)` pair always produces the same
+ * pattern of injections.
+ */
+export function buildRuntimeFaultsScript(
+  faults: ReadonlyArray<RuntimeFault>,
+  seed: number,
+): string {
+  const serialized = faults.map((f) => ({
+    name: runtimeFaultName(f),
+    pattern: serializeMatcher(f.urlPattern),
+    probability: typeof f.probability === "number" ? f.probability : 1,
+    action: f.action,
+  }));
+
+  // Body of the init script. Indented for readability; whitespace is fine
+  // because Playwright won't minify it.
+  return `(() => {
+  if (typeof window === "undefined") return;
+  if (window.__chaosbringerRuntimeFaultsInstalled) return;
+  window.__chaosbringerRuntimeFaultsInstalled = true;
+  window.__chaosbringerRuntimeStats = {};
+
+  // Park-Miller LCG — small, deterministic, good enough for fault rolls.
+  let __rng = ${seed >>> 0} || 1;
+  const __nextRoll = () => {
+    __rng = ((__rng * 16807) % 2147483647) | 0;
+    if (__rng <= 0) __rng += 2147483647;
+    return (__rng - 1) / 2147483646;
+  };
+
+  const faults = ${JSON.stringify(serialized)};
+  const stats = window.__chaosbringerRuntimeStats;
+  for (const f of faults) stats[f.name] = { matched: 0, fired: 0 };
+
+  const matchUrl = (pattern, url) => {
+    if (!pattern) return true;
+    try {
+      return new RegExp(pattern.source, pattern.flags).test(url);
+    } catch {
+      return false;
+    }
+  };
+
+  const roll = (f) => {
+    stats[f.name].matched++;
+    if (f.probability >= 1) {
+      stats[f.name].fired++;
+      return true;
+    }
+    if (f.probability <= 0) return false;
+    const fired = __nextRoll() < f.probability;
+    if (fired) stats[f.name].fired++;
+    return fired;
+  };
+
+  // --- flaky-fetch ---
+  const fetchFaults = faults.filter((f) => f.action.kind === "flaky-fetch");
+  if (fetchFaults.length > 0 && typeof window.fetch === "function") {
+    const realFetch = window.fetch.bind(window);
+    window.fetch = function chaosFetch(input, init) {
+      const url =
+        typeof input === "string" ? input :
+        input instanceof URL ? input.toString() :
+        (input && typeof input.url === "string") ? input.url :
+        "";
+      for (const f of fetchFaults) {
+        if (matchUrl(f.pattern, url) && roll(f)) {
+          const msg = f.action.rejectionMessage || "chaosbringer: simulated fetch failure";
+          return Promise.reject(new TypeError(msg));
+        }
+      }
+      return realFetch(input, init);
+    };
+  }
+
+  // --- clock-skew ---
+  const skewFaults = faults.filter((f) => f.action.kind === "clock-skew");
+  if (skewFaults.length > 0) {
+    let totalSkew = 0;
+    for (const f of skewFaults) {
+      if (matchUrl(f.pattern, location.href) && roll(f)) {
+        totalSkew += f.action.skewMs | 0;
+      }
+    }
+    if (totalSkew !== 0) {
+      const realDateNow = Date.now.bind(Date);
+      Date.now = () => realDateNow() + totalSkew;
+      const realPerfNow = performance.now.bind(performance);
+      performance.now = () => realPerfNow() + totalSkew;
+      // Patch the Date constructor so \`new Date()\` (no args) also skews.
+      const RealDate = Date;
+      const SkewedDate = function (...args) {
+        if (args.length === 0) return new RealDate(realDateNow() + totalSkew);
+        // @ts-ignore
+        return new RealDate(...args);
+      };
+      SkewedDate.now = Date.now;
+      SkewedDate.UTC = RealDate.UTC;
+      SkewedDate.parse = RealDate.parse;
+      SkewedDate.prototype = RealDate.prototype;
+      // @ts-ignore
+      window.Date = SkewedDate;
+    }
+  }
+})();`;
+}
+
+/**
+ * Read the in-page stats counter and merge into the compiled-fault counters
+ * (`matched` and `fired`). Returns the merged stats; the compiled-fault
+ * objects are mutated in place so the next page picks up where this one
+ * left off.
+ */
+export function mergeRuntimeStats(
+  compiled: CompiledRuntimeFault[],
+  pageStats: Record<string, { matched: number; fired: number }>,
+): RuntimeFaultStats[] {
+  for (const c of compiled) {
+    const ps = pageStats[c.name];
+    if (!ps) continue;
+    c.matched += ps.matched;
+    c.fired += ps.fired;
+  }
+  return compiled.map((c) => ({
+    rule: c.name,
+    matched: c.matched,
+    fired: c.fired,
+  }));
+}

--- a/src/runtime-faults.ts
+++ b/src/runtime-faults.ts
@@ -108,7 +108,11 @@ export function buildRuntimeFaultsScript(
   faults: ReadonlyArray<RuntimeFault>,
   seed: number,
 ): string {
-  const serialized = faults.map((f) => ({
+  // Stats keys are indices, not names — two faults can legitimately share
+  // a name (`flaky-fetch` x2 with different urlPatterns) and we mustn't
+  // collapse their counters.
+  const serialized = faults.map((f, i) => ({
+    id: i,
     name: runtimeFaultName(f),
     pattern: serializeMatcher(f.urlPattern),
     probability: typeof f.probability === "number" ? f.probability : 1,
@@ -133,7 +137,7 @@ export function buildRuntimeFaultsScript(
 
   const faults = ${JSON.stringify(serialized)};
   const stats = window.__chaosbringerRuntimeStats;
-  for (const f of faults) stats[f.name] = { matched: 0, fired: 0 };
+  for (const f of faults) stats[String(f.id)] = { matched: 0, fired: 0 };
 
   const matchUrl = (pattern, url) => {
     if (!pattern) return true;
@@ -145,14 +149,15 @@ export function buildRuntimeFaultsScript(
   };
 
   const roll = (f) => {
-    stats[f.name].matched++;
+    const slot = stats[String(f.id)];
+    slot.matched++;
     if (f.probability >= 1) {
-      stats[f.name].fired++;
+      slot.fired++;
       return true;
     }
     if (f.probability <= 0) return false;
     const fired = __nextRoll() < f.probability;
-    if (fired) stats[f.name].fired++;
+    if (fired) slot.fired++;
     return fired;
   };
 
@@ -179,10 +184,12 @@ export function buildRuntimeFaultsScript(
   // --- clock-skew ---
   const skewFaults = faults.filter((f) => f.action.kind === "clock-skew");
   if (skewFaults.length > 0) {
+    // Use a plain accumulator. Multi-day skews (e.g. 30 days ~ 2.6e9 ms)
+    // exceed int32 max, so any '| 0' truncation here would flip them negative.
     let totalSkew = 0;
     for (const f of skewFaults) {
       if (matchUrl(f.pattern, location.href) && roll(f)) {
-        totalSkew += f.action.skewMs | 0;
+        totalSkew += Number(f.action.skewMs);
       }
     }
     if (totalSkew !== 0) {
@@ -213,16 +220,33 @@ export function buildRuntimeFaultsScript(
  * (`matched` and `fired`). Returns the merged stats; the compiled-fault
  * objects are mutated in place so the next page picks up where this one
  * left off.
+ *
+ * Stats keys are array indices so two faults with the same name don't
+ * collide their counters. Both legacy name-keyed snapshots and the
+ * current index-keyed shape are accepted: name-keyed entries are applied
+ * to the first compiled fault with that name (the safe, non-collapsing
+ * fallback used when reading older traces).
  */
 export function mergeRuntimeStats(
   compiled: CompiledRuntimeFault[],
   pageStats: Record<string, { matched: number; fired: number }>,
 ): RuntimeFaultStats[] {
-  for (const c of compiled) {
-    const ps = pageStats[c.name];
-    if (!ps) continue;
-    c.matched += ps.matched;
-    c.fired += ps.fired;
+  for (let i = 0; i < compiled.length; i++) {
+    const c = compiled[i]!;
+    // Index-keyed (current shape).
+    const ps = pageStats[String(i)];
+    if (ps) {
+      c.matched += ps.matched;
+      c.fired += ps.fired;
+      continue;
+    }
+    // Backwards-compat: name-keyed (one slot per distinct name only;
+    // applied to the first compiled fault that wears that name).
+    const byName = pageStats[c.name];
+    if (byName && !compiled.slice(0, i).some((c2) => c2.name === c.name)) {
+      c.matched += byName.matched;
+      c.fired += byName.fired;
+    }
   }
   return compiled.map((c) => ({
     rule: c.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,15 @@ export interface CrawlerOptions {
    */
   lifecycleFaults?: LifecycleFault[];
   /**
+   * JS-runtime fault injection. Each fault is a persistent monkey-patch
+   * installed via `addInitScript` on every page navigation, subverting
+   * in-page JS APIs (fetch / Date / performance / etc.) so the app sees
+   * client-side failures that no network mock would expose. Distinct from
+   * `faultInjection` (request-scoped) and `lifecycleFaults` (one-shot at
+   * named stages).
+   */
+  runtimeFaults?: RuntimeFault[];
+  /**
    * Opt-in coverage-guided action selection. When enabled, the crawler
    * attaches a V8 precise-coverage collector (CDP `Profiler.takePreciseCoverage`)
    * to every page, attributes per-action coverage deltas to the target that
@@ -330,6 +339,55 @@ export interface LifecycleFaultStats {
   errored: number;
 }
 
+/**
+ * What a runtime fault does when it fires. Each kind is a persistent
+ * monkey-patch installed in every page via `addInitScript`.
+ */
+export type RuntimeAction =
+  /**
+   * Reject `window.fetch` calls before any network round-trip. Different
+   * from a network `Fault` of kind `"abort"`: `flaky-fetch` rejects the
+   * Promise client-side with a TypeError, simulating "Failed to fetch" /
+   * Service Worker reject / DNS failure.
+   */
+  | { kind: "flaky-fetch"; rejectionMessage?: string }
+  /**
+   * Skew `Date.now()` / `performance.now()` (and the no-arg `Date`
+   * constructor) forward by `skewMs`. Useful for forcing token-expiry,
+   * cache-bust, and "clock drift" code paths.
+   */
+  | { kind: "clock-skew"; skewMs: number };
+
+/**
+ * Page-level JS-runtime fault. Installed via `addInitScript` on every page
+ * navigation. Distinct from `FaultRule` (request-scoped) and
+ * `LifecycleFault` (one-shot at named stages of a page visit).
+ */
+export interface RuntimeFault {
+  /** Optional human-readable name used in stats. Auto-derived when omitted. */
+  name?: string;
+  /**
+   * Restrict to pages whose URL matches this matcher. Omitted = applies on
+   * every page. The check happens inside the page (against `location.href`),
+   * so the matcher must be JSON-serializable (string regex or RegExp literal).
+   */
+  urlPattern?: UrlMatcher;
+  /** 0..1, default 1.0. Rolled per call against an in-page seeded RNG. */
+  probability?: number;
+  /** What to do when the fault fires. */
+  action: RuntimeAction;
+}
+
+/** Per-fault stats for runtime fault injection, emitted on the final report. */
+export interface RuntimeFaultStats {
+  /** `name` from the `RuntimeFault`, or an auto-derived label. */
+  rule: string;
+  /** Times the fault was tested (URL matched, probability about to roll). */
+  matched: number;
+  /** Times the fault actually fired. */
+  fired: number;
+}
+
 export interface ActionWeights {
   /** Weight for navigation links (default: 3) */
   navigationLinks?: number;
@@ -583,6 +641,12 @@ export interface CrawlReport {
    * matched.
    */
   lifecycleFaults?: LifecycleFaultStats[];
+  /**
+   * Per-fault runtime fault stats (present only when `runtimeFaults` was
+   * configured). Counts are accumulated across every page visit's
+   * `window.__chaosbringerRuntimeStats` snapshot.
+   */
+  runtimeFaults?: RuntimeFaultStats[];
   /**
    * Coverage-feedback summary (present only when `coverageFeedback.enabled`
    * was true). Reports total V8 functions executed, how many pages produced

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -237,6 +237,59 @@ describe("validateOptions", () => {
     ).toThrow(/failureArtifacts.dir/);
   });
 
+  it("accepts a valid runtimeFaults config", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          runtimeFaults: [
+            { action: { kind: "flaky-fetch" } },
+            { action: { kind: "clock-skew", skewMs: 1000 }, urlPattern: /\/api\// },
+          ],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects a runtime fault probability out of [0, 1]", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          runtimeFaults: [{ action: { kind: "flaky-fetch" }, probability: 1.5 }],
+        }),
+      ),
+    ).toThrow(/probability/);
+  });
+
+  it("rejects a non-integer clock-skew", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          runtimeFaults: [{ action: { kind: "clock-skew", skewMs: 1.5 } }],
+        }),
+      ),
+    ).toThrow(/skewMs/);
+  });
+
+  it("rejects an unknown runtime fault action kind", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          runtimeFaults: [{ action: { kind: "made-up" as never } }],
+        }),
+      ),
+    ).toThrow(/action.kind/);
+  });
+
+  it("rejects a malformed runtime fault urlPattern", () => {
+    expect(() =>
+      validateOptions(
+        base({
+          runtimeFaults: [{ action: { kind: "flaky-fetch" }, urlPattern: "(" }],
+        }),
+      ),
+    ).toThrow(/urlPattern/);
+  });
+
   it("rejects a negative maxArtifacts", () => {
     expect(() =>
       validateOptions(base({ failureArtifacts: { dir: "./x", maxArtifacts: -1 } }))


### PR DESCRIPTION
## Summary

A third fault layer alongside request-scoped `FaultRule` and stage-scoped `LifecycleFault`. Each entry is a persistent monkey-patch installed via `addInitScript` on every page navigation, subverting in-page JS APIs:

- **`flaky-fetch`** — `window.fetch` rejects with a TypeError before any network round-trip, simulating "Failed to fetch" / Service Worker reject / DNS failure. Different from `faults.abort()` (Playwright `route` aborts the request from the network side) — here the Promise is rejected client-side, so app-side `try/catch` and Service-Worker fallbacks engage exactly as they would for a real network failure.
- **`clock-skew`** — `Date.now` / `performance.now` / no-arg `Date` constructor shift forward by `skewMs`. Surfaces token-expiry, cache-bust, and "clock drift" code paths without waiting real time.

| Layer | Where it runs | Targets |
| --- | --- | --- |
| `faultInjection` | Playwright `route()` (Node side) | individual network requests |
| `lifecycleFaults` | per-page hook (CDP / page eval) | one-shot at named stages |
| `runtimeFaults` | `addInitScript` (in-page) | persistent JS API patches |

### Implementation notes

- The init script is generated by a pure helper (`buildRuntimeFaultsScript(faults, seed)`) — no closures, plain string output Playwright serializes verbatim.
- Seeded from `this.rng.seed`, so `(seed, runtimeFaults)` is fully deterministic. The in-page LCG matches Park-Miller used elsewhere.
- Stats land via `window.__chaosbringerRuntimeStats` and the crawler reads them per-page (before recovery navigation, so they don't get overwritten).
- `report.runtimeFaults` is a new field with `{ rule, matched, fired }` rows.
- `RegExp` patterns survive serialization as `{ source, flags }` and are rebuilt in the page.
- Builders: `faults.flakyFetch(opts?)`, `faults.clockSkew(skewMs, opts?)`.
- `validateOptions` enforces probability range, integer `skewMs`, regex `urlPattern`, and known `action.kind`.

Programmatic-only (matches the other fault layers — they're not expressible as flat shell flags).

## Test plan

- [x] `pnpm build` — clean.
- [x] `pnpm vitest run --exclude 'fixtures/**'` — 392/392 (28 new in `runtime-faults.test.ts`, 5 in `validate.test.ts`).
- [x] `pnpm lint:nul` — clean.
- [x] README: feature bullet, new `## Runtime faults (in-page monkey-patches)` section explaining the three-layer model.
- [ ] End-to-end smoke test (skipped — Playwright chromium not installed in sandbox).

https://claude.ai/code/session_01AQUdaSBMCaR9n3UKLuVQin

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQUdaSBMCaR9n3UKLuVQin)_