### PR TITLE
feat(advisor): OpenRouter Gemini Flash 2.5 provider + prompt asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "prepare": "tsc",
+    "build": "tsc && node scripts/copy-assets.mjs",
+    "prepare": "tsc && node scripts/copy-assets.mjs",
     "dev": "tsc --watch",
     "test": "vitest run",
     "lint": "biome check src/",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Copy non-TypeScript runtime assets from src/ to dist/ after `tsc`.
+ *
+ * `tsc` only emits .js / .d.ts; anything the compiled code reads from disk
+ * at runtime (e.g. the advisor prompt asset) needs to be staged into dist/
+ * so the published package and the in-repo runtime both find it.
+ *
+ * Asset patterns are intentionally kept narrow — adding a glob is fine, but
+ * do NOT widen this to "everything except .ts". A loose copier silently
+ * ships test fixtures and notes into the published tarball.
+ */
+
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SRC = join(ROOT, "src");
+const DIST = join(ROOT, "dist");
+const ASSET_EXTENSIONS = [".md"];
+
+async function walk(dir) {
+  const out = [];
+  for (const entry of await readdir(dir)) {
+    const full = join(dir, entry);
+    const stats = await stat(full);
+    if (stats.isDirectory()) {
+      out.push(...(await walk(full)));
+    } else if (ASSET_EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const assets = await walk(SRC);
+let copied = 0;
+for (const asset of assets) {
+  const rel = relative(SRC, asset);
+  const dest = join(DIST, rel);
+  await mkdir(dirname(dest), { recursive: true });
+  await writeFile(dest, await readFile(asset));
+  copied += 1;
+}
+console.log(`copy-assets: ${copied} file(s) staged from src/ to dist/`);

--- a/src/advisor/openrouter.test.ts
+++ b/src/advisor/openrouter.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import { openRouterAdvisor } from "./openrouter.js";
+import type { AdvisorContext } from "./types.js";
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+
+const sampleContext = (
+  overrides: Partial<AdvisorContext> = {},
+): AdvisorContext => ({
+  url: "https://example.test/page",
+  screenshot: PNG,
+  candidates: [
+    { index: 0, selector: "#a", description: "button A" },
+    { index: 1, selector: "#b", description: "link B" },
+    { index: 2, selector: "#c", description: "input C" },
+  ],
+  reason: "novelty_stall",
+  budgetRemaining: 19,
+  ...overrides,
+});
+
+const okBody = (chosenIndex = 1, usageUsd = 0.001) => ({
+  choices: [
+    {
+      message: {
+        content: JSON.stringify({ chosenIndex, reasoning: "the model picks B" }),
+      },
+    },
+  ],
+  usage: { total_cost: usageUsd },
+});
+
+const okResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("openRouterAdvisor", () => {
+  it("returns a suggestion on a well-formed response", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody(1)));
+    const advisor = openRouterAdvisor({ apiKey: "key", fetch: fetchMock });
+    const result = await advisor.suggest(sampleContext());
+    expect(result).toEqual({ chosenIndex: 1, reasoning: "the model picks B" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses google/gemini-2.5-flash by default and overrides via model option", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody()));
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock, model: "anthropic/claude-haiku-4.5" });
+    await advisor.suggest(sampleContext());
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.model).toBe("anthropic/claude-haiku-4.5");
+    expect(advisor.name).toContain("anthropic/claude-haiku-4.5");
+  });
+
+  it("sends the screenshot as a base64 image_url content block", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody()));
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    await advisor.suggest(sampleContext());
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    const userMsg = body.messages.find((m: { role: string }) => m.role === "user");
+    const imagePart = userMsg.content.find((c: { type: string }) => c.type === "image_url");
+    expect(imagePart.image_url.url).toMatch(/^data:image\/png;base64,/);
+    expect(imagePart.image_url.url).toContain(PNG.toString("base64"));
+  });
+
+  it("renders candidates and url into the user text content block", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody()));
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    await advisor.suggest(sampleContext());
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    const userMsg = body.messages.find((m: { role: string }) => m.role === "user");
+    const textPart = userMsg.content.find((c: { type: string }) => c.type === "text");
+    expect(textPart.text).toContain("https://example.test/page");
+    expect(textPart.text).toContain("0. button A");
+    expect(textPart.text).toContain("1. link B");
+    expect(textPart.text).toContain("novelty_stall");
+  });
+
+  it("sends the system prompt as a system message", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody()));
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    await advisor.suggest(sampleContext());
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    const systemMsg = body.messages.find((m: { role: string }) => m.role === "system");
+    expect(systemMsg).toBeDefined();
+    expect(typeof systemMsg.content).toBe("string");
+    expect(systemMsg.content.length).toBeGreaterThan(50);
+  });
+
+  it("sends the API key as a Bearer token and never logs it", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody()));
+    const advisor = openRouterAdvisor({ apiKey: "secret-key", fetch: fetchMock });
+    await advisor.suggest(sampleContext());
+    const headers = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer secret-key");
+    expect(advisor.name).not.toContain("secret-key");
+  });
+
+  it("returns null when the response is not 2xx", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("upstream timeout", {
+          status: 504,
+          headers: { "content-type": "text/plain" },
+        }),
+    );
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    expect(await advisor.suggest(sampleContext())).toBeNull();
+  });
+
+  it("returns null when the model body is not JSON", async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({
+        choices: [{ message: { content: "not json at all" } }],
+      }),
+    );
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    expect(await advisor.suggest(sampleContext())).toBeNull();
+  });
+
+  it("returns null when chosenIndex is missing", async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({
+        choices: [{ message: { content: JSON.stringify({ reasoning: "no index" }) } }],
+      }),
+    );
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    expect(await advisor.suggest(sampleContext())).toBeNull();
+  });
+
+  it("returns null when reasoning is missing", async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({
+        choices: [{ message: { content: JSON.stringify({ chosenIndex: 0 }) } }],
+      }),
+    );
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    expect(await advisor.suggest(sampleContext())).toBeNull();
+  });
+
+  it("strips fenced code blocks around the JSON before parsing", async () => {
+    const fenced = "```json\n" + JSON.stringify({ chosenIndex: 2, reasoning: "fenced" }) + "\n```";
+    const fetchMock = vi.fn(async () =>
+      okResponse({ choices: [{ message: { content: fenced } }] }),
+    );
+    const advisor = openRouterAdvisor({ apiKey: "k", fetch: fetchMock });
+    const result = await advisor.suggest(sampleContext());
+    expect(result?.chosenIndex).toBe(2);
+  });
+
+  it("does not hit the network once the USD budget is exhausted", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody(0, 0.4)));
+    const advisor = openRouterAdvisor({
+      apiKey: "k",
+      fetch: fetchMock,
+      budgetUsd: 0.5,
+    });
+    await advisor.suggest(sampleContext()); // first call: cost 0.4, total 0.4 (under budget)
+    await advisor.suggest(sampleContext()); // second call: would push to 0.8 — let it run, charge it
+    expect(await advisor.suggest(sampleContext())).toBeNull(); // third call: budget already over, no fetch
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null and skips fetch when fetch is a no-op for budget testing", async () => {
+    const fetchMock = vi.fn(async () => okResponse(okBody(0, 1)));
+    const advisor = openRouterAdvisor({
+      apiKey: "k",
+      fetch: fetchMock,
+      budgetUsd: 0.5,
+    });
+    await advisor.suggest(sampleContext());
+    expect(await advisor.suggest(sampleContext())).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/advisor/openrouter.ts
+++ b/src/advisor/openrouter.ts
@@ -1,0 +1,166 @@
+/**
+ * OpenRouter implementation of `ActionAdvisor`. Default model is
+ * `google/gemini-2.5-flash` per the design doc; any
+ * vision-capable OpenAI-compatible model OpenRouter exposes will work
+ * by overriding `model`.
+ *
+ * Soft-failure protocol: this provider returns `null` on every recoverable
+ * problem (HTTP non-2xx, malformed JSON, missing fields, USD budget
+ * exhausted). The crawler treats `null` as "no opinion, fall back to
+ * heuristic". The provider does not throw on bad model output —
+ * exceptions only escape on programmer errors (e.g. asset missing).
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parsePromptFile, renderUserPrompt, type ParsedPrompt } from "./prompts/loader.js";
+import type {
+  ActionAdvisor,
+  AdvisorCandidate,
+  AdvisorContext,
+  AdvisorSuggestion,
+} from "./types.js";
+
+export interface OpenRouterAdvisorOptions {
+  apiKey: string;
+  /** Default: "google/gemini-2.5-flash". */
+  model?: string;
+  /** Default: "https://openrouter.ai/api/v1". */
+  baseUrl?: string;
+  /** Override fetch for tests. Default: globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+  /** Cumulative USD ceiling. After this the advisor returns null without hitting the network. */
+  budgetUsd?: number;
+}
+
+const DEFAULT_MODEL = "google/gemini-2.5-flash";
+const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+
+const PROMPT_PATH = fileURLToPath(new URL("./prompts/action-selection.md", import.meta.url));
+
+let cachedPrompt: ParsedPrompt | null = null;
+
+function loadPrompt(): ParsedPrompt {
+  if (cachedPrompt) return cachedPrompt;
+  const raw = readFileSync(PROMPT_PATH, "utf8");
+  cachedPrompt = parsePromptFile(raw);
+  return cachedPrompt;
+}
+
+function formatCandidates(candidates: ReadonlyArray<AdvisorCandidate>): string {
+  return candidates.map((c) => `${c.index}. ${c.description}`).join("\n");
+}
+
+function stripCodeFence(s: string): string {
+  const trimmed = s.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/);
+  return fenced ? fenced[1].trim() : trimmed;
+}
+
+function validateSuggestion(value: unknown, candidateCount: number): AdvisorSuggestion | null {
+  if (typeof value !== "object" || value === null) return null;
+  const obj = value as Record<string, unknown>;
+  if (!Number.isInteger(obj.chosenIndex)) return null;
+  if (typeof obj.reasoning !== "string") return null;
+  const idx = obj.chosenIndex as number;
+  if (idx < 0 || idx >= candidateCount) return null;
+  const out: AdvisorSuggestion = { chosenIndex: idx, reasoning: obj.reasoning };
+  if (typeof obj.confidence === "number") out.confidence = obj.confidence;
+  return out;
+}
+
+export function openRouterAdvisor(opts: OpenRouterAdvisorOptions): ActionAdvisor {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const httpFetch = opts.fetch ?? globalThis.fetch;
+  const budgetUsd = opts.budgetUsd;
+  let costSoFarUsd = 0;
+  const prompt = loadPrompt();
+
+  return {
+    name: `openrouter/${model}`,
+
+    async suggest(ctx: AdvisorContext): Promise<AdvisorSuggestion | null> {
+      if (budgetUsd !== undefined && costSoFarUsd >= budgetUsd) return null;
+
+      const userText = renderUserPrompt(prompt.userTemplate, {
+        url: ctx.url,
+        reason: ctx.reason,
+        candidates: formatCandidates(ctx.candidates),
+        budgetRemaining: ctx.budgetRemaining,
+      });
+
+      const imageDataUrl = `data:image/png;base64,${ctx.screenshot.toString("base64")}`;
+
+      const body = {
+        model,
+        messages: [
+          { role: "system", content: prompt.system },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: userText },
+              { type: "image_url", image_url: { url: imageDataUrl } },
+            ],
+          },
+        ],
+      };
+
+      let response: Response;
+      try {
+        response = await httpFetch(`${baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${opts.apiKey}`,
+          },
+          body: JSON.stringify(body),
+        });
+      } catch {
+        return null;
+      }
+
+      if (!response.ok) return null;
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        return null;
+      }
+
+      const usageCost = extractCostUsd(parsed);
+      if (usageCost !== null) costSoFarUsd += usageCost;
+
+      const content = extractContent(parsed);
+      if (content === null) return null;
+
+      let modelJson: unknown;
+      try {
+        modelJson = JSON.parse(stripCodeFence(content));
+      } catch {
+        return null;
+      }
+
+      return validateSuggestion(modelJson, ctx.candidates.length);
+    },
+  };
+}
+
+function extractContent(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null;
+  const choices = (body as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return null;
+  const message = (choices[0] as { message?: unknown }).message;
+  if (typeof message !== "object" || message === null) return null;
+  const content = (message as { content?: unknown }).content;
+  return typeof content === "string" ? content : null;
+}
+
+function extractCostUsd(body: unknown): number | null {
+  if (typeof body !== "object" || body === null) return null;
+  const usage = (body as { usage?: unknown }).usage;
+  if (typeof usage !== "object" || usage === null) return null;
+  const cost = (usage as { total_cost?: unknown }).total_cost;
+  return typeof cost === "number" ? cost : null;
+}

--- a/src/advisor/prompts/action-selection.md
+++ b/src/advisor/prompts/action-selection.md
@@ -1,0 +1,14 @@
+---SYSTEM---
+You are an exploratory web testing agent. Given a screenshot of a web page and a list of candidate UI elements, pick the ONE element most likely to reveal previously unexplored application state.
+
+Prefer interactive elements that look enabled and visually prominent. Avoid decorative or visibly disabled elements. If the reason for asking is `invariant_violation`, prefer an element that may bring the UI back to a consistent state (close a modal, undo, navigate back). If the reason is `novelty_stall`, prefer an element that looks unrelated to actions you would expect the page's primary affordances to handle.
+
+Respond with a single JSON object on one line and nothing else:
+{"chosenIndex": <integer in candidate range>, "reasoning": "<one to three sentences>"}
+---USER---
+URL: {{url}}
+Reason for asking: {{reason}}
+Budget remaining: {{budgetRemaining}}
+
+Candidates:
+{{candidates}}

--- a/src/advisor/prompts/loader.test.ts
+++ b/src/advisor/prompts/loader.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { parsePromptFile, renderUserPrompt } from "./loader.js";
+
+const SAMPLE = `---SYSTEM---
+sys body
+on two lines
+---USER---
+URL: {{url}}
+Reason: {{reason}}
+Candidates:
+{{candidates}}
+`;
+
+describe("parsePromptFile", () => {
+  it("splits on the SYSTEM and USER delimiters", () => {
+    const parsed = parsePromptFile(SAMPLE);
+    expect(parsed.system).toBe("sys body\non two lines");
+    expect(parsed.userTemplate).toContain("URL: {{url}}");
+    expect(parsed.userTemplate).toContain("{{candidates}}");
+  });
+
+  it("throws when SYSTEM delimiter is missing", () => {
+    expect(() => parsePromptFile("---USER---\nbody\n")).toThrow(/SYSTEM/);
+  });
+
+  it("throws when USER delimiter is missing", () => {
+    expect(() => parsePromptFile("---SYSTEM---\nbody\n")).toThrow(/USER/);
+  });
+
+  it("throws when SYSTEM appears after USER", () => {
+    expect(() => parsePromptFile("---USER---\na\n---SYSTEM---\nb\n")).toThrow();
+  });
+});
+
+describe("renderUserPrompt", () => {
+  const { userTemplate } = parsePromptFile(SAMPLE);
+
+  it("substitutes all known placeholders", () => {
+    const out = renderUserPrompt(userTemplate, {
+      url: "https://example.test/x",
+      reason: "novelty_stall",
+      candidates: "0. button A\n1. link B",
+    });
+    expect(out).toContain("URL: https://example.test/x");
+    expect(out).toContain("Reason: novelty_stall");
+    expect(out).toContain("0. button A");
+    expect(out).not.toContain("{{url}}");
+    expect(out).not.toContain("{{reason}}");
+    expect(out).not.toContain("{{candidates}}");
+  });
+
+  it("leaves unknown placeholders alone", () => {
+    const out = renderUserPrompt("{{url}} {{unknown}}", {
+      url: "u",
+      reason: "r",
+      candidates: "c",
+    });
+    expect(out).toBe("u {{unknown}}");
+  });
+
+  it("escapes nothing — values are passed through verbatim", () => {
+    const out = renderUserPrompt("{{candidates}}", {
+      url: "u",
+      reason: "r",
+      candidates: "<script>",
+    });
+    expect(out).toBe("<script>");
+  });
+});

--- a/src/advisor/prompts/loader.ts
+++ b/src/advisor/prompts/loader.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure parsing + rendering for the action-selection prompt asset.
+ * The prompt itself lives in `action-selection.md` so it diffs cleanly
+ * and can be iterated on without touching code; this module turns that
+ * file's contents into a system string and a user-template string.
+ */
+
+export interface ParsedPrompt {
+  system: string;
+  userTemplate: string;
+}
+
+export interface UserPromptVars {
+  url: string;
+  reason: string;
+  candidates: string;
+  budgetRemaining?: number | string;
+}
+
+const SYSTEM_DELIM = "---SYSTEM---";
+const USER_DELIM = "---USER---";
+
+export function parsePromptFile(content: string): ParsedPrompt {
+  const sysIdx = content.indexOf(SYSTEM_DELIM);
+  const userIdx = content.indexOf(USER_DELIM);
+  if (sysIdx === -1) {
+    throw new Error("prompt file is missing the ---SYSTEM--- delimiter");
+  }
+  if (userIdx === -1) {
+    throw new Error("prompt file is missing the ---USER--- delimiter");
+  }
+  if (sysIdx > userIdx) {
+    throw new Error("prompt file has ---SYSTEM--- after ---USER---");
+  }
+
+  const system = content.slice(sysIdx + SYSTEM_DELIM.length, userIdx).trim();
+  const userTemplate = content.slice(userIdx + USER_DELIM.length).trimStart();
+  return { system, userTemplate: userTemplate.replace(/\s+$/, "") };
+}
+
+export function renderUserPrompt(template: string, vars: UserPromptVars): string {
+  return template
+    .replace(/\{\{url\}\}/g, vars.url)
+    .replace(/\{\{reason\}\}/g, vars.reason)
+    .replace(/\{\{candidates\}\}/g, vars.candidates)
+    .replace(/\{\{budgetRemaining\}\}/g, String(vars.budgetRemaining ?? ""));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export type {
   AdvisorContext,
   AdvisorSuggestion,
 } from "./advisor/types.js";
+export { openRouterAdvisor, type OpenRouterAdvisorOptions } from "./advisor/openrouter.js";
 export {
   compareScreenshotBuffers,
   formatVisualDiff,


### PR DESCRIPTION
## Summary

Second implementation PR for the VLM action advisor (design: #38, plumbing: #39). Ships the default provider so the advisor can actually consult a model.

## What's in

- \`src/advisor/openrouter.ts\` — provider impl, default model \`google/gemini-2.5-flash\`, USD budget guard, soft-failure on every recoverable problem
- \`src/advisor/prompts/action-selection.md\` — system + user prompt template, kept as a markdown asset for diff-friendly iteration (per design doc §7)
- \`src/advisor/prompts/loader.ts\` — pure \`parsePromptFile\` + \`renderUserPrompt\`
- 20 unit tests (loader 7 + openrouter 13)
- \`scripts/copy-assets.mjs\` — stages \`*.md\` from \`src/\` to \`dist/\` after \`tsc\` so the published package resolves the asset

## Soft-failure semantics

HTTP non-2xx, malformed JSON, missing \`chosenIndex\` / \`reasoning\`, out-of-range index, USD budget exhausted — all return \`null\`. The crawler treats \`null\` as "no opinion, fall back to heuristic" — same contract \`consult.ts\` already relies on.

## What's NOT in (per design doc §10)

- Trace recording of advisor picks
- \`CrawlReport.advisor\` block
- Invariant-violation hook into \`StallTracker.recordInvariantViolation\`

Lands in #N+3 (the final integration PR).

## Asset shipping

The prompt is read from disk at module-init via \`new URL("./prompts/action-selection.md", import.meta.url)\`. \`tsc\` doesn't copy non-TS files, so \`scripts/copy-assets.mjs\` runs after \`tsc\` to stage the asset into \`dist/\`. The script's allowed-extensions list is intentionally narrow — adding to it deliberately is fine, widening it to "everything except .ts" silently ships notes / fixtures into the published tarball.

## Verified locally

- [x] \`pnpm test\` -> 464/464 pass (20 new + no regression in fixture e2e)
- [x] \`pnpm run build\` -> \`tsc\` clean + asset copied to \`dist/advisor/prompts/\`
- [x] \`node scripts/check-no-nul.mjs src fixtures scripts\` clean

## Test plan

- [ ] CI: build-and-test, chaos-crawl, flaker-merge all green
- [ ] Reviewer scans \`openrouter.ts\` soft-failure paths — every \`return null\` is a recoverable case
- [ ] Reviewer confirms the API key never appears in \`advisor.name\` or any logged field

🤖 Generated with [Claude Code](https://claude.com/claude-code)