### PR TITLE
feat(server-faults)!: stabilise observer.onFault attrs (BREAKING)

### DIFF
--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -87,11 +87,29 @@ const fault = serverFaults({
   observer: {
     onFault: (kind, attrs) => {
       // wire to OTel / Datadog / console — no framework dep imposed by this lib
-      faultsCounter.add(1, { kind, path: String(attrs.path) });
+      faultsCounter.add(1, {
+        kind,
+        path: attrs["fault.path"],
+        method: attrs["fault.method"],
+      });
     },
   },
 });
 ```
+
+### Semantic conventions for `attrs`
+
+`observer.onFault(kind, attrs)` passes a strongly-typed `FaultAttrs` object whose keys follow OTel-style `fault.*` naming so dashboards / pipelines can be reused across consumers.
+
+| Attribute | Type | Required | Notes |
+|---|---|---|---|
+| `fault.kind` | `"5xx" \| "latency"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
+| `fault.path` | `string` | always | URL pathname (no host, no query) |
+| `fault.method` | `string` | always | HTTP method, uppercased |
+| `fault.target_status` | `number` | when `kind === "5xx"` | the synthetic HTTP status returned |
+| `fault.latency_ms` | `number` | when `kind === "latency"` | milliseconds actually slept |
+
+The shape is part of the public contract: additions are backward-compatible, renames are not. This is why we shipped a stable schema before any consumer pinned to ad-hoc keys.
 
 ## License
 

--- a/packages/server-faults/src/index.ts
+++ b/packages/server-faults/src/index.ts
@@ -1,5 +1,7 @@
 export {
   serverFaults,
+  type FaultAttrs,
+  type FaultKind,
   type ServerFaultConfig,
   type ServerFaultHandle,
   type ServerFaultObserver,

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -114,17 +114,22 @@ describe("serverFaults", () => {
     sleepSpy.mockRestore();
   });
 
-  it("invokes observer.onFault for 5xx faults", async () => {
+  it("invokes observer.onFault for 5xx faults with semantic-convention attrs", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({
       status5xxRate: 1,
       observer: { onFault },
     });
     await fault.maybeInject(req("/api/x"));
-    expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ status: 503, path: "/api/x" }));
+    expect(onFault).toHaveBeenCalledWith("5xx", {
+      "fault.kind": "5xx",
+      "fault.path": "/api/x",
+      "fault.method": "GET",
+      "fault.target_status": 503,
+    });
   });
 
-  it("invokes observer.onFault for latency faults", async () => {
+  it("invokes observer.onFault for latency faults with semantic-convention attrs", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({
       latencyRate: 1,
@@ -132,7 +137,23 @@ describe("serverFaults", () => {
       observer: { onFault },
     });
     await fault.maybeInject(req("/api/x"));
-    expect(onFault).toHaveBeenCalledWith("latency", expect.objectContaining({ ms: 1, path: "/api/x" }));
+    expect(onFault).toHaveBeenCalledWith("latency", {
+      "fault.kind": "latency",
+      "fault.path": "/api/x",
+      "fault.method": "GET",
+      "fault.latency_ms": 1,
+    });
+  });
+
+  it("uppercases HTTP method in attrs (mirrors OTel http semantic convention)", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({
+      status5xxRate: 1,
+      observer: { onFault },
+    });
+    const r = new Request("https://test.local/api/x", { method: "post" as string });
+    await fault.maybeInject(r);
+    expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ "fault.method": "POST" }));
   });
 
   it("does not roll latency raffle when 5xx already won", async () => {

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -12,11 +12,33 @@
  * (1 roll for 5xx, conditionally 1 roll for latency).
  */
 
+export type FaultKind = "5xx" | "latency";
+
+/**
+ * Stable attribute schema fed to `observer.onFault`.
+ *
+ * Modeled on OTel semantic conventions: keys are namespaced under `fault.*`,
+ * values are primitive scalars so they map cleanly to OTel attributes,
+ * Prometheus labels, Datadog tags, etc. Required keys are always present;
+ * optional keys appear only when meaningful for the fault kind. Treat this
+ * shape as part of the public contract — additions are backward-compatible,
+ * renames are not.
+ */
+export interface FaultAttrs {
+  /** Mirror of the kind argument; included so an attrs object is self-describing if it ever travels without context. */
+  "fault.kind": FaultKind;
+  /** URL pathname (no host, no query). */
+  "fault.path": string;
+  /** Uppercase HTTP method. */
+  "fault.method": string;
+  /** Set when `fault.kind === "5xx"`. The synthetic HTTP status that was returned. */
+  "fault.target_status"?: number;
+  /** Set when `fault.kind === "latency"`. Milliseconds actually slept. */
+  "fault.latency_ms"?: number;
+}
+
 export interface ServerFaultObserver {
-  onFault?: (
-    kind: "5xx" | "latency",
-    attrs: Record<string, string | number>,
-  ) => void;
+  onFault?: (kind: FaultKind, attrs: FaultAttrs) => void;
 }
 
 export interface ServerFaultConfig {
@@ -79,10 +101,16 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
       const url = new URL(req.url);
       if (pattern && !pattern.test(url.pathname)) return null;
 
+      const method = req.method.toUpperCase();
       const r5 = cfg.status5xxRate ?? 0;
       if (r5 > 0 && rng.next() < r5) {
         const status = cfg.status5xxCode ?? 503;
-        cfg.observer?.onFault?.("5xx", { status, path: url.pathname });
+        cfg.observer?.onFault?.("5xx", {
+          "fault.kind": "5xx",
+          "fault.path": url.pathname,
+          "fault.method": method,
+          "fault.target_status": status,
+        });
         return Response.json(
           { error: "chaos: synthetic 5xx", path: url.pathname, status },
           { status },
@@ -92,7 +120,12 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
       const rL = cfg.latencyRate ?? 0;
       if (rL > 0 && rng.next() < rL) {
         const ms = pickLatencyMs(cfg.latencyMs);
-        cfg.observer?.onFault?.("latency", { ms, path: url.pathname });
+        cfg.observer?.onFault?.("latency", {
+          "fault.kind": "latency",
+          "fault.path": url.pathname,
+          "fault.method": method,
+          "fault.latency_ms": ms,
+        });
         await sleep(ms);
       }
       return null;


### PR DESCRIPTION
Closes #62.

Replaces the implementation-defined \`Record<string, string | number>\` attrs bag with a typed \`FaultAttrs\` interface modeled on OTel semantic conventions.

## Schema

| Attribute | Type | Required | Notes |
|---|---|---|---|
| \`fault.kind\` | \`\"5xx\" \\| \"latency\"\` | always | mirrors the \`kind\` arg |
| \`fault.path\` | \`string\` | always | URL pathname |
| \`fault.method\` | \`string\` | always | HTTP method, uppercased |
| \`fault.target_status\` | \`number\` | when \`kind === \"5xx\"\` | synthetic HTTP status |
| \`fault.latency_ms\` | \`number\` | when \`kind === \"latency\"\` | actual sleep ms |

## Why now

The attrs bag is the **contact point** with OTel / Datadog / Prometheus pipelines. Every consumer was inventing its own labels, which means dashboards cannot be shared between projects. Pinning the schema *before* consumers pile on keeps the convention coherent.

Additions to this shape stay backward-compatible going forward; renames will not.

## Breaking change

\`observer.onFault\` attrs now use \`fault.*\` namespaced keys instead of the old \`path\` / \`status\` / \`ms\`. Migration:

\`\`\`ts
// Before
onFault: (kind, attrs) => {
  metric.add(1, { kind, path: String(attrs.path), status: Number(attrs.status) });
}

// After
onFault: (kind, attrs) => {
  metric.add(1, {
    kind,
    path: attrs[\"fault.path\"],
    status: attrs[\"fault.target_status\"],
  });
}
\`\`\`

Consumers that only use the \`kind\` argument (e.g. otel-chaos-lab as of today) are **unaffected**.

## Test plan

- [x] 1 new test (method uppercasing); 14 server-faults tests pass
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] README \"Semantic conventions for attrs\" section added
- [x] \`FaultAttrs\` and \`FaultKind\` re-exported from package root

## Suggested merge order

This PR conflicts with #65 only at line ranges of \`ServerFaultConfig\` (no logical conflict). #65 / #67 / #68 / this PR can land in any order; whichever lands second resolves trivially.