### PR TITLE
feat(advisor): trace + report integration for advisor picks

### DIFF
--- a/fixtures/runner/e2e.test.ts
+++ b/fixtures/runner/e2e.test.ts
@@ -514,6 +514,57 @@ describe("ChaosCrawler against fixture site", () => {
     expect(offReport2.actions.map((a) => a.selector ?? "")).toEqual(offSelectors);
   }, 180000);
 
+  it("populates report.advisor and stamps trace entries when the advisor picks a target", async () => {
+    // Stub advisor: forces consultation by reporting always-stalled state via
+    // a permissive policy (noveltyStallThreshold=0). Picks index 0 every time.
+    const visited: Array<{ url: string; reason: string }> = [];
+    const stubAdvisor = {
+      name: "stub/test",
+      async suggest(ctx: { url: string; reason: string; candidates: { index: number }[] }) {
+        visited.push({ url: ctx.url, reason: ctx.reason });
+        return { chosenIndex: 0, reasoning: "stub picks index 0" };
+      },
+    };
+
+    const tmpTrace = join(mkdtempSync(join(tmpdir(), "chaos-advisor-")), "trace.jsonl");
+
+    const crawler = new ChaosCrawler({
+      baseUrl: server.url,
+      maxPages: 3,
+      maxActionsPerPage: 3,
+      headless: true,
+      seed: 11,
+      traceOut: tmpTrace,
+      advisor: {
+        provider: stubAdvisor,
+        noveltyStallThreshold: 0,
+        minCandidatesToConsult: 1,
+        timeoutMs: 5_000,
+      },
+    });
+    const report = await crawler.start();
+
+    expect(report.advisor).toBeDefined();
+    expect(report.advisor!.provider).toBe("stub/test");
+    expect(report.advisor!.callsAttempted).toBeGreaterThan(0);
+    expect(report.advisor!.callsSucceeded).toBeGreaterThan(0);
+    expect(report.advisor!.picks.length).toBeGreaterThan(0);
+    for (const pick of report.advisor!.picks) {
+      expect(pick.reasoning).toBe("stub picks index 0");
+      expect(pick.chosenSelector).toBeTruthy();
+    }
+
+    // Trace file should have at least one action entry tagged with advisor.
+    const { readFileSync } = await import("node:fs");
+    const lines = readFileSync(tmpTrace, "utf8").trim().split("\n");
+    const advisorActions = lines
+      .map((l) => JSON.parse(l))
+      .filter((e) => e.kind === "action" && e.advisor !== undefined);
+    expect(advisorActions.length).toBeGreaterThan(0);
+    expect(advisorActions[0].advisor.provider).toBe("stub/test");
+    expect(advisorActions[0].advisor.reasoning).toBe("stub picks index 0");
+  }, 120000);
+
   it("captures SPA history.pushState navigations as discovered links", async () => {
     // /spa-router has NO `<a href>` to /spa-router/*, only buttons that
     // call history.pushState. Static link extraction misses every one;

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -92,6 +92,7 @@ import { AdvisorBudget, StallTracker } from "./advisor/budget.js";
 import { consultAdvisor } from "./advisor/consult.js";
 import { defaultTriggerPolicy, type TriggerPolicy } from "./advisor/trigger.js";
 import type { ActionAdvisor, AdvisorCandidate } from "./advisor/types.js";
+import type { AdvisorPick } from "./types.js";
 
 // Options that are opt-in with no meaningful default (HAR, storage state,
 // perf budget, trace, device/network) are carved out of the Required<>
@@ -264,6 +265,16 @@ export class ChaosCrawler {
     budget: AdvisorBudget;
     stall: StallTracker;
     timeoutMs: number;
+    callsAttempted: number;
+    callsSucceeded: number;
+    picks: AdvisorPick[];
+    /**
+     * Selector → suggestion map, populated immediately before
+     * `performActionOnTarget` so the just-recorded ActionResult can be
+     * stamped onto the matching trace entry. Cleared after every action
+     * so a non-advisor action doesn't accidentally pick up stale state.
+     */
+    pendingPick: { selector: string; reasoning: string; reason: AdvisorPick["reason"] } | null;
   } | null = null;
 
   constructor(options: CrawlerOptions, events: CrawlerEvents = {}) {
@@ -307,6 +318,10 @@ export class ChaosCrawler {
         budget: new AdvisorBudget(),
         stall: new StallTracker(),
         timeoutMs: options.advisor.timeoutMs ?? 8_000,
+        callsAttempted: 0,
+        callsSucceeded: 0,
+        picks: [],
+        pendingPick: null,
       };
     }
 
@@ -404,6 +419,7 @@ export class ChaosCrawler {
         errors.push(error);
         this.events.onError?.(error);
         this.logger.logPageError(error);
+        this.advisorRuntime?.stall.recordInvariantViolation();
       }
     }
   }
@@ -493,6 +509,10 @@ export class ChaosCrawler {
     if (this.advisorRuntime) {
       this.advisorRuntime.budget = new AdvisorBudget();
       this.advisorRuntime.stall = new StallTracker();
+      this.advisorRuntime.callsAttempted = 0;
+      this.advisorRuntime.callsSucceeded = 0;
+      this.advisorRuntime.picks = [];
+      this.advisorRuntime.pendingPick = null;
     }
 
     if (this.isRecordingTrace()) {
@@ -976,6 +996,8 @@ export class ChaosCrawler {
 
     if (result.outcome === "skipped") return null;
 
+    runtime.callsAttempted += 1;
+
     this.logger.debug("advisor_consult", {
       url,
       reason: result.decision.reason,
@@ -985,9 +1007,45 @@ export class ChaosCrawler {
       provider: runtime.provider.name,
     });
 
-    if (!result.suggestion) return null;
+    if (!result.suggestion || !result.decision.reason) return null;
+
+    runtime.callsSucceeded += 1;
     runtime.stall.recordAdvisorPick();
-    return targets[result.suggestion.chosenIndex] ?? null;
+
+    const target = targets[result.suggestion.chosenIndex];
+    if (!target) return null;
+
+    runtime.picks.push({
+      url,
+      reason: result.decision.reason,
+      chosenSelector: target.selector,
+      reasoning: result.suggestion.reasoning,
+    });
+    runtime.pendingPick = {
+      selector: target.selector,
+      reasoning: result.suggestion.reasoning,
+      reason: result.decision.reason,
+    };
+    return target;
+  }
+
+  /**
+   * Pop the just-pending advisor pick if (and only if) it matches the
+   * selector that was actually performed. Mismatch can happen when the
+   * advisor's chosen target was rejected as not-visible and the loop
+   * fell back to a heuristic pick — those should NOT be tagged advisor.
+   */
+  private consumeAdvisorStamp(selector: string) {
+    const runtime = this.advisorRuntime;
+    if (!runtime?.pendingPick) return undefined;
+    const pending = runtime.pendingPick;
+    runtime.pendingPick = null;
+    if (pending.selector !== selector) return undefined;
+    return {
+      provider: runtime.provider.name,
+      reason: pending.reason,
+      reasoning: pending.reasoning,
+    };
   }
 
   /**
@@ -1844,8 +1902,9 @@ export class ChaosCrawler {
       actionsPerformed++;
       this.actions.push(result);
       this.addToHistory(result);  // Add to recovery history
+      const advisorStamp = this.consumeAdvisorStamp(selectedTarget.selector);
       if (this.isRecordingTrace()) {
-        this.trace.push(actionToTraceEntry(result, url));
+        this.trace.push(actionToTraceEntry(result, url, advisorStamp));
       }
       this.events.onAction?.(result);
       this.logger.logAction(result);
@@ -2111,6 +2170,14 @@ export class ChaosCrawler {
             targetNovelty: this.targetNovelty,
             topN: this.coverageFeedback.topN,
           })
+        : undefined,
+      advisor: this.advisorRuntime
+        ? {
+            provider: this.advisorRuntime.provider.name,
+            callsAttempted: this.advisorRuntime.callsAttempted,
+            callsSucceeded: this.advisorRuntime.callsSucceeded,
+            picks: [...this.advisorRuntime.picks],
+          }
         : undefined,
       errorClusters: clusterErrors(this.results.flatMap((r) => r.errors)),
       har: this.options.har,

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -42,6 +42,18 @@ export interface TraceAction {
   success: boolean;
   error?: string;
   blockedExternal?: boolean;
+  /**
+   * When the target was picked by the VLM advisor (not the heuristic),
+   * a stamp identifying the provider, the consult reason, and the
+   * model's one-line reasoning. Replay uses the recorded `selector` /
+   * `target` verbatim — this field is informational only, useful for
+   * auditing which actions were model-driven.
+   */
+  advisor?: {
+    provider: string;
+    reason: "novelty_stall" | "invariant_violation" | "explicit_request";
+    reasoning: string;
+  };
 }
 
 export type TraceEntry = TraceMeta | TraceVisit | TraceAction;
@@ -50,7 +62,11 @@ export type TraceEntry = TraceMeta | TraceVisit | TraceAction;
  * Convert a recorded ActionResult + its URL into a TraceAction. Kept pure so
  * the crawler can serialize without importing node:fs in the hot path.
  */
-export function actionToTraceEntry(action: ActionResult, url: string): TraceAction {
+export function actionToTraceEntry(
+  action: ActionResult,
+  url: string,
+  advisor?: TraceAction["advisor"],
+): TraceAction {
   const out: TraceAction = {
     kind: "action",
     url,
@@ -61,6 +77,7 @@ export function actionToTraceEntry(action: ActionResult, url: string): TraceActi
   if (action.selector !== undefined) out.selector = action.selector;
   if (action.error !== undefined) out.error = action.error;
   if (action.blockedExternal !== undefined) out.blockedExternal = action.blockedExternal;
+  if (advisor) out.advisor = advisor;
   return out;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -665,6 +665,13 @@ export interface CrawlReport {
    */
   coverage?: CoverageReport;
   /**
+   * Action-advisor activity (present only when `advisor` was configured).
+   * Reports the provider, attempt + success counts, and one row per pick
+   * the advisor actually made — useful for auditing which crawl decisions
+   * were model-driven vs heuristic-driven.
+   */
+  advisor?: AdvisorReport;
+  /**
    * Errors grouped into clusters by fingerprint (type + normalised message).
    * Use `ErrorCluster.count` to triage noisy runs where the same issue fires
    * repeatedly. Always populated, even when empty.
@@ -674,6 +681,20 @@ export interface CrawlReport {
   har?: HarConfig;
   /** Diff against a baseline report, present only when a baseline was supplied. */
   diff?: ReportDiff;
+}
+
+export interface AdvisorPick {
+  url: string;
+  reason: "novelty_stall" | "invariant_violation" | "explicit_request";
+  chosenSelector: string;
+  reasoning: string;
+}
+
+export interface AdvisorReport {
+  provider: string;
+  callsAttempted: number;
+  callsSucceeded: number;
+  picks: AdvisorPick[];
 }
 
 export interface CrawlSummary {


### PR DESCRIPTION
## Summary

Final PR in the 4-PR rollout for the VLM action advisor. Closes the loop: advisor activity is now visible in \`CrawlReport.advisor\`, individual advisor-driven actions are stamped in the trace, and invariant violations now actually feed the trigger policy.

## Phased rollout — status

| PR | Title | Status |
|----|-------|--------|
| #38 | docs: VLM action advisor design proposal | MERGED |
| #39 | feat(advisor): interface + budget plumbing (no provider) | MERGED |
| #40 | feat(advisor): OpenRouter Gemini Flash 2.5 provider + prompt asset | MERGED |
| **this PR** | **feat(advisor): trace + report integration for advisor picks** | **OPEN** |

## What's in

- \`CrawlReport.advisor\` block — \`{provider, callsAttempted, callsSucceeded, picks: [{url, reason, chosenSelector, reasoning}]}\`. Present only when advisor was configured.
- \`TraceAction.advisor\` stamp — \`{provider, reason, reasoning}\` set on the trace entry whose target was advisor-picked. Optional field — existing traces parse unchanged.
- **Invariant-violation hook** — \`StallTracker.recordInvariantViolation\` now fires from the invariant-check path; the next action consults with \`reason="invariant_violation"\` per design §4. Was deferred from #39, lands here.
- **Pending-pick guard** — \`consumeAdvisorStamp\` only stamps when the actually-performed selector matches the advisor's pick, so heuristic fallbacks (advisor's pick turned out non-visible) don't get falsely tagged.
- Fixture e2e test using a stub advisor verifies report population + trace stamping end-to-end.

## Verified locally

- [x] \`pnpm test\` -> 465/465 pass (1 new advisor e2e + no regression)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm run build\` -> tsc + asset copy clean
- [x] \`node scripts/check-no-nul.mjs src fixtures scripts\` clean

## Test plan

- [ ] CI: build-and-test, chaos-crawl, flaker-merge all green
- [ ] Reviewer scans \`consumeAdvisorStamp\` and confirms the selector-match guard prevents false-tagging
- [ ] Reviewer scans the new e2e test stub-advisor pattern (it's the recommended pattern users will follow for testing their own crawler integrations)

## Out of scope (per design doc §12 open questions)

- CLI cost-summary footer when advisor was used
- Viewport vs full-page screenshot tradeoff
- \`redactReasoning\` flag for confidential UI
- Replay fidelity when UI drifts

These can land as follow-ups against the now-stable advisor surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)