### PR TITLE
feat(chaosbringer): named fault profiles for shared operator knowledge

### DIFF
--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -184,6 +184,37 @@ await chaos({
 
 Per-rule `matched` / `injected` counters end up in `report.faultInjections`.
 
+### Fault profiles
+
+Hand-authored probabilities are easy to start with but hard to share. **Profiles** wrap operator knowledge — "S3 503 burst", "flaky third-party CDN", "regional degradation" — into a single function that returns a ready-made array of fault rules:
+
+```ts
+import { chaos, profiles } from "chaosbringer";
+
+await chaos({
+  baseUrl,
+  faultInjection: [
+    ...profiles.flakyThirdPartyCdn(/cdn\.example\.com/),
+    ...profiles.s3FivexxBurst(/s3\.amazonaws\.com/),
+    ...profiles.regionalDegradation({ urlPattern: /\/api\//, severity: 0.3 }),
+    ...profiles.slowAuthService(/\/auth\//),
+    ...profiles.partialDataLoss(/\/api\/feed/),
+  ],
+});
+```
+
+Available profiles (all return `FaultRule[]`):
+
+| Profile | What it models |
+|---|---|
+| `flakyThirdPartyCdn(urlPattern)` | Slow + occasional drops on a third-party CDN |
+| `s3FivexxBurst(urlPattern)` | Mostly 503 with a 500 sprinkle — retry-storm provocation |
+| `regionalDegradation({ urlPattern, severity })` | Severity-scaled mix of slow / 5xx / drop. `severity` is clamped to `[0, 1]` |
+| `slowAuthService(urlPattern, { ms?, rate? })` | One slow dependency. Defaults: 3000 ms, rate 0.5 |
+| `partialDataLoss(urlPattern, { rate? })` | Empty 200 body + occasional 5xx — catches `JSON.parse(\"\")` bugs |
+
+Each rule is named (`profile:behavior`), so per-profile counters land in `report.faultInjections` without extra wiring. Override knobs by passing options or compose `faults.*` directly when a profile doesn't fit.
+
 ## Pre-run setup hook
 
 State-driven apps (CRUD, anything with a list) often start empty — the BFS frontier dries up at `pages=2` and `maxPages` becomes meaningless. `chaos({ setup })` runs **before** the crawler starts, in a disposable browser context, and gives you a `page` to seed backend state.

--- a/packages/chaosbringer/src/index.ts
+++ b/packages/chaosbringer/src/index.ts
@@ -16,6 +16,7 @@ export {
   type LifecycleHelperOptions,
   type RuntimeHelperOptions,
 } from "./faults.js";
+export { profiles } from "./profiles.js";
 export {
   buildRuntimeFaultsScript,
   compileRuntimeFaults,

--- a/packages/chaosbringer/src/profiles.test.ts
+++ b/packages/chaosbringer/src/profiles.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { profiles } from "./profiles.js";
+
+const URL = /\/api\//;
+
+describe("profiles", () => {
+  it("flakyThirdPartyCdn returns slow + drop rules with conservative rates", () => {
+    const rules = profiles.flakyThirdPartyCdn(URL);
+    expect(rules).toHaveLength(2);
+    expect(rules[0].fault.kind).toBe("delay");
+    expect(rules[0].probability).toBeLessThan(0.5);
+    expect(rules[1].fault.kind).toBe("abort");
+    expect(rules[1].probability).toBeLessThanOrEqual(0.1);
+    // every rule names itself so report aggregation per-profile is trivial
+    expect(rules.every((r) => r.name?.startsWith("flaky-third-party-cdn:"))).toBe(true);
+  });
+
+  it("s3FivexxBurst is mostly 503 with a 500 sprinkle", () => {
+    const rules = profiles.s3FivexxBurst(URL);
+    expect(rules.map((r) => (r.fault.kind === "status" ? r.fault.status : null))).toEqual([503, 500]);
+    // 503 should fire much more often than 500
+    expect((rules[0].probability ?? 0) > (rules[1].probability ?? 0)).toBe(true);
+  });
+
+  it("regionalDegradation scales every probability by severity", () => {
+    const lo = profiles.regionalDegradation({ urlPattern: URL, severity: 0.1 });
+    const hi = profiles.regionalDegradation({ urlPattern: URL, severity: 0.9 });
+    for (let i = 0; i < lo.length; i++) {
+      expect((hi[i].probability ?? 0) > (lo[i].probability ?? 0)).toBe(true);
+    }
+  });
+
+  it("regionalDegradation clamps severity to [0, 1]", () => {
+    const negative = profiles.regionalDegradation({ urlPattern: URL, severity: -1 });
+    const huge = profiles.regionalDegradation({ urlPattern: URL, severity: 999 });
+    for (const r of negative) expect(r.probability).toBe(0);
+    for (const r of huge) expect((r.probability ?? 0)).toBeLessThanOrEqual(1);
+  });
+
+  it("slowAuthService accepts ms / rate overrides", () => {
+    const def = profiles.slowAuthService(URL);
+    const custom = profiles.slowAuthService(URL, { ms: 500, rate: 0.1 });
+    expect(def[0].fault.kind).toBe("delay");
+    if (def[0].fault.kind === "delay") expect(def[0].fault.ms).toBe(3000);
+    if (custom[0].fault.kind === "delay") expect(custom[0].fault.ms).toBe(500);
+    expect(custom[0].probability).toBeCloseTo(0.1);
+  });
+
+  it("partialDataLoss mixes empty 200 and 5xx", () => {
+    const rules = profiles.partialDataLoss(URL);
+    const kinds = rules.map((r) => (r.fault.kind === "status" ? r.fault.status : null));
+    expect(kinds).toContain(200);
+    expect(kinds).toContain(500);
+    // empty body lives on the 200 rule
+    const empty = rules.find((r) => r.fault.kind === "status" && r.fault.status === 200);
+    if (empty && empty.fault.kind === "status") {
+      expect(empty.fault.body).toBe("");
+    }
+  });
+
+  it("urlPattern is forwarded verbatim to every rule", () => {
+    const pattern = /^\/api\/v2\//;
+    const sets = [
+      profiles.flakyThirdPartyCdn(pattern),
+      profiles.s3FivexxBurst(pattern),
+      profiles.regionalDegradation({ urlPattern: pattern }),
+      profiles.slowAuthService(pattern),
+      profiles.partialDataLoss(pattern),
+    ];
+    for (const rules of sets) {
+      for (const r of rules) {
+        expect(r.urlPattern).toBe(pattern);
+      }
+    }
+  });
+});

--- a/packages/chaosbringer/src/profiles.ts
+++ b/packages/chaosbringer/src/profiles.ts
@@ -1,0 +1,114 @@
+/**
+ * Named fault profiles. Each profile is a small function that returns an
+ * array of FaultRule, expressing operator knowledge ("S3 is bursty",
+ * "the auth service is slow") that would otherwise live as ad-hoc
+ * probability numbers in every consumer's chaos config.
+ *
+ * Profiles are intentionally simple to compose:
+ *
+ *   import { chaos, profiles } from "chaosbringer";
+ *
+ *   await chaos({
+ *     baseUrl: "http://localhost:3000",
+ *     faultInjection: [
+ *       ...profiles.flakyThirdPartyCdn(/cdn\.example\.com/),
+ *       ...profiles.s3FivexxBurst(/s3\.amazonaws\.com/),
+ *     ],
+ *   });
+ *
+ * The numeric knobs in each profile are starting points based on what the
+ * lab has seen produce useful failures. Override anything by passing a
+ * second `options` argument; consumers who need a wholly different shape
+ * should compose `faults.*` directly instead.
+ */
+
+import { faults, type FaultHelperOptions } from "@mizchi/playwright-faults";
+import type { FaultRule, UrlMatcher } from "@mizchi/playwright-faults";
+
+/**
+ * Third-party CDN that is intermittently slow and occasionally drops a
+ * request. Conservative defaults — a chaos run with this profile should
+ * still let most pages through.
+ */
+function flakyThirdPartyCdn(urlPattern: UrlMatcher): FaultRule[] {
+  return [
+    faults.delay(2000, { urlPattern, probability: 0.3, name: "flaky-third-party-cdn:slow" }),
+    faults.abort({ urlPattern, probability: 0.05, name: "flaky-third-party-cdn:drop" }),
+  ];
+}
+
+/**
+ * Object-storage 5xx burst (S3-style). Mostly 503 (rate-limit / partition),
+ * occasional 500. Targets the kind of error pattern that causes
+ * exponential-backoff retry storms.
+ */
+function s3FivexxBurst(urlPattern: UrlMatcher): FaultRule[] {
+  return [
+    faults.status(503, { urlPattern, probability: 0.4, name: "s3-burst:503" }),
+    faults.status(500, { urlPattern, probability: 0.05, name: "s3-burst:500" }),
+  ];
+}
+
+/**
+ * "A region of the dependency graph is partially degraded." Severity 0..1
+ * scales every knob proportionally — 0.3 is the suggested default.
+ */
+function regionalDegradation(opts: {
+  urlPattern: UrlMatcher;
+  severity?: number;
+}): FaultRule[] {
+  const s = clamp01(opts.severity ?? 0.3);
+  return [
+    faults.delay(1500, { urlPattern: opts.urlPattern, probability: s * 0.7, name: "regional-degradation:slow" }),
+    faults.status(500, { urlPattern: opts.urlPattern, probability: s * 0.2, name: "regional-degradation:5xx" }),
+    faults.abort({ urlPattern: opts.urlPattern, probability: s * 0.1, name: "regional-degradation:drop" }),
+  ];
+}
+
+/**
+ * Single-dependency latency. Useful for testing that a slow auth
+ * service doesn't block first-paint or stall every page.
+ */
+function slowAuthService(urlPattern: UrlMatcher, opts?: { ms?: number; rate?: number }): FaultRule[] {
+  const ms = opts?.ms ?? 3000;
+  const rate = clamp01(opts?.rate ?? 0.5);
+  return [faults.delay(ms, { urlPattern, probability: rate, name: "slow-auth-service" })];
+}
+
+/**
+ * Mix of clean truncated bodies (200 with empty body) and outright errors.
+ * Catches consumers that crash on JSON.parse("") or assume a non-empty
+ * body on 200.
+ */
+function partialDataLoss(urlPattern: UrlMatcher, opts?: { rate?: number }): FaultRule[] {
+  const rate = clamp01(opts?.rate ?? 0.2);
+  return [
+    faults.status(200, {
+      urlPattern,
+      probability: rate * 0.6,
+      body: "",
+      contentType: "application/json",
+      name: "partial-data-loss:empty-200",
+    }),
+    faults.status(500, { urlPattern, probability: rate * 0.4, name: "partial-data-loss:5xx" }),
+  ];
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+export const profiles = {
+  flakyThirdPartyCdn,
+  s3FivexxBurst,
+  regionalDegradation,
+  slowAuthService,
+  partialDataLoss,
+};
+
+// Suppress unused-import warning for FaultHelperOptions; re-exported for
+// callers that want to write their own profile in the same shape.
+export type { FaultHelperOptions };


### PR DESCRIPTION
Closes #63.

Profiles wrap the kind of knowledge that gets hand-keyed into every chaos run (\"S3 is bursty\", \"CDN drops sometimes\") into named functions returning \`FaultRule[]\`. Consumers compose them with \`faults.*\` rules:

\`\`\`ts
faultInjection: [
  ...profiles.flakyThirdPartyCdn(/cdn\\.example\\.com/),
  ...profiles.s3FivexxBurst(/s3\\.amazonaws\\.com/),
  ...profiles.regionalDegradation({ urlPattern: /\\/api\\//, severity: 0.3 }),
],
\`\`\`

## Initial profile set

| Profile | What it models |
|---|---|
| \`flakyThirdPartyCdn(urlPattern)\` | Slow + occasional drops |
| \`s3FivexxBurst(urlPattern)\` | Mostly 503 with 500 sprinkle (retry-storm provocation) |
| \`regionalDegradation({ urlPattern, severity })\` | Severity-scaled mix; severity clamped to \`[0, 1]\` |
| \`slowAuthService(urlPattern, { ms?, rate? })\` | One slow dependency; defaults 3000 ms / 0.5 |
| \`partialDataLoss(urlPattern, { rate? })\` | Empty 200 + occasional 5xx — catches \`JSON.parse(\"\")\` bugs |

Each rule names itself \`profile-id:behavior\`, so per-profile counters land in \`report.faultInjections\` without extra wiring.

## On the numbers

The probabilities and ms values in this PR are **starting points**, picked from what produced useful failures during otel-chaos-lab runs. They are not load-tested empirics. Treat the profile names as the stable surface and the numbers as defaults that will likely move once we have more real-world data — overrides are deliberately first-class.

## Test plan

- [x] 7 unit tests in \`src/profiles.test.ts\` covering rule shape, name prefixes, urlPattern forwarding, severity scaling, and severity clamping
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] README has an entry under \"Fault injection\" with a comparison table

## Open questions

- Should \`profiles\` live in \`@mizchi/playwright-faults\` (where the underlying \`faults.*\` lives) instead of \`chaosbringer\`? Argument for staying here: profiles are ergonomics over the orchestrator, and we expect future profiles to compose lifecycle / runtime faults too. I left it here on that bet, happy to move if not.
- Do we want \`profiles.<name>.numbers\` exposed for inspection / dashboards?