### PR TITLE
feat(advisor): screenshotMode config (viewport | fullPage)

### DIFF
--- a/packages/chaosbringer/fixtures/runner/e2e.test.ts
+++ b/packages/chaosbringer/fixtures/runner/e2e.test.ts
@@ -610,6 +610,38 @@ describe("ChaosCrawler against fixture site", () => {
     }
   }, 120000);
 
+  it("forwards screenshotMode: fullPage to the advisor screenshot supplier", async () => {
+    const seenSizes: number[] = [];
+    const stubAdvisor = {
+      name: "stub/test",
+      async suggest(ctx: { screenshot: Buffer }) {
+        seenSizes.push(ctx.screenshot.byteLength);
+        return { chosenIndex: 0, reasoning: "ok" };
+      },
+    };
+
+    const crawler = new ChaosCrawler({
+      baseUrl: server.url,
+      maxPages: 2,
+      maxActionsPerPage: 2,
+      headless: true,
+      seed: 21,
+      advisor: {
+        provider: stubAdvisor,
+        noveltyStallThreshold: 0,
+        minCandidatesToConsult: 1,
+        timeoutMs: 5_000,
+        screenshotMode: "fullPage",
+      },
+    });
+    await crawler.start();
+
+    expect(seenSizes.length).toBeGreaterThan(0);
+    for (const size of seenSizes) {
+      expect(size).toBeGreaterThan(0);
+    }
+  }, 120000);
+
   it("captures SPA history.pushState navigations as discovered links", async () => {
     // /spa-router has NO `<a href>` to /spa-router/*, only buttons that
     // call history.pushState. Static link extraction misses every one;

--- a/packages/chaosbringer/src/advisor/types.ts
+++ b/packages/chaosbringer/src/advisor/types.ts
@@ -74,6 +74,14 @@ export interface AdvisorConfig {
    * Default: false.
    */
   redactReasoning?: boolean;
+  /**
+   * Screenshot mode for advisor consults. `viewport` (default) sends only
+   * what the user currently sees — smaller payload, lower cost, but the
+   * model can miss off-screen UI. `fullPage` captures the entire scrollable
+   * page — better signal for long pages but 2-5× the bytes / tokens.
+   * Default: "viewport".
+   */
+  screenshotMode?: "viewport" | "fullPage";
 }
 
 export const REDACTED_REASONING = "[redacted]";

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -266,6 +266,7 @@ export class ChaosCrawler {
     stall: StallTracker;
     timeoutMs: number;
     redactReasoning: boolean;
+    screenshotFullPage: boolean;
     callsAttempted: number;
     callsSucceeded: number;
     picks: AdvisorPick[];
@@ -320,6 +321,7 @@ export class ChaosCrawler {
         stall: new StallTracker(),
         timeoutMs: options.advisor.timeoutMs ?? 8_000,
         redactReasoning: options.advisor.redactReasoning ?? false,
+        screenshotFullPage: options.advisor.screenshotMode === "fullPage",
         callsAttempted: 0,
         callsSucceeded: 0,
         picks: [],
@@ -992,7 +994,7 @@ export class ChaosCrawler {
       provider: runtime.provider,
       url,
       candidates,
-      screenshotSupplier: () => page.screenshot({ fullPage: false }),
+      screenshotSupplier: () => page.screenshot({ fullPage: runtime.screenshotFullPage }),
       timeoutMs: runtime.timeoutMs,
     });
 


### PR DESCRIPTION
## Summary

Second §12 follow-up after #45. Resolves the **screenshot size** open question.

\`advisor.screenshotMode\` controls what the model sees:

| Mode | What's sent | Tradeoff |
|---|---|---|
| \`viewport\` (default) | Currently-visible portion only | Smaller payload, lower cost; model misses off-screen UI |
| \`fullPage\` | Entire scrollable page | Better signal on long pages; 2-5× bytes / tokens |

Single boolean threaded into \`page.screenshot({ fullPage })\`. Default preserves prior behavior.

## Verified

- [x] \`pnpm test\` -> 467/467 pass (1 new e2e + 466 prior)
- [x] tsc clean

## Test

New e2e \`forwards screenshotMode: fullPage to the advisor screenshot supplier\` runs the crawler with a stub advisor that records \`screenshot.byteLength\` per consult, asserts every received Buffer has positive length. Doesn't compare viewport-vs-fullPage byte counts (too brittle on small fixture pages); the type-system + plumbing is the proof.

## Out of scope

§12 still has:
- CLI cost-summary footer when advisor was used
- Replay fidelity tracking (UI drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)