### PR TITLE
fix(server-faults): add prepare: tsc so dist/ is populated before publish

### DIFF
--- a/packages/server-faults/package.json
+++ b/packages/server-faults/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "test": "vitest run",
     "lint:nul": "node ../chaosbringer/scripts/check-no-nul.mjs src"
   },


### PR DESCRIPTION
## Why

`@mizchi/server-faults` was the only Layer-1 package without `prepare: tsc`. Result: `pnpm install` did not build it, and an OIDC bootstrap publish (`cd packages/server-faults && npm publish --access public`) would have shipped a tarball without `dist/` — `main` / `types` pointing at non-existent files, broken on consumer install.

## What

One line: add `"prepare": "tsc"` to `packages/server-faults/package.json`.

## Verification

After this PR, on a fresh `pnpm install`:

```
$ ls packages/server-faults/dist/
index.d.ts  index.js  server-faults.d.ts  server-faults.js  (+ .map files)

$ npm pack --dry-run
... dist/index.{js,d.ts,...}
... dist/server-faults.{js,d.ts,...}
total files: 14
```

`pnpm -r test` still 391/391 pass.

## Why server-faults specifically was missed

playwright-v8-coverage and playwright-faults got `prepare: tsc` because chaosbringer depends on them via `workspace:^` and the missing prepare-script broke topological install (codified in memory). server-faults has no in-workspace consumer, so the missing prepare didn't surface as a `pnpm install` failure — only as a "tarball published from a fresh checkout would be empty" hazard at bootstrap time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)