### PR TITLE
fix(server-faults): make pathPattern / exemptPathPattern matching stateless

### DIFF
--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -212,6 +212,44 @@ describe("serverFaults", () => {
     });
   });
 
+  describe("stateless regex matching", () => {
+    // `RegExp.test()` is stateful with the `g` or `y` flag — `lastIndex`
+    // advances between calls, so a second call against the same input
+    // would spuriously miss. Both pathPattern and exemptPathPattern must
+    // be normalised before use.
+    it("handles g-flagged exemptPathPattern across repeated calls", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        exemptPathPattern: /^\/api\/health/g,
+      });
+      // 50 consecutive calls; every one must be exempt.
+      for (let i = 0; i < 50; i++) {
+        expect(await fault.maybeInject(req("/api/health"))).toBeNull();
+      }
+    });
+
+    it("handles g-flagged pathPattern across repeated calls", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        pathPattern: /^\/api\//g,
+      });
+      // Every matching call should land in the raffle and (with rate=1) inject.
+      for (let i = 0; i < 50; i++) {
+        expect(await fault.maybeInject(req("/api/x"))).not.toBeNull();
+      }
+    });
+
+    it("preserves case-insensitive flag while stripping g/y", async () => {
+      const fault = serverFaults({
+        status5xxRate: 1,
+        exemptPathPattern: /^\/API\/HEALTH/giy,
+      });
+      // i flag preserved -> /api/health and /API/HEALTH both exempt.
+      expect(await fault.maybeInject(req("/api/health"))).toBeNull();
+      expect(await fault.maybeInject(req("/API/HEALTH"))).toBeNull();
+    });
+  });
+
   it("does not roll latency raffle when 5xx already won", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -75,22 +75,29 @@ function pickLatencyMs(spec: ServerFaultConfig["latencyMs"]): number {
   return 0;
 }
 
+/**
+ * Coerce a user-supplied RegExp/string pattern into a stateless RegExp.
+ *
+ * `RegExp.test()` is **stateful** when the pattern carries the `g` or `y`
+ * flag — `lastIndex` advances between calls, so a second call against the
+ * same input can spuriously miss. That would make exempt paths
+ * intermittently receive injected faults, violating the documented
+ * "passed through unconditionally" contract. Strip those two flags so
+ * every call is positional from index 0; preserve `i` / `m` / `s` / `u`
+ * since they change *what* matches, not *how* the index moves.
+ */
+function compileStatelessPattern(p: RegExp | string | undefined): RegExp | null {
+  if (!p) return null;
+  if (typeof p === "string") return new RegExp(p);
+  if (!/[gy]/.test(p.flags)) return p;
+  return new RegExp(p.source, p.flags.replace(/[gy]/g, ""));
+}
+
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
-  const pattern =
-    cfg.pathPattern instanceof RegExp
-      ? cfg.pathPattern
-      : cfg.pathPattern
-        ? new RegExp(cfg.pathPattern)
-        : null;
-
-  const exemptPattern =
-    cfg.exemptPathPattern instanceof RegExp
-      ? cfg.exemptPathPattern
-      : cfg.exemptPathPattern
-        ? new RegExp(cfg.exemptPathPattern)
-        : null;
+  const pattern = compileStatelessPattern(cfg.pathPattern);
+  const exemptPattern = compileStatelessPattern(cfg.exemptPathPattern);
 
   const bypassHeader = cfg.bypassHeader?.toLowerCase();
 


### PR DESCRIPTION
Follow-up to merged #65, addressing the Codex P2 review comment on \`server-faults.ts:104\`.

## Problem

\`RegExp.test()\` is **stateful** when the supplied pattern has the \`g\` or \`y\` flag — \`lastIndex\` advances between calls, so a second call against the same input can spuriously miss. Concretely, a user who passes \`exemptPathPattern: /^\\/api\\/health/g\` would have **every other** request to \`/api/health\` skip the exemption and receive an injected fault, violating the documented \"passed through unconditionally\" contract.

The exact same bug applies to \`pathPattern\` since the merged #65 used the same construction for both.

## Fix

Extracted \`compileStatelessPattern()\` used for both \`pathPattern\` and \`exemptPathPattern\`:

\`\`\`ts
function compileStatelessPattern(p: RegExp | string | undefined): RegExp | null {
  if (!p) return null;
  if (typeof p === \"string\") return new RegExp(p);
  if (!/[gy]/.test(p.flags)) return p;          // common case: pass through
  return new RegExp(p.source, p.flags.replace(/[gy]/g, \"\"));
}
\`\`\`

- Preserves \`i\` / \`m\` / \`s\` / \`u\` because they change *what* matches, not *how* the index advances.
- String inputs go through \`new RegExp(p)\` which never sets \`g\` or \`y\`, so they need no special handling.
- Common case (no \`g\`/\`y\`) is a single \`/[gy]/.test(...)\` and a passthrough — zero allocation per use.

## Test plan

- [x] 3 new tests cover g-flag exempt, g-flag path, and \`i+g+y\` preservation of \`i\`
- [x] All 23 server-faults tests pass
- [x] \`pnpm exec tsc --noEmit\` clean

Resolves the Codex P2 finding from #65.