### PR TITLE
docs+ci: RELEASING.md + multi-package publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      package_dir:
+        description: "Package dir under packages/ (e.g. chaosbringer, playwright-faults). Required for workflow_dispatch."
+        required: false
 
 permissions:
   contents: read
@@ -23,12 +27,36 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      - name: Determine target package directory
+        id: pkg
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_DIR: ${{ inputs.package_dir }}
+        run: |
+          # Tag formats handled:
+          #   <short-name>-v<ver>  (release-please monorepo style)
+          #   v<ver>               (legacy chaosbringer-only, through 0.6.0)
+          # workflow_dispatch overrides via the package_dir input.
+          if [[ -n "$INPUT_DIR" ]]; then
+            dir="packages/${INPUT_DIR}"
+          elif [[ "$TAG" =~ ^([a-z0-9-]+)-v[0-9] ]]; then
+            dir="packages/${BASH_REMATCH[1]}"
+          else
+            dir="packages/chaosbringer"
+          fi
+          if [[ ! -f "${dir}/package.json" ]]; then
+            echo "::error::No package.json at ${dir} (resolved from tag '${TAG}' / input '${INPUT_DIR}')"
+            exit 1
+          fi
+          echo "dir=${dir}" >> "$GITHUB_OUTPUT"
+          echo "Publishing from ${dir}"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm -F chaosbringer run build
+      - name: Build (recursive — workspace deps must be built before any single package publishes)
+        run: pnpm -r build
 
       - name: Publish to npm (OIDC Trusted Publishing)
-        working-directory: packages/chaosbringer
+        working-directory: ${{ steps.pkg.outputs.dir }}
         run: npm publish --access public --provenance

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,125 @@
+# Releasing chaosbringer + Layer-1 packages
+
+This monorepo ships **four** npm packages from one git repo. Each has its own version, lockstep is **not** required. Some have ordering constraints (chaosbringer's deps must publish first).
+
+| Package | npm name | Source | Status |
+|---|---|---|---|
+| Crawler CLI / library | `chaosbringer` | `packages/chaosbringer/` | Published; release-please-managed |
+| Server-side fault injection | `@mizchi/server-faults` | `packages/server-faults/` | Awaiting first publish (manual OIDC bootstrap) |
+| V8 coverage primitives | `@mizchi/playwright-v8-coverage` | `packages/playwright-v8-coverage/` | Awaiting first publish (manual OIDC bootstrap) |
+| Network/lifecycle/runtime fault primitives | `@mizchi/playwright-faults` | `packages/playwright-faults/` | Awaiting first publish (manual OIDC bootstrap) |
+
+## TL;DR — releasing chaosbringer 0.8.0+ requires deps on npm first
+
+`packages/chaosbringer/package.json` declares `workspace:^` deps on `@mizchi/playwright-faults` and `@mizchi/playwright-v8-coverage`. At publish time pnpm rewrites `workspace:^` to the **published** version of each dep. If the dep is not on npm yet, the chaosbringer tarball will fail to install for any consumer fetching it from npm.
+
+Therefore: **before triggering chaosbringer 0.8.0**, `@mizchi/playwright-faults@0.1.0` and `@mizchi/playwright-v8-coverage@0.1.0` MUST be on npm.
+
+## Step 1 — bootstrap OIDC trusted publishing for new packages (one-time, mizchi)
+
+The CI `publish.yml` uses OIDC ("Trusted Publishing") to publish without any long-lived npm token. For each NEW package's first publish, npm requires the package to exist on the registry **before** OIDC can authenticate. Bootstrap by publishing manually once:
+
+```bash
+cd packages/server-faults
+npm publish --access public          # asks for 2FA OTP
+
+cd ../playwright-v8-coverage
+npm publish --access public
+
+cd ../playwright-faults
+npm publish --access public
+```
+
+`--provenance` is intentionally omitted: provenance generation requires a CI environment (GitHub Actions OIDC). For the manual bootstrap, plain publish is fine.
+
+After each first publish, configure the **Trusted Publisher** on npmjs.com:
+
+1. https://www.npmjs.com/package/@mizchi/server-faults/access (and equivalent for the other two)
+2. "Trusted Publisher" → "Add Publisher" → GitHub Actions
+3. Repository: `mizchi/chaosbringer`
+4. Workflow filename: `publish.yml`
+5. Environment: leave blank (this repo doesn't use deployment environments)
+
+Once configured, all subsequent publishes from CI succeed with `--provenance`.
+
+## Step 2 — release flow for chaosbringer (release-please)
+
+Currently configured in `release-please-config.json` and `.release-please-manifest.json`.
+
+```
+git push  # commits with feat:/fix:/perf: prefixes
+↓
+release-please.yml workflow_dispatch (or auto on PR merge to main of release-please-- branches)
+↓
+release-please-action opens a "chore(main): release chaosbringer X.Y.Z" PR
+↓
+merge that PR
+↓
+release-please.yml fires AGAIN on the merge (head.ref starts with release-please--)
+↓
+release-please creates tag chaosbringer-v<X.Y.Z> + GitHub Release
+↓
+publish.yml triggers on `release: published`
+↓
+npm publish (OIDC, with provenance)
+```
+
+**Caveat from this repo's history:** when the workspace migration in #42 changed the package's path mid-release-cycle, release-please's path-based commit matching skipped the in-flight feat: commits. Resolution was a manual 0.6.0 release (one commit bumping version + CHANGELOG, then tag + GH Release manually). After the workspace-relative paths stabilized in main, release-please resumed working correctly for 0.7.0 (#49).
+
+## Step 3 — release flow for the new Layer-1 packages
+
+Currently NOT in release-please. Two options going forward:
+
+### Option A: keep them manually-versioned (low overhead, 1-2 releases/year)
+
+Bump version in the package's `package.json`, update `CHANGELOG.md` if any, then `cd packages/<x> && npm publish --access public --provenance` (the provenance flag works in CI; for local-from-laptop manual publish, drop `--provenance`).
+
+### Option B: extend release-please-config.json to manage them
+
+Adds entries like:
+
+```json
+"packages": {
+  "packages/chaosbringer": { "package-name": "chaosbringer", "changelog-path": "CHANGELOG.md" },
+  "packages/playwright-faults": { "package-name": "@mizchi/playwright-faults", "changelog-path": "CHANGELOG.md" },
+  ...
+}
+```
+
+release-please will then open a PR per package that has unreleased feat:/fix: commits. Each PR's merge tags `<name>-v<ver>` and `publish.yml` (after the multi-package update below) publishes that one.
+
+Option B is cleaner long-term but adds CI surface. Defer until release frequency justifies it.
+
+## Step 4 — multi-package publish.yml
+
+`publish.yml` currently hardcodes `packages/chaosbringer` as the publish target. To support all 4 packages it must derive the target from the release tag.
+
+Tag format conventions:
+- `chaosbringer-v<ver>` (release-please monorepo style) → `packages/chaosbringer`
+- `v<ver>` (legacy chaosbringer-only, used through 0.6.0) → `packages/chaosbringer`
+- `<short-name>-v<ver>` for scoped packages (release-please drops the scope prefix in the tag) → `packages/<short-name>`
+
+Reference `publish.yml` skeleton (see this PR for the actual implementation):
+
+```yaml
+- name: Determine target package directory
+  id: pkg
+  env:
+    TAG: ${{ github.event.release.tag_name }}
+  run: |
+    if [[ "$TAG" =~ ^([a-z0-9-]+)-v[0-9] ]]; then
+      echo "dir=packages/${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+    else
+      echo "dir=packages/chaosbringer" >> "$GITHUB_OUTPUT"   # legacy v<ver> tag
+    fi
+- run: pnpm -r build
+- working-directory: ${{ steps.pkg.outputs.dir }}
+  run: npm publish --access public --provenance
+```
+
+## Anti-checklist (mistakes from this repo's history)
+
+- **Don't bump `chaosbringer` to a version whose deps aren't yet on npm.** The published tarball will be broken even though local CI passes.
+- **Don't trigger `release-please.yml` immediately after a workspace-path migration.** Path-based commit matching may skip in-flight `feat:` commits. Either wait for a clean post-migration cycle or do a manual release for the transitional version (chaosbringer's 0.6.0 in this repo).
+- **Don't add `--provenance` to local manual publishes.** It requires CI OIDC and fails locally with `Automatic provenance generation not supported for provider: null`.
+- **Don't forget to add `prepare: tsc` to a new workspace package** that other workspace packages depend on. Without it, the dependent's prepare runs on fresh install before the dep is built and tsc fails with `Cannot find module @mizchi/<x>`.


### PR DESCRIPTION
## Summary

Two complementary changes that close out the Layer-1 extraction arc (#43, #50, #51) so the next release-and-publish cycle isn't a guessing game:

1. **\`docs/RELEASING.md\`** — full release procedure for the workspace
2. **\`.github/workflows/publish.yml\`** — generalized to handle any of the 4 packages

## docs/RELEASING.md

Captures:
- One-time OIDC bootstrap per new package (manual \`npm publish\`, then npmjs.com Trusted Publisher config)
- **Publish ordering**: chaosbringer 0.8.0 cannot release before \`@mizchi/playwright-faults\` and \`@mizchi/playwright-v8-coverage\` are on npm (pnpm rewrites \`workspace:^\` to the published version)
- release-please flow + the workspace-migration caveat that bit us this session (chaosbringer 0.6.0 went out manually because path-based commit matching skipped in-flight feat: commits)
- Anti-checklist of the four mistakes hit in this rollout (broken-tarball release, post-migration release-please miss, \`--provenance\` locally, missing \`prepare: tsc\` on a depended-on package)

## publish.yml

Derives target package dir from the release tag prefix:

| Tag pattern | Target |
|---|---|
| \`chaosbringer-v<ver>\` | \`packages/chaosbringer\` |
| \`playwright-faults-v<ver>\` | \`packages/playwright-faults\` |
| \`playwright-v8-coverage-v<ver>\` | \`packages/playwright-v8-coverage\` |
| \`server-faults-v<ver>\` | \`packages/server-faults\` |
| \`v<ver>\` (legacy) | \`packages/chaosbringer\` |

Plus a \`workflow_dispatch\` input \`package_dir\` for ad-hoc manual triggers.

\`pnpm -r build\` runs before publish so workspace deps are built first — required when publishing a non-chaosbringer package.

**No behavior change for the existing chaosbringer release path.** New packages can ride the same workflow once their npm-side OIDC is bootstrapped.

## What this does NOT do

- Doesn't fix the chaosbringer 404 OIDC issue (that needs npm.js Trusted Publisher config — mizchi-side, documented in RELEASING.md step 1)
- Doesn't add the new packages to release-please (deferred per RELEASING.md "Option B"; manual versioning is fine for the initial release cadence)
- Doesn't bump chaosbringer to 0.8.0 (waits for deps to be on npm)

## Test plan

- [ ] CI \`build-and-test\` / \`chaos-crawl\` / \`flaker-merge\` pass
- [ ] \`publish.yml\` itself doesn't run on this PR (no release event), but the YAML parse check by GH Actions catches syntax errors
- [ ] mizchi reads RELEASING.md and the next release goes smoothly without rediscovering the four pitfalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)