### PR TITLE
feat(server-faults): add @mizchi/server-faults package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository hosts `chaosbringer` plus future Layer-1 packages extracted from
 ## Packages
 
 - [`chaosbringer`](packages/chaosbringer) — Playwright-based chaos testing CLI + library
+- [`@mizchi/server-faults`](packages/server-faults) — framework-agnostic server-side fault injection (5xx + latency) for Web Standard Request / Response
 
 ## Development
 

--- a/packages/server-faults/LICENSE
+++ b/packages/server-faults/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 mizchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -1,0 +1,98 @@
+# @mizchi/server-faults
+
+Framework-agnostic server-side fault injection (5xx + latency) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
+
+## Install
+
+```bash
+pnpm add @mizchi/server-faults
+```
+
+Requires Node 20+ (uses `Response.json` and the global `Request` constructor).
+
+## Usage
+
+### Hono on Cloudflare Workers / Node
+
+```ts
+import { Hono } from "hono";
+import { serverFaults } from "@mizchi/server-faults";
+
+const fault = serverFaults({
+  status5xxRate: Number(process.env.CHAOS_5XX_RATE ?? 0),
+  latencyRate: Number(process.env.CHAOS_LATENCY_RATE ?? 0),
+  latencyMs: { minMs: 50, maxMs: 500 },
+  pathPattern: "^/api/",
+});
+
+const app = new Hono();
+app.use("*", async (c, next) => {
+  const response = await fault.maybeInject(c.req.raw);
+  if (response) return response;
+  return next();
+});
+```
+
+### Express
+
+```ts
+import express from "express";
+import { serverFaults } from "@mizchi/server-faults";
+
+const fault = serverFaults({ status5xxRate: 0.05, pathPattern: /^\/api\// });
+
+const app = express();
+app.use(async (req, res, next) => {
+  const webReq = new Request(`http://${req.headers.host}${req.originalUrl}`, {
+    method: req.method,
+  });
+  const response = await fault.maybeInject(webReq);
+  if (!response) return next();
+  res.status(response.status);
+  res.json(await response.json());
+});
+```
+
+## Config
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `status5xxRate` | `number` (0..1) | `0` | Probability of synthetic 5xx response |
+| `status5xxCode` | `500 \| 502 \| 503 \| 504` | `503` | Status to return when the 5xx raffle wins |
+| `latencyRate` | `number` (0..1) | `0` | Probability of injected latency |
+| `latencyMs` | `number \| {minMs, maxMs}` | — | Sleep duration. Number = constant; range = uniform pick |
+| `pathPattern` | `RegExp \| string` | none | Only matching paths are considered for fault injection |
+| `seed` | `number` | none (`Math.random`) | When given, fault selection is reproducible across runs |
+| `observer.onFault` | `(kind, attrs) => void` | none | Telemetry callback |
+
+## Semantics
+
+- `null` = no fault, continue normally; `Response` = synthetic response, skip the handler.
+- 5xx and latency are **mutually exclusive in the same request**. If the 5xx raffle wins, the function returns immediately and the latency raffle is never rolled. Single-fault-per-request keeps observability data clean.
+- `seed` drives **fault selection** (which raffles win), not exact ms values inside a `latencyMs` range — the inner range pick uses `Math.random()` so config tweaks don't shift the RNG sequence.
+
+## Comparison with related layers
+
+| Layer | Library | Where the fault is applied |
+|---|---|---|
+| Network | `chaosbringer` `FaultRule` | Playwright `route()` between browser and server |
+| Page / lifecycle | `chaosbringer` `lifecycleFaults` | Browser DOM / storage / CPU |
+| **Server** | **`@mizchi/server-faults`** | **Inside the server process before the handler** |
+
+## Observability example
+
+```ts
+const fault = serverFaults({
+  status5xxRate: 0.1,
+  observer: {
+    onFault: (kind, attrs) => {
+      // wire to OTel / Datadog / console — no framework dep imposed by this lib
+      faultsCounter.add(1, { kind, path: String(attrs.path) });
+    },
+  },
+});
+```
+
+## License
+
+MIT

--- a/packages/server-faults/package.json
+++ b/packages/server-faults/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@mizchi/server-faults",
+  "version": "0.1.0",
+  "description": "Framework-agnostic server-side fault injection (5xx + latency) for Web Standard Request/Response.",
+  "license": "MIT",
+  "author": "mizchi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/chaosbringer.git",
+    "directory": "packages/server-faults"
+  },
+  "homepage": "https://github.com/mizchi/chaosbringer/tree/main/packages/server-faults#readme",
+  "bugs": {
+    "url": "https://github.com/mizchi/chaosbringer/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint:nul": "node ../chaosbringer/scripts/check-no-nul.mjs src"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "fault-injection",
+    "chaos-engineering",
+    "testing",
+    "web-standard",
+    "request",
+    "response"
+  ],
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "vitest": "^3.0.7"
+  }
+}

--- a/packages/server-faults/src/index.ts
+++ b/packages/server-faults/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  serverFaults,
+  type ServerFaultConfig,
+  type ServerFaultHandle,
+  type ServerFaultObserver,
+} from "./server-faults.js";

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { serverFaults } from "./server-faults.js";
+
+const req = (path: string) => new Request(`https://test.local${path}`);
+
+describe("serverFaults", () => {
+  it("returns null for every call when both rates are 0", async () => {
+    const fault = serverFaults({});
+    for (let i = 0; i < 100; i += 1) {
+      expect(await fault.maybeInject(req("/api/x"))).toBeNull();
+    }
+  });
+
+  it("always returns a 503 when status5xxRate=1", async () => {
+    const fault = serverFaults({ status5xxRate: 1 });
+    const response = await fault.maybeInject(req("/api/x"));
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(503);
+    const body = await response!.json();
+    expect(body.error).toMatch(/chaos/);
+    expect(body.path).toBe("/api/x");
+  });
+
+  it("honours status5xxCode override", async () => {
+    const fault = serverFaults({ status5xxRate: 1, status5xxCode: 500 });
+    const response = await fault.maybeInject(req("/api/x"));
+    expect(response!.status).toBe(500);
+  });
+
+  it("filters by pathPattern (RegExp form)", async () => {
+    const fault = serverFaults({ status5xxRate: 1, pathPattern: /^\/api\// });
+    expect(await fault.maybeInject(req("/health"))).toBeNull();
+    expect(await fault.maybeInject(req("/api/users"))).not.toBeNull();
+  });
+
+  it("filters by pathPattern (string form)", async () => {
+    const fault = serverFaults({ status5xxRate: 1, pathPattern: "^/api/" });
+    expect(await fault.maybeInject(req("/health"))).toBeNull();
+    expect(await fault.maybeInject(req("/api/users"))).not.toBeNull();
+  });
+
+  it("produces a reproducible fault sequence with the same seed", async () => {
+    const a = serverFaults({ status5xxRate: 0.5, seed: 42 });
+    const b = serverFaults({ status5xxRate: 0.5, seed: 42 });
+    const aSeq: boolean[] = [];
+    const bSeq: boolean[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      aSeq.push((await a.maybeInject(req(`/api/${i}`))) !== null);
+      bSeq.push((await b.maybeInject(req(`/api/${i}`))) !== null);
+    }
+    expect(aSeq).toEqual(bSeq);
+  });
+
+  it("different seeds produce different fault sequences", async () => {
+    const a = serverFaults({ status5xxRate: 0.5, seed: 1 });
+    const b = serverFaults({ status5xxRate: 0.5, seed: 2 });
+    const aSeq: boolean[] = [];
+    const bSeq: boolean[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      aSeq.push((await a.maybeInject(req(`/api/${i}`))) !== null);
+      bSeq.push((await b.maybeInject(req(`/api/${i}`))) !== null);
+    }
+    expect(aSeq).not.toEqual(bSeq);
+  });
+
+  describe("latency", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("delays the request by latencyMs (number)", async () => {
+      const fault = serverFaults({ latencyRate: 1, latencyMs: 100 });
+      const promise = fault.maybeInject(req("/api/x"));
+      await vi.advanceTimersByTimeAsync(99);
+      let resolved = false;
+      promise.then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      await vi.advanceTimersByTimeAsync(2);
+      const result = await promise;
+      expect(result).toBeNull();
+    });
+
+    it("returns null after latency (handler runs after delay)", async () => {
+      const fault = serverFaults({ latencyRate: 1, latencyMs: 50 });
+      const promise = fault.maybeInject(req("/api/x"));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(await promise).toBeNull();
+    });
+  });
+
+  it("latencyMs range stays within bounds", async () => {
+    const fault = serverFaults({
+      latencyRate: 1,
+      latencyMs: { minMs: 50, maxMs: 100 },
+    });
+    const sleepSpy = vi.spyOn(globalThis, "setTimeout");
+    for (let i = 0; i < 20; i += 1) {
+      const p = fault.maybeInject(req(`/api/${i}`));
+      // run all pending timers without using fake timers
+      await new Promise((r) => setImmediate(r));
+      await p;
+    }
+    for (const call of sleepSpy.mock.calls) {
+      const ms = call[1] as number;
+      expect(ms).toBeGreaterThanOrEqual(50);
+      expect(ms).toBeLessThanOrEqual(100);
+    }
+    sleepSpy.mockRestore();
+  });
+
+  it("invokes observer.onFault for 5xx faults", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({
+      status5xxRate: 1,
+      observer: { onFault },
+    });
+    await fault.maybeInject(req("/api/x"));
+    expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ status: 503, path: "/api/x" }));
+  });
+
+  it("invokes observer.onFault for latency faults", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({
+      latencyRate: 1,
+      latencyMs: 1,
+      observer: { onFault },
+    });
+    await fault.maybeInject(req("/api/x"));
+    expect(onFault).toHaveBeenCalledWith("latency", expect.objectContaining({ ms: 1, path: "/api/x" }));
+  });
+
+  it("does not roll latency raffle when 5xx already won", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({
+      status5xxRate: 1,
+      latencyRate: 1,
+      latencyMs: 1,
+      observer: { onFault },
+    });
+    await fault.maybeInject(req("/api/x"));
+    expect(onFault).toHaveBeenCalledTimes(1);
+    expect(onFault).toHaveBeenCalledWith("5xx", expect.anything());
+  });
+});

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -1,0 +1,101 @@
+/**
+ * Framework-agnostic server-side fault injection.
+ *
+ * Sits between the network-side fault injection (request interception
+ * outside the server) and any client-side mocking. Takes a Web Standard
+ * `Request`, returns a `Response | null`. `null` means "no fault, the
+ * normal handler should run". The library is independent of any HTTP
+ * framework; users wire it as a 1-2 line middleware.
+ *
+ * 5xx is exclusive of latency in the same request — a single fault per
+ * request keeps observability data clean and RNG consumption deterministic
+ * (1 roll for 5xx, conditionally 1 roll for latency).
+ */
+
+export interface ServerFaultObserver {
+  onFault?: (
+    kind: "5xx" | "latency",
+    attrs: Record<string, string | number>,
+  ) => void;
+}
+
+export interface ServerFaultConfig {
+  /** 0..1, default 0. */
+  status5xxRate?: number;
+  /** Default 503. */
+  status5xxCode?: 500 | 502 | 503 | 504;
+  /** 0..1, default 0. */
+  latencyRate?: number;
+  /** Sleep duration when the latency raffle wins. Number = constant ms; range = uniform pick. */
+  latencyMs?: number | { minMs: number; maxMs: number };
+  /** RegExp or pattern string. Only matching paths are considered for fault injection. */
+  pathPattern?: RegExp | string;
+  /** Optional. When set, fault selection (which raffles win) is reproducible across runs. */
+  seed?: number;
+  observer?: ServerFaultObserver;
+}
+
+export interface ServerFaultHandle {
+  maybeInject: (req: Request) => Promise<Response | null>;
+}
+
+interface SeededRng {
+  next(): number;
+}
+
+function mulberry32(seed: number): SeededRng {
+  let s = seed >>> 0;
+  return {
+    next() {
+      s = (s + 0x6d2b79f5) >>> 0;
+      let t = s;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    },
+  };
+}
+
+function pickLatencyMs(spec: ServerFaultConfig["latencyMs"]): number {
+  if (typeof spec === "number") return spec;
+  if (spec) return spec.minMs + Math.random() * (spec.maxMs - spec.minMs);
+  return 0;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
+  const pattern =
+    cfg.pathPattern instanceof RegExp
+      ? cfg.pathPattern
+      : cfg.pathPattern
+        ? new RegExp(cfg.pathPattern)
+        : null;
+
+  const rng: SeededRng = cfg.seed !== undefined ? mulberry32(cfg.seed) : { next: () => Math.random() };
+
+  return {
+    async maybeInject(req: Request): Promise<Response | null> {
+      const url = new URL(req.url);
+      if (pattern && !pattern.test(url.pathname)) return null;
+
+      const r5 = cfg.status5xxRate ?? 0;
+      if (r5 > 0 && rng.next() < r5) {
+        const status = cfg.status5xxCode ?? 503;
+        cfg.observer?.onFault?.("5xx", { status, path: url.pathname });
+        return Response.json(
+          { error: "chaos: synthetic 5xx", path: url.pathname, status },
+          { status },
+        );
+      }
+
+      const rL = cfg.latencyRate ?? 0;
+      if (rL > 0 && rng.next() < rL) {
+        const ms = pickLatencyMs(cfg.latencyMs);
+        cfg.observer?.onFault?.("latency", { ms, path: url.pathname });
+        await sleep(ms);
+      }
+      return null;
+    },
+  };
+}

--- a/packages/server-faults/tsconfig.json
+++ b/packages/server-faults/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,15 @@ importers:
         specifier: ^3.0.7
         version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
+  packages/server-faults:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.7
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+
 packages:
 
   '@esbuild/aix-ppc64@0.27.7':


### PR DESCRIPTION
## Summary

First Layer-1 extraction following the workspace skeleton in #42. New package: \`@mizchi/server-faults\`.

Implements the 2026-04-30 server-side fault injection design as a **standalone package** rather than an in-repo helper inside chaosbringer — the design was always framework-agnostic, and chaosbringer doesn't use it itself.

## Public surface

\`\`\`ts
serverFaults(config) -> { maybeInject(req: Request): Promise<Response | null> }
\`\`\`

Config: \`status5xxRate\`, \`status5xxCode\`, \`latencyRate\`, \`latencyMs\` (number or \`{minMs, maxMs}\` range), \`pathPattern\` (RegExp or string), \`seed\`, \`observer\`.

## Semantics

- \`null\` = no fault, continue normally; \`Response\` = skip the handler
- 5xx and latency are mutually exclusive per request (one fault max)
- \`seed\` drives fault selection (which raffles win), not exact ms values inside \`latencyMs\` ranges — config tweaks don't shift the RNG sequence

## Tests

13 unit tests cover: rate=0 no-op, rate=1 always-5xx, status code override, pathPattern (RegExp + string), seed reproducibility, latency delay (fake timers), range bounds, observer.onFault for both kinds, exclusivity.

## Verified locally

- [x] \`pnpm test\` (root, recursive) -> 478/478 pass (chaosbringer 465 + server-faults 13)
- [x] \`pnpm -F @mizchi/server-faults build\` clean
- [x] \`pnpm -F @mizchi/server-faults lint:nul\` clean

## Out of scope

Per design doc §6 (now realized in this PR's package):
- Header-based determinism with a chaosbringer crawler (\`X-Chaos-Run-Id\`, \`X-Chaos-Seed\`)
- Control-plane HTTP endpoint (\`POST /__chaos/inject\`)
- Framework adapters (Hono / Express / Fastify pre-built middleware) — keep the wrapper in user code, 1-2 lines
- Async / observable instrument-style faults (clock skew, fail-every-Nth)

## Publish status

Not yet on npm. First publish needs manual mizchi action to bootstrap OIDC Trusted Publishing under the new package name (same pattern as chaosbringer's initial 0.1.0 publish). After that, future releases can flow through the existing \`publish.yml\` (which would need a \`-F @mizchi/server-faults\` filter analog — out of scope for this PR; ship after the manual bootstrap).

## Test plan

- [ ] CI \`build-and-test\` passes (now also runs server-faults' 13 tests via \`pnpm -r test\`)
- [ ] Reviewer confirms 5xx-vs-latency exclusivity — see \`server-faults.test.ts\` "does not roll latency raffle when 5xx already won"
- [ ] Reviewer scans the README usage examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)