### PR TITLE
feat: replay fidelity tracking — surface trace UI drift

### DIFF
--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -92,7 +92,7 @@ import { AdvisorBudget, StallTracker } from "./advisor/budget.js";
 import { consultAdvisor } from "./advisor/consult.js";
 import { defaultTriggerPolicy, type TriggerPolicy } from "./advisor/trigger.js";
 import { REDACTED_REASONING, type ActionAdvisor, type AdvisorCandidate } from "./advisor/types.js";
-import type { AdvisorPick } from "./types.js";
+import type { AdvisorPick, ReplayFidelity } from "./types.js";
 
 // Options that are opt-in with no meaningful default (HAR, storage state,
 // perf budget, trace, device/network) are carved out of the Required<>
@@ -278,6 +278,8 @@ export class ChaosCrawler {
      */
     pendingPick: { selector: string; reasoning: string; reason: AdvisorPick["reason"] } | null;
   } | null = null;
+  /** Per-run replay drift counters. Populated only when `traceReplay` is set. */
+  private replayFidelity: ReplayFidelity | null = null;
 
   constructor(options: CrawlerOptions, events: CrawlerEvents = {}) {
     validateOptions(options);
@@ -518,6 +520,9 @@ export class ChaosCrawler {
       this.advisorRuntime.picks = [];
       this.advisorRuntime.pendingPick = null;
     }
+    this.replayFidelity = this.options.traceReplay
+      ? { totalActions: 0, succeeded: 0, selectorMissing: 0, noSelectorRecorded: 0, threw: 0 }
+      : null;
 
     if (this.isRecordingTrace()) {
       this.trace.push({
@@ -2018,7 +2023,25 @@ export class ChaosCrawler {
       }
       this.events.onAction?.(result);
       this.logger.logAction(result);
+      this.recordReplayOutcome(action, result);
       await page.waitForTimeout(100);
+    }
+  }
+
+  private recordReplayOutcome(action: TraceAction, result: ActionResult): void {
+    const f = this.replayFidelity;
+    if (!f) return;
+    f.totalActions += 1;
+    if (result.success) {
+      f.succeeded += 1;
+      return;
+    }
+    if (result.error?.startsWith("replay: entry has no selector")) {
+      f.noSelectorRecorded += 1;
+    } else if (result.error?.startsWith("replay: element not visible")) {
+      f.selectorMissing += 1;
+    } else {
+      f.threw += 1;
     }
   }
 
@@ -2185,6 +2208,7 @@ export class ChaosCrawler {
             picks: [...this.advisorRuntime.picks],
           }
         : undefined,
+      replayFidelity: this.replayFidelity ? { ...this.replayFidelity } : undefined,
       errorClusters: clusterErrors(this.results.flatMap((r) => r.errors)),
       har: this.options.har,
     };

--- a/packages/chaosbringer/src/reporter.test.ts
+++ b/packages/chaosbringer/src/reporter.test.ts
@@ -188,6 +188,45 @@ describe("formatReport", () => {
     const out = formatReport(makeReport());
     expect(out).not.toContain("VLM ADVISOR");
   });
+
+  it("includes a REPLAY FIDELITY section when traceReplay was used", () => {
+    const report = makeReport({
+      replayFidelity: {
+        totalActions: 10,
+        succeeded: 7,
+        selectorMissing: 2,
+        noSelectorRecorded: 1,
+        threw: 0,
+      },
+    });
+    const out = formatReport(report);
+    expect(out).toContain("REPLAY FIDELITY");
+    expect(out).toContain("7/10 actions replayed cleanly (70.0%)");
+    expect(out).toContain("selectorMissing=2");
+    expect(out).toContain("noSelectorRecorded=1");
+    expect(out).toContain("threw=0");
+  });
+
+  it("omits the drift breakdown when replay was 100% clean", () => {
+    const report = makeReport({
+      replayFidelity: {
+        totalActions: 5,
+        succeeded: 5,
+        selectorMissing: 0,
+        noSelectorRecorded: 0,
+        threw: 0,
+      },
+    });
+    const out = formatReport(report);
+    expect(out).toContain("REPLAY FIDELITY");
+    expect(out).toContain("5/5 actions replayed cleanly (100.0%)");
+    expect(out).not.toContain("drift breakdown");
+  });
+
+  it("omits the replay-fidelity section when traceReplay was not used", () => {
+    const out = formatReport(makeReport());
+    expect(out).not.toContain("REPLAY FIDELITY");
+  });
 });
 
 describe("saveReport", () => {

--- a/packages/chaosbringer/src/reporter.ts
+++ b/packages/chaosbringer/src/reporter.ts
@@ -182,6 +182,22 @@ export function formatReport(report: CrawlReport): string {
     }
   }
 
+  if (report.replayFidelity && report.replayFidelity.totalActions > 0) {
+    const r = report.replayFidelity;
+    const drift = r.totalActions - r.succeeded;
+    const pct = ((r.succeeded / r.totalActions) * 100).toFixed(1);
+    lines.push("");
+    lines.push("-".repeat(40));
+    lines.push("REPLAY FIDELITY");
+    lines.push("-".repeat(40));
+    lines.push(`  ${r.succeeded}/${r.totalActions} actions replayed cleanly (${pct}%)`);
+    if (drift > 0) {
+      lines.push(
+        `  drift breakdown: selectorMissing=${r.selectorMissing} noSelectorRecorded=${r.noSelectorRecorded} threw=${r.threw}`
+      );
+    }
+  }
+
   if (report.advisor && report.advisor.callsAttempted > 0) {
     const a = report.advisor;
     lines.push("");

--- a/packages/chaosbringer/src/types.ts
+++ b/packages/chaosbringer/src/types.ts
@@ -681,6 +681,26 @@ export interface CrawlReport {
   har?: HarConfig;
   /** Diff against a baseline report, present only when a baseline was supplied. */
   diff?: ReportDiff;
+  /**
+   * Drift signal for `--trace-replay` runs. Present only when traceReplay
+   * was set. Reports how many of the recorded trace actions resolved
+   * cleanly against the current UI vs. drifted (selector missing, threw,
+   * etc.) — surfaces UI drift before stale traces silently start producing
+   * meaningless replays.
+   */
+  replayFidelity?: ReplayFidelity;
+}
+
+export interface ReplayFidelity {
+  /** Total trace actions attempted (excludes meta + visit entries). */
+  totalActions: number;
+  succeeded: number;
+  /** Recorded selector did not resolve / element not visible. */
+  selectorMissing: number;
+  /** Recorded action had no selector (e.g. scroll fallback). */
+  noSelectorRecorded: number;
+  /** Replay threw (e.g. navigation timeout, click timeout). */
+  threw: number;
 }
 
 export interface AdvisorPick {


### PR DESCRIPTION
## Summary

**Last** §12 follow-up. Resolves the **replay fidelity (UI drift)** open question.

Recorded traces drift over time as the UI changes — selectors stop resolving, elements stop being visible. Without instrumentation that drift is invisible: a stale trace produces a "successful" \`--trace-replay\` run that didn't actually reproduce anything because every action errored quietly.

## What ships

\`CrawlReport.replayFidelity?\` (present only when \`traceReplay\` was set):
\`\`\`ts
{
  totalActions: number;       // how many TraceAction entries we attempted
  succeeded: number;          // resolved + executed cleanly
  selectorMissing: number;    // recorded selector did not resolve / element not visible
  noSelectorRecorded: number; // recorded entry had no selector (rare, mostly scroll fallbacks)
  threw: number;              // playwright click/fill threw
}
\`\`\`

\`formatReport\` adds a section:
\`\`\`
----------------------------------------
REPLAY FIDELITY
----------------------------------------
  7/10 actions replayed cleanly (70.0%)
  drift breakdown: selectorMissing=2 noSelectorRecorded=1 threw=0
\`\`\`

The drift breakdown is omitted when replay was 100% clean.

## Why general-purpose, not advisor-specific

Design doc §12 framed this around advisor-driven replays specifically, but the underlying drift problem is identical for heuristic-driven replays. The metric ships unconditionally on \`--trace-replay\` runs so existing users benefit immediately, not only those using the advisor.

## Verified

- [x] \`pnpm test\` -> 474/474 pass (3 new + 471 prior, no regression)
- [x] tsc clean
- [x] NUL gate clean

## §12 closure

| Open question | Status |
|---|---|
| redactReasoning flag | #45 merged |
| viewport vs fullPage screenshot | #46 merged |
| CLI cost / call summary | #47 merged |
| Replay fidelity tracking | this PR |

All §12 open questions now resolved. Advisor design proposal #38 is fully realized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)