### PR TITLE
chore: add justfile + recursive lint:nul in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint — no NUL bytes in source
-        run: pnpm -F chaosbringer lint:nul
+      - name: Lint — no NUL bytes in source (all workspace packages)
+        run: pnpm -r lint:nul
 
       - name: Build
         run: pnpm -F chaosbringer build

--- a/justfile
+++ b/justfile
@@ -1,0 +1,49 @@
+# chaosbringer monorepo — `just <recipe>` shortcuts.
+# Recipes are workspace-aware: `just build` / `just test` etc. operate on every package
+# via `pnpm -r`. Use `just <pkg> <recipe>` to scope to one package, e.g. `just chaosbringer test`.
+
+set shell := ["bash", "-c"]
+set positional-arguments
+
+default:
+    @just --list
+
+# install deps for the whole workspace
+install:
+    pnpm install --frozen-lockfile
+
+# build every package in topological order
+build:
+    pnpm -r build
+
+# run every package's vitest suite (chaosbringer's includes the Playwright fixture e2e)
+test:
+    pnpm -r test
+
+# fail the build when any source file contains a NUL byte (background: see scripts/check-no-nul.mjs)
+lint-nul:
+    pnpm -r lint:nul
+
+# remove dist + node_modules across the workspace
+clean:
+    rm -rf packages/*/dist packages/*/node_modules node_modules
+
+# run a script within one package: `just pkg chaosbringer build`
+pkg name *args:
+    pnpm -F {{name}} {{args}}
+
+# run the fixture site standalone (chaosbringer dev loop)
+fixture-serve:
+    pnpm -F chaosbringer fixture:serve
+
+# crawl the local fixture (assumes fixture-serve is running on PORT=4173)
+fixture-crawl:
+    pnpm -F chaosbringer fixture:run
+
+# release ops — see docs/RELEASING.md for the full procedure
+release-please:
+    gh workflow run release-please.yml --ref main
+
+# manual publish for the FIRST release of a new package (OIDC bootstrap; no --provenance from local)
+publish-bootstrap pkg:
+    cd packages/{{pkg}} && npm publish --access public


### PR DESCRIPTION
## Summary

Two small workspace-hygiene items.

### \`justfile\`

Per CLAUDE.md "タスク: justfile". Workspace-aware shortcuts:

| Recipe | Action |
|---|---|
| \`just install\` / \`build\` / \`test\` / \`lint-nul\` / \`clean\` | recursive across all packages |
| \`just pkg <name> <script>\` | forward to one package |
| \`just fixture-serve\` / \`fixture-crawl\` | chaosbringer dev loop |
| \`just release-please\` | dispatch release-please workflow |
| \`just publish-bootstrap <pkg>\` | manual OIDC bootstrap (no \`--provenance\`) |

### \`ci.yml\`: \`pnpm -F chaosbringer lint:nul\` -> \`pnpm -r lint:nul\`

The 3 new Layer-1 packages already declare \`lint:nul\` in their \`package.json\`. Recursive form covers them automatically. Locally verified: 4 of 5 workspace projects (root has no script) all clean.

## Verified

- [x] \`just --list\` renders all recipes
- [x] \`pnpm -r lint:nul\` clean across all packages

## Out of scope

- Updating chaosbringer's existing scripts to call \`just\` (not worth the churn)
- A workspace-level \`lint\` recipe via biome (chaosbringer's own \`lint\` works; the new packages don't have biome configured yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)