### PR TITLE
feat(chaosbringer): inject W3C traceparent for OTel correlation

### DIFF
--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -215,6 +215,36 @@ Available profiles (all return `FaultRule[]`):
 
 Each rule is named (`profile:behavior`), so per-profile counters land in `report.faultInjections` without extra wiring. Override knobs by passing options or compose `faults.*` directly when a profile doesn't fit.
 
+## Trace correlation (W3C traceparent)
+
+When the server is OTel-instrumented, it's useful to find the server-side trace that corresponds to a specific browser-driven action. Enable `traceparent: true` and chaosbringer will inject a fresh W3C `traceparent` header onto every request the browser sends:
+
+```ts
+await chaos({
+  baseUrl: "http://localhost:3000",
+  traceparent: true,
+});
+```
+
+To capture the generated trace IDs in your own report, pass an `onInject` hook:
+
+```ts
+const traceIds: Array<{ url: string; traceId: string }> = [];
+
+await chaos({
+  baseUrl: "http://localhost:3000",
+  traceparent: {
+    onInject: ({ url, traceId, existing }) => {
+      // `existing` is true when the request already carried a traceparent
+      // (e.g. set by an outer middleware) — chaosbringer never overwrites it.
+      traceIds.push({ url, traceId });
+    },
+  },
+});
+```
+
+The injected header is the standard `00-{trace-id}-{span-id}-01` format. Existing `traceparent` headers are honoured (passed through unchanged), so explicit upstream propagation always wins. The fault-injection layer also keeps the header attached, so a fault response and the matching server-side trace share the same correlation id.
+
 ## Pre-run setup hook
 
 State-driven apps (CRUD, anything with a list) often start empty — the BFS frontier dries up at `pages=2` and `maxPages` becomes meaningless. `chaos({ setup })` runs **before** the crawler starts, in a disposable browser context, and gives you a `page` to seed backend state.

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -4,6 +4,7 @@
 
 import type { Browser, BrowserContext, Page, Route } from "playwright";
 import { chromium, devices } from "playwright";
+import { randomBytes } from "node:crypto";
 import { mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type {
@@ -114,6 +115,7 @@ const DEFAULT_OPTIONS: Required<
     | "failureArtifacts"
     | "coverageFeedback"
     | "advisor"
+    | "traceparent"
   >
 > = {
   maxPages: 50,
@@ -165,6 +167,23 @@ export const COMMON_IGNORE_PATTERNS = [
   // Generic error message from blocked resources
   "Failed to load resource: net::ERR_FAILED$",
 ];
+
+/**
+ * Parse a W3C traceparent header. Returns `null` if the value is malformed.
+ * Used by the route handler when honouring an incoming traceparent so we
+ * can still pass `traceId` / `spanId` to the consumer hook.
+ *
+ * Format: `00-{trace-id-32hex}-{span-id-16hex}-{flags-2hex}`.
+ *
+ * Exported for testing — consumers should not parse traceparents
+ * themselves.
+ */
+export function parseTraceparent(value: string): { traceId: string; spanId: string } | null {
+  // version-traceId-spanId-flags
+  const m = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i.exec(value.trim());
+  if (!m) return null;
+  return { traceId: m[2].toLowerCase(), spanId: m[3].toLowerCase() };
+}
 
 function describeTarget(t: ActionTarget): string {
   const parts: string[] = [];
@@ -706,7 +725,11 @@ export class ChaosCrawler {
     this.baseOrigin = new URL(url).origin;
 
     // Set up external navigation blocking and/or fault injection routing.
-    if (this.options.blockExternalNavigation || this.compiledFaultRules.length > 0) {
+    if (
+      this.options.blockExternalNavigation ||
+      this.compiledFaultRules.length > 0 ||
+      this.options.traceparent
+    ) {
       await this.setupNavigationBlocking(page);
     }
 
@@ -1117,6 +1140,9 @@ export class ChaosCrawler {
   private async setupNavigationBlocking(page: Page): Promise<void> {
     const blockExternal = this.options.blockExternalNavigation;
     const rules = this.compiledFaultRules;
+    const traceparentEnabled = this.options.traceparent !== undefined && this.options.traceparent !== false;
+    const traceparentHook =
+      typeof this.options.traceparent === "object" ? this.options.traceparent.onInject : undefined;
 
     // Install a single route handler that first considers fault injection,
     // then falls back to external-navigation blocking, then continues.
@@ -1124,6 +1150,42 @@ export class ChaosCrawler {
       const request = route.request();
       const url = request.url();
       const method = request.method().toUpperCase();
+
+      // Decide on the traceparent header up front so it's attached to every
+      // path through this handler (fault response, blocked, fallback).
+      let outgoingHeaders: Record<string, string> | null = null;
+      if (traceparentEnabled) {
+        const reqHeaders = await request.allHeaders();
+        const existingTp = reqHeaders["traceparent"];
+        if (existingTp) {
+          // Honour explicit propagation upstream — but still surface it to
+          // the consumer hook so the report can record the correlation id.
+          if (traceparentHook) {
+            const parts = parseTraceparent(existingTp);
+            traceparentHook({
+              url,
+              method,
+              traceparent: existingTp,
+              traceId: parts?.traceId ?? "",
+              spanId: parts?.spanId ?? "",
+              existing: true,
+            });
+          }
+        } else {
+          const traceId = randomBytes(16).toString("hex"); // 32 hex chars
+          const spanId = randomBytes(8).toString("hex"); // 16 hex chars
+          const traceparent = `00-${traceId}-${spanId}-01`;
+          outgoingHeaders = { ...reqHeaders, traceparent };
+          traceparentHook?.({
+            url,
+            method,
+            traceparent,
+            traceId,
+            spanId,
+            existing: false,
+          });
+        }
+      }
 
       // 1. Fault injection has priority so tests can exercise backends that
       // would otherwise be allowed through.
@@ -1156,7 +1218,13 @@ export class ChaosCrawler {
 
       // route.fallback() (not continue) so context-level routes — notably
       // routeFromHAR for replay — still get a chance to serve this request.
-      await route.fallback();
+      // When traceparent injection is on, override headers; otherwise let the
+      // request through unchanged.
+      if (outgoingHeaders) {
+        await route.fallback({ headers: outgoingHeaders });
+      } else {
+        await route.fallback();
+      }
     });
   }
 
@@ -1191,7 +1259,11 @@ export class ChaosCrawler {
       }
     }
 
-    if (this.options.blockExternalNavigation || this.compiledFaultRules.length > 0) {
+    if (
+      this.options.blockExternalNavigation ||
+      this.compiledFaultRules.length > 0 ||
+      this.options.traceparent
+    ) {
       await this.setupNavigationBlocking(page);
     }
 

--- a/packages/chaosbringer/src/index.ts
+++ b/packages/chaosbringer/src/index.ts
@@ -166,6 +166,7 @@ export type {
   ClusterDiffEntry,
   PageDiffEntry,
   FailureArtifactsOptions,
+  TraceparentInjectionOptions,
 } from "./types.js";
 export { NETWORK_PROFILES, PERF_BUDGET_KEYS } from "./types.js";
 export { networkConditionsFor, type NetworkConditions } from "./network.js";

--- a/packages/chaosbringer/src/traceparent.test.ts
+++ b/packages/chaosbringer/src/traceparent.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { parseTraceparent } from "./crawler.js";
+
+describe("parseTraceparent", () => {
+  it("parses a well-formed traceparent into traceId and spanId", () => {
+    const tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    expect(parseTraceparent(tp)).toEqual({
+      traceId: "0af7651916cd43dd8448eb211c80319c",
+      spanId: "b7ad6b7169203331",
+    });
+  });
+
+  it("is case-insensitive on input but lowercases the output", () => {
+    const tp = "00-0AF7651916CD43DD8448EB211C80319C-B7AD6B7169203331-01";
+    const got = parseTraceparent(tp);
+    expect(got?.traceId).toBe("0af7651916cd43dd8448eb211c80319c");
+    expect(got?.spanId).toBe("b7ad6b7169203331");
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(parseTraceparent("  00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01\n")).not.toBeNull();
+  });
+
+  it.each([
+    ["empty", ""],
+    ["wrong segment count", "00-trace-span"],
+    ["short trace id", "00-deadbeef-b7ad6b7169203331-01"],
+    ["short span id", "00-0af7651916cd43dd8448eb211c80319c-cafe-01"],
+    ["non-hex char", "00-0af7651916cd43dd8448eb211c80319g-b7ad6b7169203331-01"],
+  ])("returns null for malformed input (%s)", (_label, input) => {
+    expect(parseTraceparent(input)).toBeNull();
+  });
+});

--- a/packages/chaosbringer/src/types.ts
+++ b/packages/chaosbringer/src/types.ts
@@ -33,6 +33,20 @@ export interface CrawlerOptions {
   userAgent?: string;
   /** Block navigation to external domains */
   blockExternalNavigation?: boolean;
+  /**
+   * Inject a fresh W3C `traceparent` header onto every request the browser
+   * sends. Pair with an OTel-instrumented server to correlate browser-driven
+   * actions with server-side traces.
+   *
+   * - `true` / `{}`        — generate a new trace per request.
+   * - `false` / undefined  — do nothing (default).
+   * - `{ onInject }`       — also receive the generated traceparent so the
+   *                          consumer can stash it in their own report.
+   *
+   * Existing `traceparent` headers (e.g. set by another middleware) are left
+   * alone so explicit propagation always wins.
+   */
+  traceparent?: boolean | TraceparentInjectionOptions;
   /** Action weighting configuration */
   actionWeights?: ActionWeights;
   /** Log file path (enables file logging) */
@@ -149,6 +163,32 @@ export interface CrawlerOptions {
    * Default: undefined (advisor disabled, zero overhead).
    */
   advisor?: AdvisorConfig;
+}
+
+/**
+ * Options for `CrawlerOptions.traceparent`. The hook lets the consumer
+ * stash the generated trace ID alongside their own per-request data
+ * (e.g. for cross-referencing the browser-side action log with a
+ * server-side OTel trace).
+ */
+export interface TraceparentInjectionOptions {
+  /**
+   * Called once per request *after* the traceparent header is decided.
+   * `traceparent` is the full W3C value, `traceId` and `spanId` are the
+   * pre-split components (32-hex / 16-hex).
+   *
+   * If the request already carried a `traceparent` header (e.g. set by
+   * an outer middleware), the existing value is forwarded as-is and
+   * `existing` is `true`. Consumers can use this to avoid double-counting.
+   */
+  onInject?: (info: {
+    url: string;
+    method: string;
+    traceparent: string;
+    traceId: string;
+    spanId: string;
+    existing: boolean;
+  }) => void;
 }
 
 export interface FailureArtifactsOptions {


### PR DESCRIPTION
Closes #57 (PoC scope).

Adds \`CrawlerOptions.traceparent: boolean | { onInject }\`. When set, the route handler that already governs fault injection and nav blocking also generates a fresh W3C traceparent (\`00-{32hex}-{16hex}-01\`) for every request and injects it via \`route.fallback({ headers })\`.

\`\`\`ts
await chaos({
  baseUrl,
  traceparent: {
    onInject: ({ url, traceId, existing }) => {
      // existing === true when the request already had a traceparent;
      // chaosbringer never overwrites explicit upstream propagation.
      myReport.set(url, traceId);
    },
  },
});
\`\`\`

## Behavior

- Generates a new traceparent **per request**; consumer hook receives \`{ url, method, traceparent, traceId, spanId, existing }\`.
- Honours an incoming \`traceparent\` (the consumer's existing middleware wins) and still surfaces the parsed components to the hook.
- Travels along the same code path as fault injection, so a fault response and the corresponding server-side trace share the correlation id.

## Out of scope (deliberate)

- Writing \`request.traceId\` directly into \`chaos-report.json\` — needs a small types.ts change and design discussion on whether to attach it to \`actions[]\` or a sibling \`requestTraces\` array. Happy to follow up in a second PR once this primitive lands.
- Per-page reuse of one trace_id across all sub-resources. The current \"new trace per request\" model is the simpler and more conservative starting point; we can layer page-scoped grouping on top if real consumers want it.

## Test plan

- [x] 8 unit tests for \`parseTraceparent\` (used to honour incoming traceparent)
- [x] All 402 existing chaosbringer tests still pass (\`pnpm test\`)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] README adds a \"Trace correlation\" section under Fault injection

The new option is opt-in (default \`undefined\` / \`false\`), so existing crawls don't get touched.