### PR TITLE
feat: new package @mizchi/cf-faults — KV / Service Binding chaos

### DIFF
--- a/packages/cf-faults/README.md
+++ b/packages/cf-faults/README.md
@@ -1,0 +1,84 @@
+# @mizchi/cf-faults
+
+Cloudflare Workers-specific chaos injection. Targets the failure modes that don't fit cleanly into HTTP-level chaos:
+
+- **KV namespaces** — make `get` / `put` / `delete` / `list` throw or return null
+- **Service Bindings** — make `env.X.fetch()` return a synthetic 5xx or abort
+
+The wrappers are drop-in (same shape as the underlying binding), so application code is unchanged. Each fault is surfaced through an `observer.onFault` hook with the same `fault.*` attribute schema as [`@mizchi/server-faults`](../server-faults), so a single OTel pipeline catches both layers.
+
+## Install
+
+```bash
+pnpm add @mizchi/cf-faults
+```
+
+Requires Node 20+. The package is zero-dep; no `@cloudflare/workers-types` requirement on consumers — bindings are matched structurally.
+
+## Usage
+
+### KV namespace
+
+```ts
+import { wrapKv } from "@mizchi/cf-faults";
+
+const todos = wrapKv(env.TODOS, {
+  rate: 0.1,
+  kinds: ["throw", "miss"],   // any subset of "throw" | "miss"
+  bindingName: "TODOS",       // shows up as fault.target on observer events
+  seed: 42,                   // reproducible run; omit for Math.random
+  observer: {
+    onFault: (kind, attrs) => myMetric.add(1, { kind, target: attrs["fault.target"] }),
+  },
+});
+
+// use `todos` exactly like the original env.TODOS
+const t = await todos.get(id); // ← may throw or be null
+```
+
+| Kind | Effect | Applies to |
+|---|---|---|
+| `"throw"` | Reject the call with a synthetic Error | `get`, `put`, `delete`, `list` |
+| `"miss"` | Resolve `get` to `null` regardless of underlying value | `get` only (other ops fall through) |
+
+### Service Binding
+
+```ts
+import { wrapServiceBinding } from "@mizchi/cf-faults";
+
+const enricher = wrapServiceBinding(env.ENRICHER, {
+  status5xxRate: 0.3,
+  status5xxCode: 503,
+  abortRate: 0.05,
+  bindingName: "ENRICHER",
+  seed: 42,
+  observer: {
+    onFault: (kind, attrs) => myMetric.add(1, { kind, target: attrs["fault.target"] }),
+  },
+});
+
+const res = await enricher.fetch("https://enricher/enrich", { method: "POST", body });
+```
+
+5xx and abort are independent raffles (5xx is rolled first). At `status5xxRate=1, abortRate=1` the 5xx wins, mirroring `@mizchi/server-faults`'s "single fault per request" semantics.
+
+## Observer schema
+
+`observer.onFault(kind, attrs)` follows the `fault.*` namespace shared with `@mizchi/server-faults`:
+
+| Attribute | Required | Notes |
+|---|---|---|
+| `fault.kind` | always | `"kv.throw" \| "kv.miss" \| "service.5xx" \| "service.abort"` |
+| `fault.target` | when set | KV / Service binding name |
+| `fault.path` | always | KV op label (`get:KEY`) or service URL pathname |
+| `fault.target_status` | for `service.5xx` | the synthetic HTTP status |
+
+The shared schema means a single OTel counter (`fault.injections_total`) can aggregate across server-side and Cloudflare-binding chaos.
+
+## Why a separate package
+
+Server-side fault injection (`@mizchi/server-faults`) operates on Web Standard `Request` / `Response` and is framework-agnostic. KV / Service Binding aren't on that surface — they're Cloudflare runtime APIs with their own shapes — so layering them onto server-faults would muddy its contract. Splitting keeps server-faults framework-agnostic and lets `cf-faults` evolve without holding it back.
+
+## License
+
+MIT

--- a/packages/cf-faults/package.json
+++ b/packages/cf-faults/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@mizchi/cf-faults",
+  "version": "0.1.0",
+  "description": "Cloudflare Workers-specific chaos injection: KV namespaces and Service Bindings.",
+  "license": "MIT",
+  "author": "mizchi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/chaosbringer.git",
+    "directory": "packages/cf-faults"
+  },
+  "homepage": "https://github.com/mizchi/chaosbringer/tree/main/packages/cf-faults#readme",
+  "bugs": {
+    "url": "https://github.com/mizchi/chaosbringer/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc",
+    "test": "vitest run",
+    "lint:nul": "node ../chaosbringer/scripts/check-no-nul.mjs src"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "fault-injection",
+    "chaos-engineering",
+    "cloudflare-workers",
+    "kv",
+    "service-binding",
+    "testing"
+  ],
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "vitest": "^3.0.7"
+  }
+}

--- a/packages/cf-faults/src/index.ts
+++ b/packages/cf-faults/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  wrapKv,
+  type KvLike,
+  type KvFaultKind,
+  type WrapKvOptions,
+} from "./kv.js";
+export {
+  wrapServiceBinding,
+  type FetcherLike,
+  type WrapServiceBindingOptions,
+} from "./service.js";
+export {
+  type CfFaultAttrs,
+  type CfFaultKind,
+  type CfFaultObserver,
+} from "./types.js";

--- a/packages/cf-faults/src/kv.test.ts
+++ b/packages/cf-faults/src/kv.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapKv, type KvLike } from "./kv.js";
+
+function fakeKv(overrides: Partial<KvLike> = {}): KvLike {
+  return {
+    get: vi.fn(async () => "real-value"),
+    put: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+    list: vi.fn(async () => ({ keys: [], list_complete: true })),
+    ...overrides,
+  };
+}
+
+describe("wrapKv", () => {
+  it("passes calls through unchanged at rate=0", async () => {
+    const inner = fakeKv();
+    const wrapped = wrapKv(inner, { rate: 0 });
+    expect(await wrapped.get("k")).toBe("real-value");
+    await wrapped.put("k", "v");
+    await wrapped.delete("k");
+    await wrapped.list();
+    expect(inner.get).toHaveBeenCalledTimes(1);
+    expect(inner.put).toHaveBeenCalledTimes(1);
+    expect(inner.delete).toHaveBeenCalledTimes(1);
+    expect(inner.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on every call at rate=1 with kind=throw", async () => {
+    const inner = fakeKv();
+    const wrapped = wrapKv(inner, { rate: 1, kinds: ["throw"] });
+    await expect(wrapped.get("k")).rejects.toThrow(/kv\.throw/);
+    await expect(wrapped.put("k", "v")).rejects.toThrow(/kv\.throw/);
+    await expect(wrapped.delete("k")).rejects.toThrow(/kv\.throw/);
+    await expect(wrapped.list()).rejects.toThrow(/kv\.throw/);
+    // Inner KV is never touched when the raffle wins.
+    expect(inner.get).not.toHaveBeenCalled();
+    expect(inner.put).not.toHaveBeenCalled();
+  });
+
+  it("returns null on get at rate=1 with kind=miss; falls through on put/delete/list", async () => {
+    const inner = fakeKv();
+    const wrapped = wrapKv(inner, { rate: 1, kinds: ["miss"] });
+    expect(await wrapped.get("k")).toBeNull();
+    // miss is a get-only effect — put/delete/list must still hit the underlying KV
+    await wrapped.put("k", "v");
+    await wrapped.delete("k");
+    await wrapped.list();
+    expect(inner.put).toHaveBeenCalledTimes(1);
+    expect(inner.delete).toHaveBeenCalledTimes(1);
+    expect(inner.list).toHaveBeenCalledTimes(1);
+    // ...and the inner get was bypassed
+    expect(inner.get).not.toHaveBeenCalled();
+  });
+
+  it("invokes observer.onFault with semantic-convention attrs", async () => {
+    const onFault = vi.fn();
+    const inner = fakeKv();
+    const wrapped = wrapKv(inner, {
+      rate: 1,
+      kinds: ["throw"],
+      bindingName: "TODOS",
+      observer: { onFault },
+    });
+    await expect(wrapped.get("foo")).rejects.toThrow();
+    expect(onFault).toHaveBeenCalledWith("kv.throw", {
+      "fault.kind": "kv.throw",
+      "fault.target": "TODOS",
+      "fault.path": "get:foo",
+    });
+  });
+
+  it("is reproducible with the same seed", async () => {
+    const inner = fakeKv();
+    const a = wrapKv(inner, { rate: 0.5, seed: 42 });
+    const b = wrapKv(inner, { rate: 0.5, seed: 42 });
+    const aSeq: boolean[] = [];
+    const bSeq: boolean[] = [];
+    for (let i = 0; i < 20; i++) {
+      aSeq.push(await a.get(`k${i}`).then(() => false).catch(() => true));
+      bSeq.push(await b.get(`k${i}`).then(() => false).catch(() => true));
+    }
+    expect(aSeq).toEqual(bSeq);
+  });
+});

--- a/packages/cf-faults/src/kv.ts
+++ b/packages/cf-faults/src/kv.ts
@@ -1,0 +1,107 @@
+/**
+ * KV namespace fault injection.
+ *
+ * Wraps a Cloudflare KV namespace so that `get` / `put` / `delete` / `list`
+ * occasionally throw or return null — the kind of failure mode that
+ * exercises a Worker's graceful-degradation paths and shows up clearly in
+ * server-side OTel traces (each KV call is its own span via
+ * `@microlabs/otel-cf-workers`'s auto-instrumentation).
+ *
+ * The wrapper has the same shape as the underlying namespace, so wiring
+ * is one line:
+ *
+ *   const todos = wrapKv(env.TODOS, { rate: 0.1, kinds: ["throw"] });
+ */
+
+import { makeRng, type CfFaultObserver, type SeededRng } from "./types.js";
+
+/**
+ * The duck-typed KV surface we wrap. Matches the public contract of
+ * `KVNamespace` (Cloudflare Workers types) but only at the call sites
+ * this wrapper actually proxies through. Consumers pass their real
+ * `env.MY_KV` and TS narrows structurally.
+ */
+export interface KvLike {
+  get(key: string, options?: unknown): Promise<unknown>;
+  put(key: string, value: unknown, options?: unknown): Promise<unknown>;
+  delete(key: string): Promise<unknown>;
+  list(options?: unknown): Promise<unknown>;
+}
+
+export type KvFaultKind = "throw" | "miss";
+
+export interface WrapKvOptions {
+  /** 0..1 — probability of injecting a fault on each call. Default 0. */
+  rate: number;
+  /**
+   * Which fault flavours can fire when the raffle wins. Default `["throw"]`.
+   * - `"throw"` rejects the wrapped call with a synthetic Error.
+   * - `"miss"` makes `get` resolve to `null` regardless of the underlying
+   *   value. Other ops are unaffected (you can't "miss" a `put`); when the
+   *   raffle picks `miss` for a non-`get` op it falls through unchanged.
+   */
+  kinds?: KvFaultKind[];
+  /** Reproducible run when set. Otherwise uses Math.random. */
+  seed?: number;
+  /** KV binding name; surfaced through `observer.onFault` as `fault.target`. */
+  bindingName?: string;
+  observer?: CfFaultObserver;
+}
+
+function pickKind(kinds: KvFaultKind[], rng: SeededRng): KvFaultKind {
+  if (kinds.length <= 1) return kinds[0] ?? "throw";
+  return kinds[Math.min(kinds.length - 1, Math.floor(rng.next() * kinds.length))];
+}
+
+export function wrapKv<T extends KvLike>(kv: T, opts: WrapKvOptions): T {
+  const rng = makeRng(opts.seed);
+  const kinds = opts.kinds && opts.kinds.length > 0 ? opts.kinds : (["throw"] as KvFaultKind[]);
+  const bindingName = opts.bindingName;
+
+  function shouldFire(): false | KvFaultKind {
+    if (opts.rate <= 0) return false;
+    if (rng.next() >= opts.rate) return false;
+    return pickKind(kinds, rng);
+  }
+
+  const wrapped: KvLike = {
+    async get(key, options) {
+      const kind = shouldFire();
+      if (kind === "throw") {
+        opts.observer?.onFault?.("kv.throw", { "fault.kind": "kv.throw", "fault.target": bindingName, "fault.path": `get:${key}` });
+        throw new Error(`cf-faults: synthetic kv.throw on get(${JSON.stringify(key)})`);
+      }
+      if (kind === "miss") {
+        opts.observer?.onFault?.("kv.miss", { "fault.kind": "kv.miss", "fault.target": bindingName, "fault.path": `get:${key}` });
+        return null;
+      }
+      return kv.get(key, options);
+    },
+    async put(key, value, options) {
+      const kind = shouldFire();
+      if (kind === "throw") {
+        opts.observer?.onFault?.("kv.throw", { "fault.kind": "kv.throw", "fault.target": bindingName, "fault.path": `put:${key}` });
+        throw new Error(`cf-faults: synthetic kv.throw on put(${JSON.stringify(key)})`);
+      }
+      // "miss" doesn't apply to put — fall through unchanged.
+      return kv.put(key, value, options);
+    },
+    async delete(key) {
+      const kind = shouldFire();
+      if (kind === "throw") {
+        opts.observer?.onFault?.("kv.throw", { "fault.kind": "kv.throw", "fault.target": bindingName, "fault.path": `delete:${key}` });
+        throw new Error(`cf-faults: synthetic kv.throw on delete(${JSON.stringify(key)})`);
+      }
+      return kv.delete(key);
+    },
+    async list(options) {
+      const kind = shouldFire();
+      if (kind === "throw") {
+        opts.observer?.onFault?.("kv.throw", { "fault.kind": "kv.throw", "fault.target": bindingName, "fault.path": "list" });
+        throw new Error(`cf-faults: synthetic kv.throw on list`);
+      }
+      return kv.list(options);
+    },
+  };
+  return wrapped as T;
+}

--- a/packages/cf-faults/src/service.test.ts
+++ b/packages/cf-faults/src/service.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapServiceBinding, type FetcherLike } from "./service.js";
+
+function fakeFetcher(): FetcherLike {
+  return { fetch: vi.fn(async () => Response.json({ ok: true })) };
+}
+
+describe("wrapServiceBinding", () => {
+  it("passes through when both rates are 0", async () => {
+    const inner = fakeFetcher();
+    const wrapped = wrapServiceBinding(inner, {});
+    const r = await wrapped.fetch("https://b.local/enrich");
+    expect(r.status).toBe(200);
+    expect(inner.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns synthetic 5xx at status5xxRate=1", async () => {
+    const inner = fakeFetcher();
+    const wrapped = wrapServiceBinding(inner, { status5xxRate: 1, status5xxCode: 502 });
+    const r = await wrapped.fetch("https://b.local/enrich");
+    expect(r.status).toBe(502);
+    const body = await r.json();
+    expect(body).toMatchObject({ status: 502 });
+    expect(inner.fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws at abortRate=1", async () => {
+    const inner = fakeFetcher();
+    const wrapped = wrapServiceBinding(inner, { abortRate: 1 });
+    await expect(wrapped.fetch("https://b.local/enrich")).rejects.toThrow(/service\.abort/);
+    expect(inner.fetch).not.toHaveBeenCalled();
+  });
+
+  it("5xx wins over abort when both rates are 1 (raffle order is deterministic)", async () => {
+    const inner = fakeFetcher();
+    const wrapped = wrapServiceBinding(inner, { status5xxRate: 1, abortRate: 1 });
+    const r = await wrapped.fetch("https://b.local/enrich");
+    expect(r.status).toBe(503);
+  });
+
+  it("invokes observer.onFault with semantic-convention attrs", async () => {
+    const onFault = vi.fn();
+    const inner = fakeFetcher();
+    const wrapped = wrapServiceBinding(inner, {
+      status5xxRate: 1,
+      bindingName: "ENRICHER",
+      observer: { onFault },
+    });
+    await wrapped.fetch("https://b.local/enrich/x?q=1");
+    expect(onFault).toHaveBeenCalledWith("service.5xx", {
+      "fault.kind": "service.5xx",
+      "fault.target": "ENRICHER",
+      "fault.path": "/enrich/x",
+      "fault.target_status": 503,
+    });
+  });
+
+  it("is reproducible with the same seed", async () => {
+    const inner = fakeFetcher();
+    const a = wrapServiceBinding(inner, { status5xxRate: 0.5, seed: 42 });
+    const b = wrapServiceBinding(inner, { status5xxRate: 0.5, seed: 42 });
+    const aSeq: number[] = [];
+    const bSeq: number[] = [];
+    for (let i = 0; i < 20; i++) {
+      aSeq.push((await a.fetch(`https://b.local/${i}`)).status);
+      bSeq.push((await b.fetch(`https://b.local/${i}`)).status);
+    }
+    expect(aSeq).toEqual(bSeq);
+  });
+});

--- a/packages/cf-faults/src/service.ts
+++ b/packages/cf-faults/src/service.ts
@@ -1,0 +1,88 @@
+/**
+ * Service Binding fault injection.
+ *
+ * Wraps a Cloudflare Service Binding (a `Fetcher`) so that `fetch()`
+ * occasionally returns a 5xx response or throws. Use this to test how
+ * Worker A degrades when Worker B is unavailable, without touching
+ * Worker B's deployment.
+ *
+ *   const enricher = wrapServiceBinding(env.ENRICHER, {
+ *     status5xxRate: 0.3,
+ *     abortRate: 0.05,
+ *   });
+ */
+
+import { makeRng, type CfFaultObserver, type SeededRng } from "./types.js";
+
+/**
+ * The duck-typed surface of a Cloudflare `Fetcher`. Matches what
+ * `env.MY_SERVICE` exposes for service-binding RPC.
+ */
+export interface FetcherLike {
+  fetch(input: string | Request, init?: RequestInit): Promise<Response>;
+}
+
+export interface WrapServiceBindingOptions {
+  /** 0..1 — probability of returning a synthetic 5xx response. Default 0. */
+  status5xxRate?: number;
+  /** Default 503. */
+  status5xxCode?: 500 | 502 | 503 | 504;
+  /** 0..1 — probability of throwing instead of returning a response. Default 0. */
+  abortRate?: number;
+  /** Reproducible run when set. */
+  seed?: number;
+  /** Service binding name; surfaced as `fault.target`. */
+  bindingName?: string;
+  observer?: CfFaultObserver;
+}
+
+function pathOf(input: string | Request): string {
+  try {
+    const u = new URL(typeof input === "string" ? input : input.url);
+    return u.pathname;
+  } catch {
+    return "";
+  }
+}
+
+export function wrapServiceBinding<T extends FetcherLike>(
+  fetcher: T,
+  opts: WrapServiceBindingOptions,
+): T {
+  const rng: SeededRng = makeRng(opts.seed);
+  const r5 = opts.status5xxRate ?? 0;
+  const rA = opts.abortRate ?? 0;
+  const code = opts.status5xxCode ?? 503;
+  const target = opts.bindingName;
+
+  const wrapped: FetcherLike = {
+    async fetch(input, init) {
+      const path = pathOf(input);
+
+      if (r5 > 0 && rng.next() < r5) {
+        opts.observer?.onFault?.("service.5xx", {
+          "fault.kind": "service.5xx",
+          "fault.target": target,
+          "fault.path": path,
+          "fault.target_status": code,
+        });
+        return Response.json(
+          { error: "cf-faults: synthetic service.5xx", path, status: code },
+          { status: code },
+        );
+      }
+
+      if (rA > 0 && rng.next() < rA) {
+        opts.observer?.onFault?.("service.abort", {
+          "fault.kind": "service.abort",
+          "fault.target": target,
+          "fault.path": path,
+        });
+        throw new Error(`cf-faults: synthetic service.abort${path ? ` on ${path}` : ""}`);
+      }
+
+      return fetcher.fetch(input, init);
+    },
+  };
+  return wrapped as T;
+}

--- a/packages/cf-faults/src/types.ts
+++ b/packages/cf-faults/src/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared types for @mizchi/cf-faults. We deliberately avoid pulling
+ * `@cloudflare/workers-types` so the package stays zero-dep — consumers
+ * pass their own KV / Fetcher instances and TypeScript narrows them
+ * structurally.
+ */
+
+export type CfFaultKind = "kv.throw" | "kv.miss" | "service.5xx" | "service.abort";
+
+/**
+ * Stable attribute schema fed to `observer.onFault`. Mirrors the
+ * `fault.*` namespace established in `@mizchi/server-faults` so consumers
+ * can reuse the same OTel / Prometheus pipeline across both packages.
+ */
+export interface CfFaultAttrs {
+  "fault.kind": CfFaultKind;
+  /** KV binding name or service binding name, when known to the wrapper. */
+  "fault.target"?: string;
+  /** KV op or service-binding URL pathname. */
+  "fault.path"?: string;
+  /** For service.5xx, the synthetic HTTP status. */
+  "fault.target_status"?: number;
+}
+
+export interface CfFaultObserver {
+  onFault?: (kind: CfFaultKind, attrs: CfFaultAttrs) => void;
+}
+
+/**
+ * Mulberry32 PRNG. Tiny, fast, fine for 0..1 raffle decisions; not for
+ * cryptography. Re-implemented (rather than imported from server-faults)
+ * to keep cf-faults a leaf package with no internal sibling deps.
+ */
+export interface SeededRng {
+  next(): number;
+}
+
+export function mulberry32(seed: number): SeededRng {
+  let s = seed >>> 0;
+  return {
+    next() {
+      s = (s + 0x6d2b79f5) >>> 0;
+      let t = s;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    },
+  };
+}
+
+export function makeRng(seed: number | undefined): SeededRng {
+  return seed !== undefined ? mulberry32(seed) : { next: () => Math.random() };
+}

--- a/packages/cf-faults/tsconfig.json
+++ b/packages/cf-faults/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .: {}
 
+  packages/cf-faults:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.7
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+
   packages/chaosbringer:
     dependencies:
       '@mizchi/playwright-faults':


### PR DESCRIPTION
Closes #61.

Adds \`@mizchi/cf-faults\`, a sibling to \`@mizchi/server-faults\` for the failure modes that don't fit cleanly on Web Standard Request/Response: Cloudflare Workers KV namespaces and Service Bindings.

\`\`\`ts
import { wrapKv, wrapServiceBinding } from \"@mizchi/cf-faults\";

const todos = wrapKv(env.TODOS, {
  rate: 0.1,
  kinds: [\"throw\", \"miss\"],
  bindingName: \"TODOS\",
  observer: { onFault: (kind, attrs) => metric.add(1, { kind, ...attrs }) },
});

const enricher = wrapServiceBinding(env.ENRICHER, {
  status5xxRate: 0.3,
  abortRate: 0.05,
  bindingName: \"ENRICHER\",
});
\`\`\`

## Design

- **Drop-in**: wrapper has the same shape as the underlying binding, application code is unchanged.
- **Zero-dep**: \`KvLike\` / \`FetcherLike\` are duck-typed so consumers don't need \`@cloudflare/workers-types\` and the package compiles standalone.
- **Shared \`fault.*\` schema**: \`observer.onFault\` uses the same attribute keys as \`@mizchi/server-faults\` (\`fault.kind\` / \`fault.target\` / \`fault.path\` / \`fault.target_status\`). One OTel pipeline catches both layers.
- **Same RNG primitive (mulberry32) as server-faults** for \`seed\`-driven reproducibility. Re-implemented in this package rather than imported across the workspace, to keep cf-faults a leaf with no internal sibling deps.

## Why a separate package

\`server-faults\` is framework-agnostic — Web Standard \`Request\` in, \`Response\` out. KV / Service Binding are Cloudflare runtime APIs with their own shapes. Layering them onto server-faults would muddy its contract and pull Cloudflare types into a generic library. Splitting keeps server-faults clean and lets cf-faults evolve at its own pace.

## What's not here (deliberate scope)

- D1 / Cache API / Durable Objects wrappers — easy follow-ups once the KV+Service-Binding pattern is reviewed and merged. Wanted to keep this PR small enough to actually read.
- KV \"stale\" fault kind — needs a notion of cached prior values; punted.
- Status flapping / latency injection on Service Binding — could come from \`server-faults\`-style reuse, but \`Fetcher\` doesn't have the same Web Standard hooks. Out of scope here.

## Test plan

- [x] 11 unit tests across \`kv.test.ts\` and \`service.test.ts\`
- [x] \`pnpm exec tsc --noEmit\` clean in \`packages/cf-faults\`
- [x] \`pnpm install\` from monorepo root: every existing package's \`prepare\` still builds, no version drift
- [x] No changes to \`chaosbringer\` / \`server-faults\` / \`playwright-faults\` — strictly additive

## Related

- README in \`packages/chaosbringer\` already links to this proposal in the layering table (added in #66). No further README changes needed there until the package is published.