### PR TITLE
feat(advisor): CLI cost / call summary in formatReport + formatCompactReport

### DIFF
--- a/packages/chaosbringer/src/reporter.test.ts
+++ b/packages/chaosbringer/src/reporter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFileSync, existsSync, unlinkSync } from "node:fs";
-import { formatCompactReport, getExitCode, saveReport } from "./reporter.js";
+import { formatCompactReport, formatReport, getExitCode, saveReport } from "./reporter.js";
 import type { CrawlReport, CrawlSummary } from "./types.js";
 
 function makeSummary(overrides: Partial<CrawlSummary> = {}): CrawlSummary {
@@ -135,6 +135,58 @@ describe("formatCompactReport", () => {
     const report = makeReport({ summary: makeSummary({ invariantViolations: 1 }) });
     expect(formatCompactReport(report)).toContain("[FAIL]");
     expect(formatCompactReport(report, true)).toContain("[FAIL]");
+  });
+
+  it("appends advisor=succeeded/attempted suffix when advisor was used", () => {
+    const report = makeReport({
+      advisor: {
+        provider: "openrouter/google/gemini-2.5-flash",
+        callsAttempted: 5,
+        callsSucceeded: 4,
+        picks: [],
+      },
+    });
+    expect(formatCompactReport(report)).toContain("advisor=4/5");
+  });
+
+  it("omits advisor suffix when advisor was configured but never consulted", () => {
+    const report = makeReport({
+      advisor: {
+        provider: "openrouter/google/gemini-2.5-flash",
+        callsAttempted: 0,
+        callsSucceeded: 0,
+        picks: [],
+      },
+    });
+    expect(formatCompactReport(report)).not.toContain("advisor=");
+  });
+});
+
+describe("formatReport", () => {
+  it("includes a VLM ADVISOR section when advisor was used", () => {
+    const report = makeReport({
+      advisor: {
+        provider: "openrouter/google/gemini-2.5-flash",
+        callsAttempted: 3,
+        callsSucceeded: 3,
+        picks: [
+          { url: "/a", reason: "novelty_stall", chosenSelector: "#a", reasoning: "x" },
+          { url: "/b", reason: "novelty_stall", chosenSelector: "#b", reasoning: "y" },
+          { url: "/c", reason: "invariant_violation", chosenSelector: "#c", reasoning: "z" },
+        ],
+      },
+    });
+    const out = formatReport(report);
+    expect(out).toContain("VLM ADVISOR");
+    expect(out).toContain("openrouter/google/gemini-2.5-flash");
+    expect(out).toContain("3/3 succeeded");
+    expect(out).toContain("novelty_stall=2");
+    expect(out).toContain("invariant_violation=1");
+  });
+
+  it("omits the advisor section when advisor was never consulted", () => {
+    const out = formatReport(makeReport());
+    expect(out).not.toContain("VLM ADVISOR");
   });
 });
 

--- a/packages/chaosbringer/src/reporter.ts
+++ b/packages/chaosbringer/src/reporter.ts
@@ -182,6 +182,28 @@ export function formatReport(report: CrawlReport): string {
     }
   }
 
+  if (report.advisor && report.advisor.callsAttempted > 0) {
+    const a = report.advisor;
+    lines.push("");
+    lines.push("-".repeat(40));
+    lines.push("VLM ADVISOR");
+    lines.push("-".repeat(40));
+    lines.push(`  provider: ${a.provider}`);
+    lines.push(
+      `  calls: ${a.callsSucceeded}/${a.callsAttempted} succeeded (${a.picks.length} picks recorded)`
+    );
+    if (a.picks.length > 0) {
+      const reasonCounts = new Map<string, number>();
+      for (const p of a.picks) {
+        reasonCounts.set(p.reason, (reasonCounts.get(p.reason) ?? 0) + 1);
+      }
+      const reasonStr = [...reasonCounts.entries()]
+        .map(([r, n]) => `${r}=${n}`)
+        .join(" ");
+      lines.push(`  picks by reason: ${reasonStr}`);
+    }
+  }
+
   if (report.diff) {
     const d = report.diff;
     lines.push("");
@@ -237,9 +259,13 @@ export function formatCompactReport(report: CrawlReport, strict: boolean | ExitC
   const diffSuffix = report.diff
     ? ` diff=+${report.diff.newClusters.length}c/+${report.diff.newFailedPages.length}p`
     : "";
+  const advisorSuffix =
+    report.advisor && report.advisor.callsAttempted > 0
+      ? ` advisor=${report.advisor.callsSucceeded}/${report.advisor.callsAttempted}`
+      : "";
 
   return [
-    `[${status}] ${report.pagesVisited} pages, ${errors} errors, ${(report.duration / 1000).toFixed(1)}s (seed=${report.seed})${diffSuffix}`,
+    `[${status}] ${report.pagesVisited} pages, ${errors} errors, ${(report.duration / 1000).toFixed(1)}s (seed=${report.seed})${diffSuffix}${advisorSuffix}`,
     report.summary.avgMetrics
       ? `  Metrics: TTFB=${report.summary.avgMetrics.ttfb.toFixed(0)}ms, FCP=${report.summary.avgMetrics.fcp.toFixed(0)}ms`
       : "",


### PR DESCRIPTION
## Summary

Third §12 follow-up after #45 (\`redactReasoning\`) and #46 (\`screenshotMode\`). Resolves the **CLI cost surfacing** open question.

\`formatReport\` (full):
\`\`\`
----------------------------------------
VLM ADVISOR
----------------------------------------
  provider: openrouter/google/gemini-2.5-flash
  calls: 4/5 succeeded (4 picks recorded)
  picks by reason: novelty_stall=3 invariant_violation=1
\`\`\`

\`formatCompactReport\`: appends \`advisor=4/5\` to the existing summary line so the single-line output still fits.

Both gated on \`report.advisor && callsAttempted > 0\`, so runs without an advisor configured (or configured but never consulted) print exactly as before. 4 new unit tests.

## Out of scope

Actual USD cost rendering. The OpenRouter provider's internal \`costSoFarUsd\` accumulator is not exposed on \`CrawlReport.advisor\` yet — surfacing it cleanly needs a separate type-level decision (per-pick? per-run? does the contract include token usage?). Tracked for a follow-up if it turns out to be valuable in practice.

## Verified

- [x] \`pnpm test\` -> 471/471 (4 new + 467 pre-existing, no regression)
- [x] tsc clean

## §12 status after this PR

- [x] redactReasoning flag — #45 merged
- [x] viewport vs fullPage screenshot — #46 merged
- [x] CLI cost / call summary — this PR
- [ ] Replay fidelity tracking (UI drift) — last open

🤖 Generated with [Claude Code](https://claude.com/claude-code)