### PR TITLE
chore(release): chaosbringer 0.6.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/chaosbringer": "0.5.0"
+  "packages/chaosbringer": "0.6.0"
 }

--- a/packages/chaosbringer/CHANGELOG.md
+++ b/packages/chaosbringer/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.0](https://github.com/mizchi/chaosbringer/compare/v0.5.0...v0.6.0) (2026-05-01)
+
+
+### Features
+
+* **advisor:** opt-in VLM (vision-language model) action advisor that picks the next action from a candidate list when the coverage-guided heuristic stalls. Default reference provider is OpenRouter `google/gemini-2.5-flash`. Off by default; configure via `CrawlerOptions.advisor`. Soft-failure on every recoverable problem; falls back to heuristic. ([#38](https://github.com/mizchi/chaosbringer/pull/38), [#39](https://github.com/mizchi/chaosbringer/pull/39), [#40](https://github.com/mizchi/chaosbringer/pull/40), [#41](https://github.com/mizchi/chaosbringer/pull/41))
+* **report.advisor:** new `CrawlReport.advisor` block (provider, callsAttempted, callsSucceeded, picks). Each pick records the URL, reason (`novelty_stall` / `invariant_violation` / `explicit_request`), chosen selector, and model reasoning.
+* **trace:** advisor-driven actions are stamped into the JSONL trace with `{provider, reason, reasoning}`. Replays use the recorded selector verbatim — model is not re-consulted.
+
+
+### Build / repo
+
+* repo converted to a pnpm workspace ([#42](https://github.com/mizchi/chaosbringer/pull/42)). Source moved to `packages/chaosbringer/`. No effect on the published npm package contents.
+
 ## [0.5.0](https://github.com/mizchi/chaosbringer/compare/chaosbringer-v0.4.0...chaosbringer-v0.5.0) (2026-05-01)
 
 

--- a/packages/chaosbringer/package.json
+++ b/packages/chaosbringer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaosbringer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Playwright-based chaos testing tool for web applications",
   "license": "MIT",
   "author": "mizchi",


### PR DESCRIPTION
## Summary

Manual release of **chaosbringer 0.6.0**, covering the VLM action advisor feature (4 PRs) and the pnpm workspace migration.

## Why manual

\`release-please\` did not pick up the advisor commits (#39, #40, #41) because they were committed to the pre-workspace layout (root \`src/\`), and the workspace migration in #42 moved the package path to \`packages/chaosbringer/\`. \`release-please\` walks history by path, so the \`feat:\` commits no longer match the package's path glob and got skipped on dispatch.

After this release, future advisor follow-ups land on \`packages/chaosbringer/**\` and \`release-please\` will resume operating correctly.

## Scope

| PR | Title |
|---|---|
| #38 | docs: VLM action advisor design proposal |
| #39 | feat(advisor): interface + budget plumbing |
| #40 | feat(advisor): OpenRouter Gemini Flash 2.5 provider + prompt asset |
| #41 | feat(advisor): trace + report integration for advisor picks |
| #42 | chore: convert to pnpm workspace |

## What ships

\`\`\`ts
import { ChaosCrawler, openRouterAdvisor } from "chaosbringer";

const crawler = new ChaosCrawler({
  url: "...",
  advisor: {
    provider: openRouterAdvisor({ apiKey: process.env.OPENROUTER_API_KEY! }),
    maxCallsPerCrawl: 20,
  },
});
const report = await crawler.start();
console.log(report.advisor); // { provider, callsAttempted, callsSucceeded, picks: [...] }
\`\`\`

Default off; configure via \`CrawlerOptions.advisor\`. Soft-failure → heuristic fallback. CI baselines remain deterministic.

## Post-merge actions (manual)

1. After merge, tag \`v0.6.0\` on the merge commit and push the tag
2. Create a GitHub Release on \`v0.6.0\` (the existing \`publish.yml\` triggers on release publish)
3. \`publish.yml\` runs \`pnpm -F chaosbringer run build\` then \`npm publish --access public --provenance\` from \`packages/chaosbringer/\` (per #42)

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: tag + GitHub Release created, \`publish.yml\` succeeds, \`npm view chaosbringer version\` reports 0.6.0
- [ ] Smoke install in a separate dir confirms \`import { openRouterAdvisor } from "chaosbringer"\` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)