### PR TITLE
feat(advisor): action advisor interface + budget plumbing (no provider)

### DIFF
--- a/src/advisor/budget.test.ts
+++ b/src/advisor/budget.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { AdvisorBudget, StallTracker } from "./budget.js";
+
+describe("AdvisorBudget", () => {
+  it("starts with zero calls", () => {
+    const b = new AdvisorBudget();
+    expect(b.callsThisCrawl()).toBe(0);
+    expect(b.callsThisPage("/foo")).toBe(0);
+  });
+
+  it("counts crawl-wide and per-page independently", () => {
+    const b = new AdvisorBudget();
+    b.recordCall("/foo");
+    b.recordCall("/foo");
+    b.recordCall("/bar");
+    expect(b.callsThisCrawl()).toBe(3);
+    expect(b.callsThisPage("/foo")).toBe(2);
+    expect(b.callsThisPage("/bar")).toBe(1);
+    expect(b.callsThisPage("/baz")).toBe(0);
+  });
+
+  it("resetPage zeroes only the named page", () => {
+    const b = new AdvisorBudget();
+    b.recordCall("/foo");
+    b.recordCall("/foo");
+    b.recordCall("/bar");
+    b.resetPage("/foo");
+    expect(b.callsThisPage("/foo")).toBe(0);
+    expect(b.callsThisPage("/bar")).toBe(1);
+    expect(b.callsThisCrawl()).toBe(3);
+  });
+});
+
+describe("StallTracker", () => {
+  it("starts not stalled and without invariant violation", () => {
+    const s = new StallTracker();
+    expect(s.consecutiveZeroNovelty()).toBe(0);
+    expect(s.invariantViolationPending()).toBe(false);
+  });
+
+  it("recordZeroNovelty increments the counter", () => {
+    const s = new StallTracker();
+    s.recordZeroNovelty();
+    s.recordZeroNovelty();
+    expect(s.consecutiveZeroNovelty()).toBe(2);
+  });
+
+  it("recordNovelty resets the stall counter", () => {
+    const s = new StallTracker();
+    s.recordZeroNovelty();
+    s.recordZeroNovelty();
+    s.recordNovelty();
+    expect(s.consecutiveZeroNovelty()).toBe(0);
+  });
+
+  it("recordInvariantViolation sets the flag", () => {
+    const s = new StallTracker();
+    s.recordInvariantViolation();
+    expect(s.invariantViolationPending()).toBe(true);
+  });
+
+  it("recordAdvisorPick clears stall and invariant flag", () => {
+    const s = new StallTracker();
+    s.recordZeroNovelty();
+    s.recordZeroNovelty();
+    s.recordInvariantViolation();
+    s.recordAdvisorPick();
+    expect(s.consecutiveZeroNovelty()).toBe(0);
+    expect(s.invariantViolationPending()).toBe(false);
+  });
+
+  it("resetForNewPage clears stall and invariant flag", () => {
+    const s = new StallTracker();
+    s.recordZeroNovelty();
+    s.recordInvariantViolation();
+    s.resetForNewPage();
+    expect(s.consecutiveZeroNovelty()).toBe(0);
+    expect(s.invariantViolationPending()).toBe(false);
+  });
+});

--- a/src/advisor/budget.ts
+++ b/src/advisor/budget.ts
@@ -1,0 +1,63 @@
+/**
+ * Budget + stall tracking for the action advisor. Both classes are
+ * crawler-internal state holders; they are intentionally not exported
+ * from `src/index.ts` because users never construct them directly —
+ * the crawler owns one of each per run.
+ */
+
+export class AdvisorBudget {
+  #total = 0;
+  #perPage = new Map<string, number>();
+
+  recordCall(url: string): void {
+    this.#total += 1;
+    this.#perPage.set(url, (this.#perPage.get(url) ?? 0) + 1);
+  }
+
+  callsThisCrawl(): number {
+    return this.#total;
+  }
+
+  callsThisPage(url: string): number {
+    return this.#perPage.get(url) ?? 0;
+  }
+
+  resetPage(url: string): void {
+    this.#perPage.delete(url);
+  }
+}
+
+export class StallTracker {
+  #consecutive = 0;
+  #invariantPending = false;
+
+  recordZeroNovelty(): void {
+    this.#consecutive += 1;
+  }
+
+  recordNovelty(): void {
+    this.#consecutive = 0;
+  }
+
+  recordInvariantViolation(): void {
+    this.#invariantPending = true;
+  }
+
+  recordAdvisorPick(): void {
+    this.#consecutive = 0;
+    this.#invariantPending = false;
+  }
+
+  resetForNewPage(): void {
+    this.#consecutive = 0;
+    this.#invariantPending = false;
+  }
+
+  consecutiveZeroNovelty(): number {
+    return this.#consecutive;
+  }
+
+  invariantViolationPending(): boolean {
+    return this.#invariantPending;
+  }
+}

--- a/src/advisor/consult.test.ts
+++ b/src/advisor/consult.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import { AdvisorBudget, StallTracker } from "./budget.js";
+import { consultAdvisor, type ConsultDeps } from "./consult.js";
+import { defaultTriggerPolicy } from "./trigger.js";
+import type { ActionAdvisor, AdvisorCandidate } from "./types.js";
+
+const sampleScreenshot = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+const sampleCandidates = (): AdvisorCandidate[] => [
+  { index: 0, selector: "#a", description: "button A" },
+  { index: 1, selector: "#b", description: "button B" },
+  { index: 2, selector: "#c", description: "button C" },
+];
+
+const makeProvider = (
+  suggest: ActionAdvisor["suggest"],
+  name = "mock",
+): ActionAdvisor => ({
+  name,
+  suggest,
+});
+
+const baseDeps = (overrides: Partial<ConsultDeps> = {}): ConsultDeps => {
+  const stall = new StallTracker();
+  for (let i = 0; i < 5; i += 1) stall.recordZeroNovelty();
+  return {
+    state: {
+      callsThisCrawl: 0,
+      callsThisPage: 0,
+      consecutiveZeroNovelty: stall.consecutiveZeroNovelty(),
+      pendingInvariantViolation: stall.invariantViolationPending(),
+    },
+    policy: defaultTriggerPolicy(),
+    budget: new AdvisorBudget(),
+    provider: makeProvider(async () => ({ chosenIndex: 0, reasoning: "ok" })),
+    url: "https://example.test/page",
+    candidates: sampleCandidates(),
+    screenshotSupplier: async () => sampleScreenshot,
+    timeoutMs: 1_000,
+    ...overrides,
+  };
+};
+
+describe("consultAdvisor", () => {
+  it("returns null without calling the provider when trigger declines", async () => {
+    const provider = makeProvider(vi.fn(async () => ({ chosenIndex: 0, reasoning: "x" })));
+    const deps = baseDeps({
+      provider,
+      state: {
+        callsThisCrawl: 0,
+        callsThisPage: 0,
+        consecutiveZeroNovelty: 0,
+        pendingInvariantViolation: false,
+      },
+    });
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("skipped");
+    expect(result.suggestion).toBeNull();
+    expect(provider.suggest).not.toHaveBeenCalled();
+    expect(deps.budget.callsThisCrawl()).toBe(0);
+  });
+
+  it("does not request a screenshot when trigger declines", async () => {
+    const screenshotSupplier = vi.fn(async () => sampleScreenshot);
+    const deps = baseDeps({
+      screenshotSupplier,
+      state: {
+        callsThisCrawl: 0,
+        callsThisPage: 0,
+        consecutiveZeroNovelty: 0,
+        pendingInvariantViolation: false,
+      },
+    });
+    await consultAdvisor(deps);
+    expect(screenshotSupplier).not.toHaveBeenCalled();
+  });
+
+  it("calls the provider and records budget on success", async () => {
+    const deps = baseDeps();
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("consulted");
+    expect(result.suggestion).toEqual({ chosenIndex: 0, reasoning: "ok" });
+    expect(deps.budget.callsThisCrawl()).toBe(1);
+    expect(deps.budget.callsThisPage(deps.url)).toBe(1);
+  });
+
+  it("treats provider returning null as soft_fail and still records budget", async () => {
+    const deps = baseDeps({ provider: makeProvider(async () => null) });
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("soft_fail");
+    expect(result.suggestion).toBeNull();
+    expect(deps.budget.callsThisCrawl()).toBe(1);
+  });
+
+  it("rejects out-of-range chosenIndex", async () => {
+    const deps = baseDeps({
+      provider: makeProvider(async () => ({ chosenIndex: 99, reasoning: "bad" })),
+    });
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("out_of_range");
+    expect(result.suggestion).toBeNull();
+    expect(deps.budget.callsThisCrawl()).toBe(1);
+  });
+
+  it("rejects negative chosenIndex", async () => {
+    const deps = baseDeps({
+      provider: makeProvider(async () => ({ chosenIndex: -1, reasoning: "bad" })),
+    });
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("out_of_range");
+  });
+
+  it("catches provider throws and records budget", async () => {
+    const deps = baseDeps({
+      provider: makeProvider(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("threw");
+    expect(result.suggestion).toBeNull();
+    expect(deps.budget.callsThisCrawl()).toBe(1);
+  });
+
+  it("returns timeout when provider exceeds timeoutMs", async () => {
+    const deps = baseDeps({
+      timeoutMs: 30,
+      provider: makeProvider(
+        () => new Promise((resolve) => setTimeout(() => resolve({ chosenIndex: 0, reasoning: "late" }), 200)),
+      ),
+    });
+    const result = await consultAdvisor(deps);
+    expect(result.outcome).toBe("timeout");
+    expect(result.suggestion).toBeNull();
+    expect(deps.budget.callsThisCrawl()).toBe(1);
+  });
+
+  it("passes through reason from trigger decision into the context", async () => {
+    const seen: string[] = [];
+    const deps = baseDeps({
+      provider: makeProvider(async (ctx) => {
+        seen.push(ctx.reason);
+        return { chosenIndex: 0, reasoning: "ok" };
+      }),
+      state: {
+        callsThisCrawl: 0,
+        callsThisPage: 0,
+        consecutiveZeroNovelty: 0,
+        pendingInvariantViolation: true,
+      },
+    });
+    await consultAdvisor(deps);
+    expect(seen).toEqual(["invariant_violation"]);
+  });
+
+  it("computes budgetRemaining from the policy minus current crawl-wide calls", async () => {
+    const seen: number[] = [];
+    const budget = new AdvisorBudget();
+    budget.recordCall("https://example.test/page");
+    budget.recordCall("https://example.test/page");
+    const deps = baseDeps({
+      budget,
+      state: {
+        callsThisCrawl: 2,
+        callsThisPage: 2,
+        consecutiveZeroNovelty: 5,
+        pendingInvariantViolation: false,
+      },
+      provider: makeProvider(async (ctx) => {
+        seen.push(ctx.budgetRemaining);
+        return { chosenIndex: 0, reasoning: "ok" };
+      }),
+    });
+    await consultAdvisor(deps);
+    expect(seen).toEqual([20 - 2 - 1]);
+  });
+});

--- a/src/advisor/consult.ts
+++ b/src/advisor/consult.ts
@@ -1,0 +1,96 @@
+/**
+ * Orchestrator that ties trigger policy + budget + provider together.
+ * The crawler calls `consultAdvisor` once per chaos action attempt; the
+ * policy decides whether to actually invoke the model. Soft failures —
+ * provider returning null, throwing, timing out, returning an
+ * out-of-range index — all collapse to a null suggestion so the caller
+ * can fall back to its heuristic without branching on every failure
+ * mode.
+ */
+
+import { AdvisorBudget } from "./budget.js";
+import { decideTrigger, type TriggerDecision, type TriggerPolicy, type TriggerState } from "./trigger.js";
+import type { ActionAdvisor, AdvisorCandidate, AdvisorSuggestion } from "./types.js";
+
+export interface ConsultDeps {
+  state: TriggerState;
+  policy: TriggerPolicy;
+  budget: AdvisorBudget;
+  provider: ActionAdvisor;
+  url: string;
+  candidates: AdvisorCandidate[];
+  screenshotSupplier: () => Promise<Buffer>;
+  timeoutMs: number;
+}
+
+export type ConsultOutcome =
+  | "consulted"
+  | "skipped"
+  | "soft_fail"
+  | "out_of_range"
+  | "timeout"
+  | "threw";
+
+export interface ConsultResult {
+  suggestion: AdvisorSuggestion | null;
+  decision: TriggerDecision;
+  outcome: ConsultOutcome;
+  durationMs?: number;
+}
+
+const TIMEOUT_SENTINEL = Symbol("advisor-timeout");
+
+export async function consultAdvisor(deps: ConsultDeps): Promise<ConsultResult> {
+  const decision = decideTrigger(deps.state, deps.policy, deps.candidates.length);
+  if (!decision.consult || !decision.reason) {
+    return { suggestion: null, decision, outcome: "skipped" };
+  }
+
+  // Reserve the budget slot up-front so concurrent attempts (future feature)
+  // cannot oversubscribe the cap. Soft failures still consume budget — a
+  // failed call still cost the wall clock and may have cost money.
+  deps.budget.recordCall(deps.url);
+
+  const screenshot = await deps.screenshotSupplier();
+  const remaining = Math.max(0, deps.policy.maxCallsPerCrawl - deps.budget.callsThisCrawl());
+
+  const start = Date.now();
+  let raw: AdvisorSuggestion | null | typeof TIMEOUT_SENTINEL;
+  try {
+    raw = await Promise.race([
+      deps.provider.suggest({
+        url: deps.url,
+        screenshot,
+        candidates: deps.candidates,
+        reason: decision.reason,
+        budgetRemaining: remaining,
+      }),
+      new Promise<typeof TIMEOUT_SENTINEL>((resolve) =>
+        setTimeout(() => resolve(TIMEOUT_SENTINEL), deps.timeoutMs),
+      ),
+    ]);
+  } catch {
+    return {
+      suggestion: null,
+      decision,
+      outcome: "threw",
+      durationMs: Date.now() - start,
+    };
+  }
+  const durationMs = Date.now() - start;
+
+  if (raw === TIMEOUT_SENTINEL) {
+    return { suggestion: null, decision, outcome: "timeout", durationMs };
+  }
+  if (raw === null) {
+    return { suggestion: null, decision, outcome: "soft_fail", durationMs };
+  }
+  if (
+    !Number.isInteger(raw.chosenIndex) ||
+    raw.chosenIndex < 0 ||
+    raw.chosenIndex >= deps.candidates.length
+  ) {
+    return { suggestion: null, decision, outcome: "out_of_range", durationMs };
+  }
+  return { suggestion: raw, decision, outcome: "consulted", durationMs };
+}

--- a/src/advisor/trigger.test.ts
+++ b/src/advisor/trigger.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { decideTrigger, defaultTriggerPolicy, type TriggerPolicy, type TriggerState } from "./trigger.js";
+
+const baseState = (): TriggerState => ({
+  callsThisCrawl: 0,
+  callsThisPage: 0,
+  consecutiveZeroNovelty: 0,
+  pendingInvariantViolation: false,
+});
+
+const policy = (overrides: Partial<TriggerPolicy> = {}): TriggerPolicy => ({
+  ...defaultTriggerPolicy(),
+  ...overrides,
+});
+
+describe("decideTrigger", () => {
+  it("does not consult below the novelty stall threshold", () => {
+    const decision = decideTrigger(
+      { ...baseState(), consecutiveZeroNovelty: 4 },
+      policy({ noveltyStallThreshold: 5 }),
+      10,
+    );
+    expect(decision.consult).toBe(false);
+    expect(decision.skipReason).toBe("not_stalled");
+  });
+
+  it("consults when novelty stall threshold reached", () => {
+    const decision = decideTrigger(
+      { ...baseState(), consecutiveZeroNovelty: 5 },
+      policy({ noveltyStallThreshold: 5 }),
+      10,
+    );
+    expect(decision.consult).toBe(true);
+    expect(decision.reason).toBe("novelty_stall");
+  });
+
+  it("consults on invariant violation regardless of novelty", () => {
+    const decision = decideTrigger(
+      { ...baseState(), pendingInvariantViolation: true },
+      policy({ noveltyStallThreshold: 999, consultOnInvariantViolation: true }),
+      10,
+    );
+    expect(decision.consult).toBe(true);
+    expect(decision.reason).toBe("invariant_violation");
+  });
+
+  it("skips invariant violation when consultOnInvariantViolation is false", () => {
+    const decision = decideTrigger(
+      { ...baseState(), pendingInvariantViolation: true },
+      policy({ noveltyStallThreshold: 999, consultOnInvariantViolation: false }),
+      10,
+    );
+    expect(decision.consult).toBe(false);
+  });
+
+  it("rejects when per-crawl budget exhausted", () => {
+    const decision = decideTrigger(
+      { ...baseState(), consecutiveZeroNovelty: 99, callsThisCrawl: 20 },
+      policy({ maxCallsPerCrawl: 20 }),
+      10,
+    );
+    expect(decision.consult).toBe(false);
+    expect(decision.skipReason).toBe("budget_crawl");
+  });
+
+  it("rejects when per-page budget exhausted", () => {
+    const decision = decideTrigger(
+      { ...baseState(), consecutiveZeroNovelty: 99, callsThisPage: 3 },
+      policy({ maxCallsPerPage: 3 }),
+      10,
+    );
+    expect(decision.consult).toBe(false);
+    expect(decision.skipReason).toBe("budget_page");
+  });
+
+  it("rejects when candidates are below the minimum", () => {
+    const decision = decideTrigger(
+      { ...baseState(), consecutiveZeroNovelty: 99 },
+      policy({ minCandidatesToConsult: 3 }),
+      2,
+    );
+    expect(decision.consult).toBe(false);
+    expect(decision.skipReason).toBe("few_candidates");
+  });
+
+  it("budget rejection takes priority over not-stalled", () => {
+    const decision = decideTrigger(
+      { ...baseState(), callsThisCrawl: 20 },
+      policy({ maxCallsPerCrawl: 20, noveltyStallThreshold: 5 }),
+      10,
+    );
+    expect(decision.skipReason).toBe("budget_crawl");
+  });
+});
+
+describe("defaultTriggerPolicy", () => {
+  it("matches the design doc defaults", () => {
+    const p = defaultTriggerPolicy();
+    expect(p.maxCallsPerCrawl).toBe(20);
+    expect(p.maxCallsPerPage).toBe(3);
+    expect(p.noveltyStallThreshold).toBe(5);
+    expect(p.consultOnInvariantViolation).toBe(true);
+    expect(p.minCandidatesToConsult).toBe(3);
+  });
+});

--- a/src/advisor/trigger.ts
+++ b/src/advisor/trigger.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure trigger policy for the action advisor. Decides whether the crawler
+ * should consult the advisor on a given step, based on stall counters,
+ * pending invariant violations, and budget caps. No I/O, no provider
+ * coupling — kept pure so the policy can be unit-tested without mocking
+ * the crawler or the model.
+ *
+ * See `docs/superpowers/specs/2026-05-01-vlm-action-advisor-design.md` §4
+ * for the design rationale.
+ */
+
+export interface TriggerPolicy {
+  maxCallsPerCrawl: number;
+  maxCallsPerPage: number;
+  noveltyStallThreshold: number;
+  consultOnInvariantViolation: boolean;
+  minCandidatesToConsult: number;
+}
+
+export interface TriggerState {
+  callsThisCrawl: number;
+  callsThisPage: number;
+  consecutiveZeroNovelty: number;
+  pendingInvariantViolation: boolean;
+}
+
+export type TriggerReason = "novelty_stall" | "invariant_violation" | "explicit_request";
+
+export type TriggerSkipReason =
+  | "budget_crawl"
+  | "budget_page"
+  | "few_candidates"
+  | "not_stalled";
+
+export interface TriggerDecision {
+  consult: boolean;
+  reason?: TriggerReason;
+  skipReason?: TriggerSkipReason;
+}
+
+export function defaultTriggerPolicy(): TriggerPolicy {
+  return {
+    maxCallsPerCrawl: 20,
+    maxCallsPerPage: 3,
+    noveltyStallThreshold: 5,
+    consultOnInvariantViolation: true,
+    minCandidatesToConsult: 3,
+  };
+}
+
+export function decideTrigger(
+  state: TriggerState,
+  policy: TriggerPolicy,
+  candidateCount: number,
+): TriggerDecision {
+  if (state.callsThisCrawl >= policy.maxCallsPerCrawl) {
+    return { consult: false, skipReason: "budget_crawl" };
+  }
+  if (state.callsThisPage >= policy.maxCallsPerPage) {
+    return { consult: false, skipReason: "budget_page" };
+  }
+  if (candidateCount < policy.minCandidatesToConsult) {
+    return { consult: false, skipReason: "few_candidates" };
+  }
+
+  if (policy.consultOnInvariantViolation && state.pendingInvariantViolation) {
+    return { consult: true, reason: "invariant_violation" };
+  }
+  if (state.consecutiveZeroNovelty >= policy.noveltyStallThreshold) {
+    return { consult: true, reason: "novelty_stall" };
+  }
+  return { consult: false, skipReason: "not_stalled" };
+}

--- a/src/advisor/types.ts
+++ b/src/advisor/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Public types for the action advisor. The advisor is an opt-in second
+ * opinion the crawler consults rarely (budgeted) when its
+ * coverage-guided heuristic stalls. Default reference provider
+ * (OpenRouter google/gemini-2.5-flash) lands in a follow-up PR per
+ * `docs/superpowers/specs/2026-05-01-vlm-action-advisor-design.md` §10.
+ */
+
+export interface AdvisorCandidate {
+  /** Stable index inside the candidate batch. The advisor returns this. */
+  index: number;
+  /** Playwright selector — internal only, not sent to the model. */
+  selector: string;
+  /** What the model sees: role + accessible name + visible text. */
+  description: string;
+  /** Optional bbox in viewport coords; lets the prompt cite "the button at top-right". */
+  bbox?: { x: number; y: number; width: number; height: number };
+}
+
+export type AdvisorConsultReason =
+  | "novelty_stall"
+  | "invariant_violation"
+  | "explicit_request";
+
+export interface AdvisorContext {
+  url: string;
+  /** PNG bytes of the page screenshot at the moment of consult. */
+  screenshot: Buffer;
+  candidates: AdvisorCandidate[];
+  /** Why the crawler is asking — drives prompt framing. */
+  reason: AdvisorConsultReason;
+  /** How many advisor calls remain in this crawl, after this one. */
+  budgetRemaining: number;
+}
+
+export interface AdvisorSuggestion {
+  chosenIndex: number;
+  reasoning: string;
+  confidence?: number;
+}
+
+export interface ActionAdvisor {
+  readonly name: string;
+  /**
+   * Pick one candidate. Return `null` for soft failures (timeout, rate
+   * limit, malformed response) — the crawler will fall back to its
+   * heuristic. Hard failures (auth, network down) may throw; the crawler
+   * catches and degrades.
+   */
+  suggest(ctx: AdvisorContext): Promise<AdvisorSuggestion | null>;
+}
+
+export interface AdvisorConfig {
+  /** Required to enable. Default: undefined (advisor disabled). */
+  provider: ActionAdvisor;
+  /** Hard cap on advisor calls per crawl. Default: 20. */
+  maxCallsPerCrawl?: number;
+  /** Hard cap per page. Default: 3. */
+  maxCallsPerPage?: number;
+  /** Consult after this many consecutive zero-novelty actions. Default: 5. */
+  noveltyStallThreshold?: number;
+  /** Also consult on invariant violation. Default: true. */
+  consultOnInvariantViolation?: boolean;
+  /** Per-call timeout in ms. Default: 8000. After timeout the call returns null. */
+  timeoutMs?: number;
+  /** Skip advisor when fewer than N candidates. Default: 3. */
+  minCandidatesToConsult?: number;
+}

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -88,6 +88,10 @@ import {
   type TraceAction,
   type TraceEntry,
 } from "./trace.js";
+import { AdvisorBudget, StallTracker } from "./advisor/budget.js";
+import { consultAdvisor } from "./advisor/consult.js";
+import { defaultTriggerPolicy, type TriggerPolicy } from "./advisor/trigger.js";
+import type { ActionAdvisor, AdvisorCandidate } from "./advisor/types.js";
 
 // Options that are opt-in with no meaningful default (HAR, storage state,
 // perf budget, trace, device/network) are carved out of the Required<>
@@ -108,6 +112,7 @@ const DEFAULT_OPTIONS: Required<
     | "shardCount"
     | "failureArtifacts"
     | "coverageFeedback"
+    | "advisor"
   >
 > = {
   maxPages: 50,
@@ -159,6 +164,15 @@ export const COMMON_IGNORE_PATTERNS = [
   // Generic error message from blocked resources
   "Failed to load resource: net::ERR_FAILED$",
 ];
+
+function describeTarget(t: ActionTarget): string {
+  const parts: string[] = [];
+  if (t.role) parts.push(t.role);
+  if (t.name) parts.push(`"${t.name}"`);
+  parts.push(`(${t.type})`);
+  if (t.href) parts.push(`href=${t.href}`);
+  return parts.join(" ");
+}
 
 export class ChaosCrawler {
   private options: Required<CrawlerOptions>;
@@ -243,6 +257,14 @@ export class ChaosCrawler {
    * empty set whenever a fresh page is opened.
    */
   private lastCoverageSnapshot: Set<string> = new Set();
+  /** Resolved advisor wiring (null when the option is unset). */
+  private advisorRuntime: {
+    provider: ActionAdvisor;
+    policy: TriggerPolicy;
+    budget: AdvisorBudget;
+    stall: StallTracker;
+    timeoutMs: number;
+  } | null = null;
 
   constructor(options: CrawlerOptions, events: CrawlerEvents = {}) {
     validateOptions(options);
@@ -265,6 +287,26 @@ export class ChaosCrawler {
         enabled: true,
         boost: options.coverageFeedback.boost ?? 2,
         topN: options.coverageFeedback.topN ?? 20,
+      };
+    }
+
+    if (options.advisor) {
+      const defaults = defaultTriggerPolicy();
+      this.advisorRuntime = {
+        provider: options.advisor.provider,
+        policy: {
+          maxCallsPerCrawl: options.advisor.maxCallsPerCrawl ?? defaults.maxCallsPerCrawl,
+          maxCallsPerPage: options.advisor.maxCallsPerPage ?? defaults.maxCallsPerPage,
+          noveltyStallThreshold:
+            options.advisor.noveltyStallThreshold ?? defaults.noveltyStallThreshold,
+          consultOnInvariantViolation:
+            options.advisor.consultOnInvariantViolation ?? defaults.consultOnInvariantViolation,
+          minCandidatesToConsult:
+            options.advisor.minCandidatesToConsult ?? defaults.minCandidatesToConsult,
+        },
+        budget: new AdvisorBudget(),
+        stall: new StallTracker(),
+        timeoutMs: options.advisor.timeoutMs ?? 8_000,
       };
     }
 
@@ -448,6 +490,10 @@ export class ChaosCrawler {
     this.globalCoverage = new Set();
     this.pageCoverageDeltas = [];
     this.targetNovelty = new Map();
+    if (this.advisorRuntime) {
+      this.advisorRuntime.budget = new AdvisorBudget();
+      this.advisorRuntime.stall = new StallTracker();
+    }
 
     if (this.isRecordingTrace()) {
       this.trace.push({
@@ -824,6 +870,10 @@ export class ChaosCrawler {
    * the per-action delta baseline.
    */
   private async recordPageLoadCoverage(url: string): Promise<void> {
+    if (this.advisorRuntime) {
+      this.advisorRuntime.stall.resetForNewPage();
+      this.advisorRuntime.budget.resetPage(url);
+    }
     if (!this.coverageCollector) {
       this.lastCoverageSnapshot = new Set();
       return;
@@ -869,6 +919,7 @@ export class ChaosCrawler {
     const actionDelta = coverageDelta(this.lastCoverageSnapshot, snapshot);
     if (actionDelta.size === 0) {
       this.lastCoverageSnapshot = snapshot;
+      this.advisorRuntime?.stall.recordZeroNovelty();
       return;
     }
     const novel = coverageDelta(this.globalCoverage, actionDelta);
@@ -876,6 +927,9 @@ export class ChaosCrawler {
       const key = targetKey(url, selector);
       this.targetNovelty.set(key, (this.targetNovelty.get(key) ?? 0) + novel.size);
       for (const fp of novel) this.globalCoverage.add(fp);
+      this.advisorRuntime?.stall.recordNovelty();
+    } else {
+      this.advisorRuntime?.stall.recordZeroNovelty();
     }
     this.lastCoverageSnapshot = snapshot;
   }
@@ -888,6 +942,52 @@ export class ChaosCrawler {
     if (!this.coverageFeedback) return 1;
     const score = this.targetNovelty.get(targetKey(url, selector)) ?? 0;
     return noveltyMultiplier(score, this.coverageFeedback.boost);
+  }
+
+  private async consultAdvisorIfStalled(
+    page: Page,
+    url: string,
+    targets: ReadonlyArray<ActionTarget>,
+  ): Promise<ActionTarget | null> {
+    const runtime = this.advisorRuntime;
+    if (!runtime) return null;
+
+    const candidates: AdvisorCandidate[] = targets.map((t, index) => ({
+      index,
+      selector: t.selector,
+      description: describeTarget(t),
+    }));
+
+    const result = await consultAdvisor({
+      state: {
+        callsThisCrawl: runtime.budget.callsThisCrawl(),
+        callsThisPage: runtime.budget.callsThisPage(url),
+        consecutiveZeroNovelty: runtime.stall.consecutiveZeroNovelty(),
+        pendingInvariantViolation: runtime.stall.invariantViolationPending(),
+      },
+      policy: runtime.policy,
+      budget: runtime.budget,
+      provider: runtime.provider,
+      url,
+      candidates,
+      screenshotSupplier: () => page.screenshot({ fullPage: false }),
+      timeoutMs: runtime.timeoutMs,
+    });
+
+    if (result.outcome === "skipped") return null;
+
+    this.logger.debug("advisor_consult", {
+      url,
+      reason: result.decision.reason,
+      candidateCount: candidates.length,
+      outcome: result.outcome,
+      durationMs: result.durationMs,
+      provider: runtime.provider.name,
+    });
+
+    if (!result.suggestion) return null;
+    runtime.stall.recordAdvisorPick();
+    return targets[result.suggestion.chosenIndex] ?? null;
   }
 
   /**
@@ -1721,14 +1821,17 @@ export class ChaosCrawler {
     while (actionsPerformed < this.options.maxActionsPerPage && attempts < maxAttempts) {
       attempts++;
 
-      const selectedTarget = weightedPick(
-        targets,
-        // Coverage-guided action selection: bias picks toward targets that
-        // historically delivered new V8 coverage. `coverageWeightFor` returns
-        // 1 when feedback is off, so the no-feedback path is unchanged.
-        (t) => t.weight * this.coverageWeightFor(url, t.selector),
-        this.rng,
-      );
+      const advisorPick = await this.consultAdvisorIfStalled(page, url, targets);
+      const selectedTarget =
+        advisorPick ??
+        weightedPick(
+          targets,
+          // Coverage-guided action selection: bias picks toward targets that
+          // historically delivered new V8 coverage. `coverageWeightFor` returns
+          // 1 when feedback is off, so the no-feedback path is unchanged.
+          (t) => t.weight * this.coverageWeightFor(url, t.selector),
+          this.rng,
+        );
 
       const result = await this.performActionOnTarget(page, selectedTarget, url);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,14 @@ export {
   targetKey,
   type CoverageScriptResult,
 } from "./coverage.js";
+export type {
+  ActionAdvisor,
+  AdvisorCandidate,
+  AdvisorConfig,
+  AdvisorConsultReason,
+  AdvisorContext,
+  AdvisorSuggestion,
+} from "./advisor/types.js";
 export {
   compareScreenshotBuffers,
   formatVisualDiff,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@
  * Core types for Chaos Crawler
  */
 
+import type { AdvisorConfig } from "./advisor/types.js";
+
+export type { AdvisorConfig } from "./advisor/types.js";
+
 export interface CrawlerOptions {
   /** Base URL to start crawling */
   baseUrl: string;
@@ -138,6 +142,13 @@ export interface CrawlerOptions {
    * and the reader can reproduce locally.
    */
   failureArtifacts?: FailureArtifactsOptions;
+  /**
+   * Opt-in vision-language model advisor that picks the next action
+   * when the coverage-guided heuristic stalls. See
+   * `docs/superpowers/specs/2026-05-01-vlm-action-advisor-design.md`.
+   * Default: undefined (advisor disabled, zero overhead).
+   */
+  advisor?: AdvisorConfig;
 }
 
 export interface FailureArtifactsOptions {


### PR DESCRIPTION
## Summary

First implementation PR for the VLM action advisor (design: #38, doc: \`docs/superpowers/specs/2026-05-01-vlm-action-advisor-design.md\`). Ships the contract and integration plumbing only — **no provider, no network, no behavior change for existing crawls**.

## What's in

- \`src/advisor/types.ts\` — public \`ActionAdvisor\` / \`AdvisorConfig\` surface
- \`src/advisor/trigger.ts\` — pure \`decideTrigger()\` policy (stall + per-crawl + per-page caps + min candidates)
- \`src/advisor/budget.ts\` — \`AdvisorBudget\` + \`StallTracker\` run-state holders
- \`src/advisor/consult.ts\` — orchestrator that ties trigger + provider + budget. Collapses soft failures (\`null\` / out-of-range / timeout / throw) to a \`null\` suggestion so callers fall back to heuristic
- 28 unit tests
- \`CrawlerOptions.advisor\` wiring; \`ChaosCrawler\` initializes runtime only when configured — **zero overhead for the unconfigured default path**
- \`consultAdvisorIfStalled\` hooked into \`performWeightedActions\`; weighted-heuristic fallback when advisor declines / fails / unset
- Stall counter fed from \`attributeActionCoverage\` novelty signal; reset per page via \`recordPageLoadCoverage\`

## What's NOT in (per design doc §10)

- OpenRouter \`google/gemini-2.5-flash\` provider impl → #N+2
- Prompts asset → #N+2
- Trace recording of advisor picks + \`CrawlReport.advisor\` block → #N+3
- Hooking invariant violations into \`StallTracker.recordInvariantViolation\` (the policy and tracker support it, but the integration site is deferred to keep this PR small)

## Verified locally

- [x] \`pnpm test\` → 444/444 pass (no regressions in fixture e2e)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`node scripts/check-no-nul.mjs src fixtures scripts\` clean

## Test plan

- [ ] CI: build-and-test, chaos-crawl, flaker-merge all green
- [ ] Reviewer scans \`src/advisor/consult.ts\` outcome enum and confirms the soft-failure → null collapse matches design §6
- [ ] Reviewer scans \`performWeightedActions\` change and confirms unconfigured path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)