### PR TITLE
feat(chaosbringer): add chaos({ setup }) pre-run hook for state seeding

### DIFF
--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -170,6 +170,28 @@ await chaos({
 
 Per-rule `matched` / `injected` counters end up in `report.faultInjections`.
 
+## Pre-run setup hook
+
+State-driven apps (CRUD, anything with a list) often start empty — the BFS frontier dries up at `pages=2` and `maxPages` becomes meaningless. `chaos({ setup })` runs **before** the crawler starts, in a disposable browser context, and gives you a `page` to seed backend state.
+
+```ts
+await chaos({
+  baseUrl: "http://localhost:3000",
+  setup: async ({ page, baseUrl }) => {
+    for (let i = 0; i < 5; i++) {
+      await page.request.post(`${baseUrl}/api/todos`, {
+        data: { title: `seed-${i}` },
+        // pair with @mizchi/server-faults' bypassHeader to keep seeds out of the chaos surface
+        headers: { "x-chaos-bypass": "1" },
+      });
+    }
+  },
+  // ... maxPages, faultInjection, etc.
+});
+```
+
+The setup browser is closed before the crawler starts; carry shared state through the server (REST seed) or by saving `storageState` to a file and pointing `options.storageState` at it.
+
 ## Lifecycle faults (client-side)
 
 `faultInjection` is request-scoped; **lifecycle faults** are page-scoped client-side perturbations that fire at well-defined stages of every page visit. Use them to simulate slow CPUs, stale auth tokens, evicted Service Worker caches, and other browser-side conditions that aren't expressible at the network layer.

--- a/packages/chaosbringer/src/chaos.test.ts
+++ b/packages/chaosbringer/src/chaos.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { chaos } from "./chaos.js";
+
+describe("chaos() setup hook", () => {
+  it("invokes setup before the crawl and forwards baseUrl + a Playwright page", async () => {
+    const setup = vi.fn(async ({ baseUrl, page }: { baseUrl: string; page: unknown }) => {
+      // smoke: page is a Playwright page-like object
+      expect(baseUrl).toBe("http://127.0.0.1:65535");
+      expect(page).toBeDefined();
+      expect(typeof (page as { goto: unknown }).goto).toBe("function");
+    });
+
+    // 65535 is reserved by some OSes, and we never connect anyway: the crawl
+    // will fail-fast and we only care that setup ran first. Wrap in catch so
+    // the unreachable baseUrl doesn't fail the test.
+    await chaos({
+      baseUrl: "http://127.0.0.1:65535",
+      maxPages: 1,
+      headless: true,
+      setup,
+    }).catch(() => {
+      /* expected: nothing is listening */
+    });
+
+    expect(setup).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it("does not invoke a missing setup", async () => {
+    // Pure shape check — a no-setup chaos run should still type-check and
+    // not crash before reaching the crawler. We bail the crawl by pointing
+    // at a closed port.
+    const result = await chaos({
+      baseUrl: "http://127.0.0.1:65535",
+      maxPages: 1,
+      headless: true,
+    }).catch((e) => e as Error);
+
+    expect(result).toBeDefined();
+  }, 30_000);
+});

--- a/packages/chaosbringer/src/chaos.test.ts
+++ b/packages/chaosbringer/src/chaos.test.ts
@@ -37,4 +37,24 @@ describe("chaos() setup hook", () => {
 
     expect(result).toBeDefined();
   }, 30_000);
+
+  it("does NOT invoke setup when CrawlerOptions validation fails", async () => {
+    // Re-ordering safety: validation runs in ChaosCrawler's constructor,
+    // which we now construct *before* the setup hook fires. A bad
+    // maxPages should reject the run without ever calling the user's
+    // backend-seeding side effect.
+    const setup = vi.fn(async () => {
+      throw new Error("setup must not run for invalid configs");
+    });
+
+    await expect(
+      chaos({
+        baseUrl: "http://127.0.0.1:65535",
+        maxPages: -1, // rejected by validateOptions
+        setup,
+      }),
+    ).rejects.toThrow(/maxPages/);
+
+    expect(setup).not.toHaveBeenCalled();
+  });
 });

--- a/packages/chaosbringer/src/chaos.ts
+++ b/packages/chaosbringer/src/chaos.ts
@@ -75,11 +75,19 @@ export async function chaos(
 ): Promise<ChaosResult> {
   const { strict, baseline, baselineStrict, setup, ...crawlerOptions } = options;
 
+  // Construct the crawler before invoking the setup hook so that
+  // CrawlerOptions validation (bad maxPages, malformed fault regex,
+  // invalid shard settings, …) runs first. Otherwise a user-visible
+  // side effect — typically a backend seed POST — fires for runs that
+  // would then fail validation, mutating state that should never have
+  // been touched. ChaosCrawler's constructor is side-effect-free; the
+  // browser doesn't start until .start(), so the re-ordering is safe.
+  const crawler = new ChaosCrawler(crawlerOptions, events);
+
   if (setup) {
     await runSetup(setup, options.baseUrl);
   }
 
-  const crawler = new ChaosCrawler(crawlerOptions, events);
   const report = await crawler.start();
 
   if (baseline) {

--- a/packages/chaosbringer/src/chaos.ts
+++ b/packages/chaosbringer/src/chaos.ts
@@ -4,6 +4,7 @@
  * these from CrawlReport; this just makes the common case one call.
  */
 
+import { chromium, type Page } from "playwright";
 import { ChaosCrawler } from "./crawler.js";
 import { diffReports, hasRegressions, loadBaseline } from "./diff.js";
 import { getExitCode } from "./reporter.js";
@@ -14,6 +15,21 @@ export interface ChaosResult {
   passed: boolean;
   exitCode: number;
 }
+
+/**
+ * Context handed to the `setup` hook. `page` is a one-shot Playwright page
+ * that lives only for the duration of the hook; it is closed before the
+ * crawler starts. Use `page.request` for REST seeding, or drive UI flows
+ * (e.g. login, then save the resulting `storageState` to disk and feed the
+ * path to `options.storageState`) when you need browser context to carry
+ * into the crawl.
+ */
+export interface ChaosSetupContext {
+  page: Page;
+  baseUrl: string;
+}
+
+export type ChaosSetupHook = (ctx: ChaosSetupContext) => Promise<void>;
 
 export interface ChaosRunOptions extends CrawlerOptions {
   /** Treat console errors / JS exceptions as failures when computing exitCode. */
@@ -27,13 +43,42 @@ export interface ChaosRunOptions extends CrawlerOptions {
   baseline?: string;
   /** When true, new regressions vs the baseline force exitCode=1. */
   baselineStrict?: boolean;
+  /**
+   * Pre-run hook that fires before any chaos action or fault rolls. Receives
+   * a Playwright page in a disposable browser context. Typical use is REST
+   * seeding via `page.request.post(...)` so the crawler has navigable state
+   * to discover. The disposable context does NOT carry into the crawl —
+   * propagate shared state through the server (REST) or by saving
+   * `storageState` to a path that the main crawler reads.
+   */
+  setup?: ChaosSetupHook;
+}
+
+async function runSetup(hook: ChaosSetupHook, baseUrl: string): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await hook({ page, baseUrl });
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
 }
 
 export async function chaos(
   options: ChaosRunOptions,
   events: CrawlerEvents = {}
 ): Promise<ChaosResult> {
-  const { strict, baseline, baselineStrict, ...crawlerOptions } = options;
+  const { strict, baseline, baselineStrict, setup, ...crawlerOptions } = options;
+
+  if (setup) {
+    await runSetup(setup, options.baseUrl);
+  }
+
   const crawler = new ChaosCrawler(crawlerOptions, events);
   const report = await crawler.start();
 


### PR DESCRIPTION
Closes #60.

State-driven apps (CRUD, lists) start empty, so the BFS frontier dries up at \`pages=2\` and \`maxPages\` becomes meaningless. Until now consumers had to write their own \"seed N rows then call chaos()\" runner — see [otel-chaos-lab's chaos/run.ts](https://github.com/mizchi/otel-chaos-lab/blob/main/chaos/run.ts) for an example. This PR ships the hook in the box.

## API

\`\`\`ts
await chaos({
  baseUrl,
  setup: async ({ page, baseUrl }) => {
    for (let i = 0; i < 5; i++) {
      await page.request.post(\`\${baseUrl}/api/todos\`, {
        data: { title: \`seed-\${i}\` },
        headers: { \"x-chaos-bypass\": \"1\" },  // pairs with #55
      });
    }
  },
  // ... maxPages, faultInjection, etc.
});
\`\`\`

## Semantics

The setup runs in a **disposable browser context** that is closed before the crawler starts. State propagates through:
- the server (REST seed via \`page.request.*\`) — the common case
- \`storageState\` saved to disk inside the hook + \`options.storageState\` on the crawl side, for login flows

This keeps the hook simple and decoupled from the crawler's own context. If we later want shared-context setup (e.g. in-memory fixtures), that can layer on without breaking this API.

## Test plan

- [x] 2 new tests in \`chaos.test.ts\` covering the with-setup and no-setup paths
- [x] All 391 existing chaosbringer tests still pass
- [x] \`pnpm exec tsc --noEmit\` clean

## Related

- #55 (\`bypassHeader\` on server-faults) — the README example uses both together so seed traffic skips the chaos surface
- #57 (trace correlation) — once setup traffic is on the same trace as the crawl, the seed is debuggable from Jaeger