### PR TITLE
feat(server-faults): add bypassHeader / exemptPathPattern

### DIFF
--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -62,8 +62,16 @@ app.use(async (req, res, next) => {
 | `latencyRate` | `number` (0..1) | `0` | Probability of injected latency |
 | `latencyMs` | `number \| {minMs, maxMs}` | — | Sleep duration. Number = constant; range = uniform pick |
 | `pathPattern` | `RegExp \| string` | none | Only matching paths are considered for fault injection |
+| `exemptPathPattern` | `RegExp \| string` | none | Paths that match are passed through unconditionally — useful for health checks or seed endpoints. Wins over `pathPattern`. |
+| `bypassHeader` | `string` | none | Header name (case-insensitive). Any request that carries it is passed through unconditionally — useful for warm-up / fixture traffic in tests. |
 | `seed` | `number` | none (`Math.random`) | When given, fault selection is reproducible across runs |
 | `observer.onFault` | `(kind, attrs) => void` | none | Telemetry callback |
+
+### Bypass and exempt — when to use which
+
+- **`bypassHeader`** is opt-in **per request**. The caller (test runner, fixture script, internal monitor) attaches the header to mark "this one is mine, don't break it." Headers don't show up in the URL, so it is safe for shared paths.
+- **`exemptPathPattern`** is opt-out **by URL**. It carves out a region of the surface that the caller cannot touch (e.g. `^/api/health`). Use this for paths that should *never* see chaos regardless of who calls them.
+- Both fire **before** any raffle, so they are zero-cost on exempt traffic and they do not invoke `observer.onFault`.
 
 ## Semantics
 

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -135,6 +135,83 @@ describe("serverFaults", () => {
     expect(onFault).toHaveBeenCalledWith("latency", expect.objectContaining({ ms: 1, path: "/api/x" }));
   });
 
+  describe("bypassHeader", () => {
+    it("skips fault raffle when the named header is present (case-insensitive)", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        status5xxRate: 1,
+        bypassHeader: "x-chaos-bypass",
+        observer: { onFault },
+      });
+      const r = new Request("https://test.local/api/x", {
+        headers: { "X-Chaos-Bypass": "1" },
+      });
+      expect(await fault.maybeInject(r)).toBeNull();
+      expect(onFault).not.toHaveBeenCalled();
+    });
+
+    it("still rolls fault when the header is absent", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        bypassHeader: "x-chaos-bypass",
+      });
+      expect(await fault.maybeInject(req("/api/x"))).not.toBeNull();
+    });
+
+    it("ignores any other header value", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        bypassHeader: "x-chaos-bypass",
+      });
+      const r = new Request("https://test.local/api/x", {
+        headers: { "x-some-other": "1" },
+      });
+      expect(await fault.maybeInject(r)).not.toBeNull();
+    });
+  });
+
+  describe("exemptPathPattern", () => {
+    it("skips fault raffle when pathname matches (RegExp)", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        status5xxRate: 1,
+        exemptPathPattern: /^\/api\/health/,
+        observer: { onFault },
+      });
+      expect(await fault.maybeInject(req("/api/health"))).toBeNull();
+      expect(await fault.maybeInject(req("/api/health/deep"))).toBeNull();
+      expect(onFault).not.toHaveBeenCalled();
+    });
+
+    it("skips fault raffle when pathname matches (string)", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        exemptPathPattern: "^/api/health",
+      });
+      expect(await fault.maybeInject(req("/api/health"))).toBeNull();
+    });
+
+    it("still rolls fault for non-exempt paths", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        exemptPathPattern: /^\/api\/health/,
+      });
+      expect(await fault.maybeInject(req("/api/users"))).not.toBeNull();
+    });
+
+    it("exemption short-circuits before pathPattern", async () => {
+      // exempt covers a sub-prefix of pathPattern. The exempt pathname matches
+      // both, but exempt should win and the request should pass through.
+      const fault = serverFaults({
+        status5xxRate: 1,
+        pathPattern: /^\/api\//,
+        exemptPathPattern: /^\/api\/health/,
+      });
+      expect(await fault.maybeInject(req("/api/health"))).toBeNull();
+      expect(await fault.maybeInject(req("/api/users"))).not.toBeNull();
+    });
+  });
+
   it("does not roll latency raffle when 5xx already won", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -30,6 +30,19 @@ export interface ServerFaultConfig {
   latencyMs?: number | { minMs: number; maxMs: number };
   /** RegExp or pattern string. Only matching paths are considered for fault injection. */
   pathPattern?: RegExp | string;
+  /**
+   * Header name (case-insensitive) that, when present on a request, makes that
+   * request bypass all fault raffles. Use this to keep test fixture / warm-up
+   * traffic out of the chaos surface.
+   */
+  bypassHeader?: string;
+  /**
+   * RegExp or pattern string. Requests whose pathname matches are skipped
+   * unconditionally (e.g. health checks, seed endpoints). Evaluated before
+   * `pathPattern`; an exempt request never has a raffle rolled, even if it
+   * also matches `pathPattern`.
+   */
+  exemptPathPattern?: RegExp | string;
   /** Optional. When set, fault selection (which raffles win) is reproducible across runs. */
   seed?: number;
   observer?: ServerFaultObserver;
@@ -72,11 +85,23 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         ? new RegExp(cfg.pathPattern)
         : null;
 
+  const exemptPattern =
+    cfg.exemptPathPattern instanceof RegExp
+      ? cfg.exemptPathPattern
+      : cfg.exemptPathPattern
+        ? new RegExp(cfg.exemptPathPattern)
+        : null;
+
+  const bypassHeader = cfg.bypassHeader?.toLowerCase();
+
   const rng: SeededRng = cfg.seed !== undefined ? mulberry32(cfg.seed) : { next: () => Math.random() };
 
   return {
     async maybeInject(req: Request): Promise<Response | null> {
+      if (bypassHeader && req.headers.has(bypassHeader)) return null;
+
       const url = new URL(req.url);
+      if (exemptPattern && exemptPattern.test(url.pathname)) return null;
       if (pattern && !pattern.test(url.pathname)) return null;
 
       const r5 = cfg.status5xxRate ?? 0;


### PR DESCRIPTION
Closes #55.

Two opt-out mechanisms for keeping non-production traffic out of the chaos surface, with different ergonomics:

- \`bypassHeader: \"x-chaos-bypass\"\` — per-request, set by the caller (test runner, fixture, internal monitor). Header lookup is case-insensitive. Useful for warm-up / fixture traffic on shared paths.
- \`exemptPathPattern: /^\\/api\\/health/\` — by URL, fixed at config time. Useful for paths that should never see chaos regardless of who calls them. Wins over \`pathPattern\`.

Both fire **before** any raffle, so exempt traffic is zero-cost and never invokes \`observer.onFault\`. README adds a \"when to use which\" note.

## Why

This is the very first thing that bit me when integrating \`@mizchi/server-faults\` into [otel-chaos-lab](https://github.com/mizchi/otel-chaos-lab) — the seed POST that warms up the crawler's BFS frontier was getting eaten by the same 5xx raffle as production traffic. Workaround there was retries; the right fix is letting the caller mark fixture traffic as exempt.

## Test plan

- [x] 7 new unit tests in \`server-faults.test.ts\`
- [x] All 20 server-faults tests pass (\`pnpm test\` in \`packages/server-faults\`)