### PR TITLE
feat(server-faults)!: flat FaultAttrs + traceId + FaultVerdict + metadataHeader

### DIFF
--- a/docs/superpowers/plans/2026-05-06-chaos-server-orchestration.md
+++ b/docs/superpowers/plans/2026-05-06-chaos-server-orchestration.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Wire `@mizchi/server-faults` events into a chaosbringer `chaos()` run via response headers and trace_id, so a single chaos run produces one report covering both layers.
+**Goal:** Wire `@mizchi/server-faults` events into a chaosbringer `chaos()` run via response headers and trace-id, so a single chaos run produces one report covering both layers.
 
-**Architecture:** server-faults extracts `fault.trace_id` from incoming `traceparent` and mirrors `FaultAttrs` onto kebab-case response headers (`x-chaos-fault-*`). chaosbringer attaches a `page.on('response', ...)` listener, parses those headers, and surfaces events via `CrawlReport.serverFaults`. `maybeInject` is refactored to a verdict shape so the latency path can also annotate the real response.
+**Architecture:** server-faults extracts `traceId` from incoming `traceparent` and mirrors a flat camelCase `FaultAttrs` onto kebab-case response headers (`x-chaos-fault-*`). A `toOtelAttrs(attrs)` translator emits the OTel-style dotted form (`fault.kind`, `fault.target_status`, …) at the wire boundary for OTel exporter consumers. chaosbringer attaches a `page.on('response', ...)` listener, parses headers back into `FaultAttrs`, and surfaces events via `CrawlReport.serverFaults`. `maybeInject` is refactored to a verdict shape so the latency path can also annotate the real response.
 
 **Tech Stack:** TypeScript, vitest, Playwright, Web Standard `Request`/`Response`, W3C Trace Context.
 
@@ -20,98 +20,188 @@
 
 ## PR 1 — server-faults: trace_id, verdict refactor, metadataHeader
 
-### Task 1: Add `extractTraceId` helper + `fault.trace_id` to `FaultAttrs`
+### Task 1: Flatten `FaultAttrs` to camelCase + add `traceId` + `toOtelAttrs`
 
 **Files:**
 - Modify: `packages/server-faults/src/server-faults.ts`
 - Modify: `packages/server-faults/src/server-faults.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+This combines two breakages into one commit so the test file is only edited once: rename every `"fault.x"` key to its camelCase equivalent **and** add the new `traceId` field. A `toOtelAttrs(attrs)` translator preserves the OTel-mapped dotted form for downstream exporters.
 
-Append to `packages/server-faults/src/server-faults.test.ts`:
+Rename map:
+
+| Old (PR #69 dotted) | New (flat camelCase) |
+| --- | --- |
+| `"fault.kind"` | `kind` |
+| `"fault.path"` | `path` |
+| `"fault.method"` | `method` |
+| `"fault.target_status"` | `targetStatus` |
+| `"fault.latency_ms"` | `latencyMs` |
+| (new) | `traceId` |
+
+- [ ] **Step 1: Update existing tests to flat camelCase + add new tests**
+
+In `packages/server-faults/src/server-faults.test.ts`, replace every dotted attrs assertion. The two existing observer tests:
 
 ```ts
-describe("fault.trace_id", () => {
-  it("populates fault.trace_id from a valid traceparent header", async () => {
+it("invokes observer.onFault for 5xx faults with semantic-convention attrs", async () => {
+  const onFault = vi.fn();
+  const fault = serverFaults({
+    status5xxRate: 1,
+    observer: { onFault },
+  });
+  await fault.maybeInject(req("/api/x"));
+  expect(onFault).toHaveBeenCalledWith("5xx", {
+    kind: "5xx",
+    path: "/api/x",
+    method: "GET",
+    targetStatus: 503,
+  });
+});
+
+it("invokes observer.onFault for latency faults with semantic-convention attrs", async () => {
+  const onFault = vi.fn();
+  const fault = serverFaults({
+    latencyRate: 1,
+    latencyMs: 1,
+    observer: { onFault },
+  });
+  await fault.maybeInject(req("/api/x"));
+  expect(onFault).toHaveBeenCalledWith("latency", {
+    kind: "latency",
+    path: "/api/x",
+    method: "GET",
+    latencyMs: 1,
+  });
+});
+
+it("uppercases HTTP method in attrs (mirrors OTel http semantic convention)", async () => {
+  const onFault = vi.fn();
+  const fault = serverFaults({
+    status5xxRate: 1,
+    observer: { onFault },
+  });
+  const r = new Request("https://test.local/api/x", { method: "post" as string });
+  await fault.maybeInject(r);
+  expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ method: "POST" }));
+});
+```
+
+Append the new traceId + translator tests:
+
+```ts
+describe("traceId", () => {
+  const TP = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+  it("populates traceId from a valid traceparent header (5xx)", async () => {
     const onFault = vi.fn();
-    const fault = serverFaults({
-      status5xxRate: 1,
-      observer: { onFault },
-    });
-    const r = new Request("https://test.local/api/x", {
-      headers: { traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
-    });
-    await fault.maybeInject(r);
+    const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
+    await fault.maybeInject(
+      new Request("https://test.local/api/x", { headers: { traceparent: TP } }),
+    );
     expect(onFault).toHaveBeenCalledWith(
       "5xx",
-      expect.objectContaining({ "fault.trace_id": "0af7651916cd43dd8448eb211c80319c" }),
+      expect.objectContaining({ traceId: "0af7651916cd43dd8448eb211c80319c" }),
     );
   });
 
-  it("omits fault.trace_id when traceparent is absent", async () => {
+  it("populates traceId on latency events too", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({ latencyRate: 1, latencyMs: 1, observer: { onFault } });
+    await fault.maybeInject(
+      new Request("https://test.local/api/x", { headers: { traceparent: TP } }),
+    );
+    expect(onFault).toHaveBeenCalledWith(
+      "latency",
+      expect.objectContaining({ traceId: "0af7651916cd43dd8448eb211c80319c" }),
+    );
+  });
+
+  it("omits traceId when traceparent is absent", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
     await fault.maybeInject(new Request("https://test.local/api/x"));
     const attrs = onFault.mock.calls[0][1] as Record<string, unknown>;
-    expect("fault.trace_id" in attrs).toBe(false);
+    expect("traceId" in attrs).toBe(false);
   });
 
-  it("omits fault.trace_id when traceparent is malformed", async () => {
+  it("omits traceId when traceparent is malformed", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
-    const r = new Request("https://test.local/api/x", {
-      headers: { traceparent: "garbage" },
-    });
-    await fault.maybeInject(r);
+    await fault.maybeInject(
+      new Request("https://test.local/api/x", { headers: { traceparent: "garbage" } }),
+    );
     const attrs = onFault.mock.calls[0][1] as Record<string, unknown>;
-    expect("fault.trace_id" in attrs).toBe(false);
+    expect("traceId" in attrs).toBe(false);
+  });
+});
+
+describe("toOtelAttrs", () => {
+  it("maps every populated camelCase key to its OTel dotted equivalent", () => {
+    const out = toOtelAttrs({
+      kind: "5xx",
+      path: "/api/x",
+      method: "GET",
+      targetStatus: 503,
+      traceId: "0af7651916cd43dd8448eb211c80319c",
+    });
+    expect(out).toEqual({
+      "fault.kind": "5xx",
+      "fault.path": "/api/x",
+      "fault.method": "GET",
+      "fault.target_status": 503,
+      "fault.trace_id": "0af7651916cd43dd8448eb211c80319c",
+    });
   });
 
-  it("populates fault.trace_id on latency events too", async () => {
-    const onFault = vi.fn();
-    const fault = serverFaults({
-      latencyRate: 1,
-      latencyMs: 1,
-      observer: { onFault },
+  it("omits keys that are undefined", () => {
+    const out = toOtelAttrs({ kind: "latency", path: "/x", method: "GET", latencyMs: 50 });
+    expect(out).toEqual({
+      "fault.kind": "latency",
+      "fault.path": "/x",
+      "fault.method": "GET",
+      "fault.latency_ms": 50,
     });
-    const r = new Request("https://test.local/api/x", {
-      headers: { traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
-    });
-    await fault.maybeInject(r);
-    expect(onFault).toHaveBeenCalledWith(
-      "latency",
-      expect.objectContaining({ "fault.trace_id": "0af7651916cd43dd8448eb211c80319c" }),
-    );
+    expect("fault.target_status" in out).toBe(false);
+    expect("fault.trace_id" in out).toBe(false);
   });
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+Add `toOtelAttrs` to the existing import statement:
+
+```ts
+import { serverFaults, toOtelAttrs } from "./server-faults.js";
+```
+
+- [ ] **Step 2: Run, observe failures**
 
 ```bash
 cd ~/ghq/github.com/mizchi/chaosbringer
-pnpm --filter @mizchi/server-faults test -- server-faults.test.ts -t "fault.trace_id"
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts
 ```
 
-Expected: 4 failing tests (assertions on `fault.trace_id`).
+Expected: every observer-shape and traceId test fails (current production code emits dotted keys; `toOtelAttrs` is unresolved).
 
-- [ ] **Step 3: Implement extractor + wire into both observer call sites**
+- [ ] **Step 3: Update `FaultAttrs`, attrs construction, and add helpers**
 
-In `packages/server-faults/src/server-faults.ts`, after the `FaultAttrs` interface, add the optional field:
+In `packages/server-faults/src/server-faults.ts`:
+
+a) Replace the `FaultAttrs` interface:
 
 ```ts
 export interface FaultAttrs {
-  "fault.kind": FaultKind;
-  "fault.path": string;
-  "fault.method": string;
-  "fault.target_status"?: number;
-  "fault.latency_ms"?: number;
+  kind: FaultKind;
+  path: string;
+  method: string;
+  targetStatus?: number;
+  latencyMs?: number;
   /** Trace-id from incoming traceparent (W3C Trace Context). 32 lowercase hex. */
-  "fault.trace_id"?: string;
+  traceId?: string;
 }
 ```
 
-Add the helper near `compileStatelessPattern`:
+b) Add the traceparent extractor near `compileStatelessPattern`:
 
 ```ts
 const TRACEPARENT_RE = /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/;
@@ -124,45 +214,67 @@ function extractTraceId(req: Request): string | undefined {
 }
 ```
 
-In `serverFaults()`, replace each `observer.onFault?.(...)` call with one that conditionally sets `"fault.trace_id"`:
+c) Add the OTel translator at the bottom of the file, exported:
+
+```ts
+/**
+ * Map a flat `FaultAttrs` to the OTel-style dotted attribute schema
+ * (`fault.kind`, `fault.target_status`, …) for consumers that pipe
+ * fault events directly into an OTel exporter. Undefined optional
+ * keys are dropped so the output is tight.
+ */
+export function toOtelAttrs(a: FaultAttrs): Record<string, string | number> {
+  const out: Record<string, string | number> = {
+    "fault.kind": a.kind,
+    "fault.path": a.path,
+    "fault.method": a.method,
+  };
+  if (a.targetStatus !== undefined) out["fault.target_status"] = a.targetStatus;
+  if (a.latencyMs !== undefined) out["fault.latency_ms"] = a.latencyMs;
+  if (a.traceId !== undefined) out["fault.trace_id"] = a.traceId;
+  return out;
+}
+```
+
+d) Inside `serverFaults()`, rebuild the attrs and observer calls:
 
 ```ts
 const traceId = extractTraceId(req);
 
 // 5xx branch:
 const attrs5xx: FaultAttrs = {
-  "fault.kind": "5xx",
-  "fault.path": url.pathname,
-  "fault.method": method,
-  "fault.target_status": status,
+  kind: "5xx",
+  path: url.pathname,
+  method,
+  targetStatus: status,
 };
-if (traceId !== undefined) attrs5xx["fault.trace_id"] = traceId;
+if (traceId !== undefined) attrs5xx.traceId = traceId;
 cfg.observer?.onFault?.("5xx", attrs5xx);
 
 // latency branch:
 const attrsLat: FaultAttrs = {
-  "fault.kind": "latency",
-  "fault.path": url.pathname,
-  "fault.method": method,
-  "fault.latency_ms": ms,
+  kind: "latency",
+  path: url.pathname,
+  method,
+  latencyMs: ms,
 };
-if (traceId !== undefined) attrsLat["fault.trace_id"] = traceId;
+if (traceId !== undefined) attrsLat.traceId = traceId;
 cfg.observer?.onFault?.("latency", attrsLat);
 ```
 
 - [ ] **Step 4: Run tests to verify**
 
 ```bash
-pnpm --filter @mizchi/server-faults test
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts
 ```
 
-Expected: full suite green, including the 4 new trace_id tests.
+Expected: full file green.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add packages/server-faults/src/server-faults.ts packages/server-faults/src/server-faults.test.ts
-git commit -m "feat(server-faults): add fault.trace_id extracted from W3C traceparent"
+git commit -m "feat(server-faults)!: flat camelCase FaultAttrs + traceId + toOtelAttrs translator"
 ```
 
 ---
@@ -284,9 +396,9 @@ describe("metadataHeader", () => {
     const v = await fault.maybeInject(r);
     expect(v?.kind).toBe("annotate");
     const attrs = (v as { kind: "annotate"; attrs: FaultAttrs }).attrs;
-    expect(attrs["fault.kind"]).toBe("latency");
-    expect(attrs["fault.latency_ms"]).toBe(1);
-    expect(attrs["fault.trace_id"]).toBe("0af7651916cd43dd8448eb211c80319c");
+    expect(attrs.kind).toBe("latency");
+    expect(attrs.latencyMs).toBe(1);
+    expect(attrs.traceId).toBe("0af7651916cd43dd8448eb211c80319c");
   });
 });
 ```
@@ -315,32 +427,32 @@ export interface ServerFaultConfig {
    * out-of-process consumers (e.g. chaosbringer's `chaos()` crawler) can
    * observe server-side faults without sharing memory with the server.
    *
-   * Header naming: `{prefix}-{key}`, where `key` is the attrs key with
-   * `fault.` stripped and `_` replaced by `-` (e.g. `fault.target_status`
-   * → `{prefix}-target-status`). `true` uses the default prefix
-   * `"x-chaos-fault"`.
+   * Header naming: `{prefix}-{kebab(key)}` where `key` is a TS attrs
+   * property name and `kebab` lower-cases the camelCase boundary
+   * (e.g. `targetStatus` → `{prefix}-target-status`). `true` uses
+   * the default prefix `"x-chaos-fault"`.
    */
   metadataHeader?: boolean | { prefix?: string };
 }
 ```
 
-2. Add a helper to materialise the header set:
+2. Add a helper to materialise the header set (camelCase → kebab-case):
 
 ```ts
 const DEFAULT_METADATA_PREFIX = "x-chaos-fault";
 
-function attrsToHeaderEntries(attrs: FaultAttrs, prefix: string): Array<[string, string]> {
+export function attrsToHeaderEntries(attrs: FaultAttrs, prefix: string): Array<[string, string]> {
   const out: Array<[string, string]> = [];
   for (const [k, v] of Object.entries(attrs)) {
     if (v === undefined) continue;
-    // Strip "fault." prefix; underscore → kebab.
-    const tail = k.replace(/^fault\./, "").replace(/_/g, "-");
+    // camelCase → kebab-case (e.g. `targetStatus` → `target-status`).
+    const tail = k.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
     out.push([`${prefix}-${tail}`, String(v)]);
   }
   return out;
 }
 
-function resolveMetadataPrefix(opt: ServerFaultConfig["metadataHeader"]): string | null {
+export function resolveMetadataPrefix(opt: ServerFaultConfig["metadataHeader"]): string | null {
   if (!opt) return null;
   if (opt === true) return DEFAULT_METADATA_PREFIX;
   return opt.prefix ?? DEFAULT_METADATA_PREFIX;
@@ -363,7 +475,7 @@ const response = Response.json(
 return { kind: "synthetic", response, attrs: attrs5xx };
 ```
 
-The latency branch returns `{ kind: "annotate", attrs: attrsLat }`. The `metadataPrefix` value is not consumed there — adapters look up `cfg` themselves, see Tasks 4–7. (Adapters import `attrsToHeaderEntries` and `resolveMetadataPrefix` indirectly: we re-export them privately from server-faults.ts so adapters can reuse the same encoding without redefining the rule. Add `export` to both helpers.)
+The latency branch returns `{ kind: "annotate", attrs: attrsLat }`. The `metadataPrefix` value is not consumed there — adapters look up `cfg` themselves, see Tasks 4–7. The `export` keywords on `attrsToHeaderEntries` and `resolveMetadataPrefix` are deliberate so adapters can reuse the same encoding without redefining the rule.
 
 - [ ] **Step 4: Run tests**
 
@@ -875,9 +987,9 @@ git commit -m "chore(server-faults): refresh build artefacts"
 
 ```bash
 git push -u origin feat/server-faults-metadata-header
-gh pr create --title "feat(server-faults)!: trace_id, FaultVerdict, metadataHeader" --body "$(cat <<'EOF'
+gh pr create --title "feat(server-faults)!: flat FaultAttrs + traceId + FaultVerdict + metadataHeader" --body "$(cat <<'EOF'
 ## Summary
-- `FaultAttrs` gains `fault.trace_id` extracted from incoming W3C `traceparent`
+- `FaultAttrs` is now flat camelCase (`kind`, `path`, `method`, `targetStatus`, `latencyMs`, `traceId`); a new `toOtelAttrs(attrs)` translator emits the OTel-style dotted form for downstream exporters. `traceId` is extracted from the incoming W3C `traceparent`. **Breaking** rename of PR #69's landed schema
 - `maybeInject` now returns `FaultVerdict` (`synthetic` | `annotate` | `null`); the latency path returns `annotate` so adapters can stamp metadata headers on the real response
 - `metadataHeader` option mirrors fault attrs onto kebab-case response headers (`x-chaos-fault-*` by default)
 - All four adapters (hono / express / fastify / koa) updated for the new verdict + header stamping
@@ -940,11 +1052,11 @@ describe("parseServerFaultHeaders", () => {
     });
     expect(parseServerFaultHeaders(h, "x-chaos-fault")).toEqual({
       attrs: {
-        "fault.kind": "5xx",
-        "fault.path": "/api/todos",
-        "fault.method": "GET",
-        "fault.target_status": 503,
-        "fault.trace_id": "0af7651916cd43dd8448eb211c80319c",
+        kind: "5xx",
+        path: "/api/todos",
+        method: "GET",
+        targetStatus: 503,
+        traceId: "0af7651916cd43dd8448eb211c80319c",
       },
       traceId: "0af7651916cd43dd8448eb211c80319c",
     });
@@ -959,10 +1071,10 @@ describe("parseServerFaultHeaders", () => {
     });
     const r = parseServerFaultHeaders(h, "x-chaos-fault");
     expect(r?.attrs).toEqual({
-      "fault.kind": "latency",
-      "fault.path": "/api/x",
-      "fault.method": "POST",
-      "fault.latency_ms": 350,
+      kind: "latency",
+      path: "/api/x",
+      method: "POST",
+      latencyMs: 350,
     });
     expect(r?.traceId).toBeUndefined();
   });
@@ -983,7 +1095,7 @@ describe("parseServerFaultHeaders", () => {
       "x-my-fault-method": "GET",
       "x-my-fault-target-status": "500",
     });
-    expect(parseServerFaultHeaders(h, "x-my-fault")?.attrs["fault.kind"]).toBe("5xx");
+    expect(parseServerFaultHeaders(h, "x-my-fault")?.attrs.kind).toBe("5xx");
     expect(parseServerFaultHeaders(h, "x-chaos-fault")).toBeNull();
   });
 
@@ -995,9 +1107,9 @@ describe("parseServerFaultHeaders", () => {
       "x-chaos-fault-latency-ms": "not-a-number",
     });
     const r = parseServerFaultHeaders(h, "x-chaos-fault");
-    // Latency event still parses; the bad number is dropped (no fault.latency_ms).
-    expect(r?.attrs["fault.kind"]).toBe("latency");
-    expect(r?.attrs["fault.latency_ms"]).toBeUndefined();
+    // Latency event still parses; the bad number is dropped (no latencyMs).
+    expect(r?.attrs.kind).toBe("latency");
+    expect(r?.attrs.latencyMs).toBeUndefined();
   });
 });
 ```
@@ -1025,12 +1137,12 @@ Create `packages/chaosbringer/src/server-fault-events.ts`:
 const KNOWN_KINDS = new Set(["5xx", "latency"]);
 
 export interface ServerFaultEventAttrs {
-  "fault.kind": "5xx" | "latency";
-  "fault.path": string;
-  "fault.method": string;
-  "fault.target_status"?: number;
-  "fault.latency_ms"?: number;
-  "fault.trace_id"?: string;
+  kind: "5xx" | "latency";
+  path: string;
+  method: string;
+  targetStatus?: number;
+  latencyMs?: number;
+  traceId?: string;
 }
 
 export interface ParsedServerFault {
@@ -1050,25 +1162,25 @@ export function parseServerFaultHeaders(
   if (!path || !method) return null;
 
   const attrs: ServerFaultEventAttrs = {
-    "fault.kind": kind as "5xx" | "latency",
-    "fault.path": path,
-    "fault.method": method,
+    kind: kind as "5xx" | "latency",
+    path,
+    method,
   };
 
-  const targetStatus = headers.get(`${prefix}-target-status`);
-  if (targetStatus !== null) {
-    const n = Number.parseInt(targetStatus, 10);
-    if (Number.isFinite(n)) attrs["fault.target_status"] = n;
+  const targetStatusHeader = headers.get(`${prefix}-target-status`);
+  if (targetStatusHeader !== null) {
+    const n = Number.parseInt(targetStatusHeader, 10);
+    if (Number.isFinite(n)) attrs.targetStatus = n;
   }
 
-  const latencyMs = headers.get(`${prefix}-latency-ms`);
-  if (latencyMs !== null) {
-    const n = Number.parseFloat(latencyMs);
-    if (Number.isFinite(n)) attrs["fault.latency_ms"] = n;
+  const latencyMsHeader = headers.get(`${prefix}-latency-ms`);
+  if (latencyMsHeader !== null) {
+    const n = Number.parseFloat(latencyMsHeader);
+    if (Number.isFinite(n)) attrs.latencyMs = n;
   }
 
   const traceId = headers.get(`${prefix}-trace-id`) ?? undefined;
-  if (traceId) attrs["fault.trace_id"] = traceId;
+  if (traceId) attrs.traceId = traceId;
 
   return { attrs, traceId };
 }
@@ -1120,13 +1232,18 @@ export interface ChaosRemoteServer {
 export interface ServerFaultEvent {
   /** Trace-id from the response headers (W3C traceparent's trace-id segment). */
   traceId?: string;
+  /**
+   * Flat camelCase attrs mirroring `@mizchi/server-faults`'s `FaultAttrs`.
+   * Use `toOtelAttrs(attrs)` (re-exported from chaosbringer) when shipping
+   * these to an OTel exporter.
+   */
   attrs: {
-    "fault.kind": "5xx" | "latency";
-    "fault.path": string;
-    "fault.method": string;
-    "fault.target_status"?: number;
-    "fault.latency_ms"?: number;
-    "fault.trace_id"?: string;
+    kind: "5xx" | "latency";
+    path: string;
+    method: string;
+    targetStatus?: number;
+    latencyMs?: number;
+    traceId?: string;
   };
   /** Wall-clock ms when chaos observed the response. */
   observedAt: number;
@@ -1253,7 +1370,7 @@ describe("ServerFaultCollector", () => {
     expect(events).toHaveLength(1);
     expect(events[0].pageUrl).toBe("https://app/todos");
     expect(events[0].traceId).toBe("0af7651916cd43dd8448eb211c80319c");
-    expect(events[0].attrs["fault.kind"]).toBe("5xx");
+    expect(events[0].attrs.kind).toBe("5xx");
     expect(typeof events[0].observedAt).toBe("number");
   });
 
@@ -1274,7 +1391,7 @@ describe("ServerFaultCollector", () => {
     c.observe({ headers: headers("5xx", "/a"), pageUrl: "https://app/a" });
     c.observe({ headers: headers("latency", "/b"), pageUrl: "https://app/b" });
     const events = c.drain();
-    expect(events.map((e) => e.attrs["fault.path"])).toEqual(["/a", "/b"]);
+    expect(events.map((e) => e.attrs.path)).toEqual(["/a", "/b"]);
   });
 
   it("drain() empties the buffer", () => {
@@ -1449,11 +1566,11 @@ describe("server-fault report integration", () => {
       traceId: "abcdef0123456789abcdef0123456789",
       pageUrl: "https://app/x",
       attrs: {
-        "fault.kind": "5xx",
-        "fault.path": "/api/x",
-        "fault.method": "GET",
-        "fault.target_status": 503,
-        "fault.trace_id": "abcdef0123456789abcdef0123456789",
+        kind: "5xx",
+        path: "/api/x",
+        method: "GET",
+        targetStatus: 503,
+        traceId: "abcdef0123456789abcdef0123456789",
       },
     });
     expect(typeof drained[0].observedAt).toBe("number");

--- a/docs/superpowers/plans/2026-05-06-chaos-server-orchestration.md
+++ b/docs/superpowers/plans/2026-05-06-chaos-server-orchestration.md
@@ -1,0 +1,1544 @@
+# Chaos × server-faults orchestration (C2 Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `@mizchi/server-faults` events into a chaosbringer `chaos()` run via response headers and trace_id, so a single chaos run produces one report covering both layers.
+
+**Architecture:** server-faults extracts `fault.trace_id` from incoming `traceparent` and mirrors `FaultAttrs` onto kebab-case response headers (`x-chaos-fault-*`). chaosbringer attaches a `page.on('response', ...)` listener, parses those headers, and surfaces events via `CrawlReport.serverFaults`. `maybeInject` is refactored to a verdict shape so the latency path can also annotate the real response.
+
+**Tech Stack:** TypeScript, vitest, Playwright, Web Standard `Request`/`Response`, W3C Trace Context.
+
+**Spec:** [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`](../specs/2026-05-06-chaos-server-orchestration-design.md)
+
+**Repository root for paths:** `~/ghq/github.com/mizchi/chaosbringer/` (all paths below are relative to this).
+
+**Sequencing:**
+- PR 1 (Tasks 1–9): server-faults breaking changes + metadataHeader.
+- PR 2 (Tasks 10–14): chaosbringer integration. Depends on PR 1 being merged + a local link / version bump.
+
+---
+
+## PR 1 — server-faults: trace_id, verdict refactor, metadataHeader
+
+### Task 1: Add `extractTraceId` helper + `fault.trace_id` to `FaultAttrs`
+
+**Files:**
+- Modify: `packages/server-faults/src/server-faults.ts`
+- Modify: `packages/server-faults/src/server-faults.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/server-faults/src/server-faults.test.ts`:
+
+```ts
+describe("fault.trace_id", () => {
+  it("populates fault.trace_id from a valid traceparent header", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({
+      status5xxRate: 1,
+      observer: { onFault },
+    });
+    const r = new Request("https://test.local/api/x", {
+      headers: { traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+    });
+    await fault.maybeInject(r);
+    expect(onFault).toHaveBeenCalledWith(
+      "5xx",
+      expect.objectContaining({ "fault.trace_id": "0af7651916cd43dd8448eb211c80319c" }),
+    );
+  });
+
+  it("omits fault.trace_id when traceparent is absent", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
+    await fault.maybeInject(new Request("https://test.local/api/x"));
+    const attrs = onFault.mock.calls[0][1] as Record<string, unknown>;
+    expect("fault.trace_id" in attrs).toBe(false);
+  });
+
+  it("omits fault.trace_id when traceparent is malformed", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
+    const r = new Request("https://test.local/api/x", {
+      headers: { traceparent: "garbage" },
+    });
+    await fault.maybeInject(r);
+    const attrs = onFault.mock.calls[0][1] as Record<string, unknown>;
+    expect("fault.trace_id" in attrs).toBe(false);
+  });
+
+  it("populates fault.trace_id on latency events too", async () => {
+    const onFault = vi.fn();
+    const fault = serverFaults({
+      latencyRate: 1,
+      latencyMs: 1,
+      observer: { onFault },
+    });
+    const r = new Request("https://test.local/api/x", {
+      headers: { traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+    });
+    await fault.maybeInject(r);
+    expect(onFault).toHaveBeenCalledWith(
+      "latency",
+      expect.objectContaining({ "fault.trace_id": "0af7651916cd43dd8448eb211c80319c" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd ~/ghq/github.com/mizchi/chaosbringer
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts -t "fault.trace_id"
+```
+
+Expected: 4 failing tests (assertions on `fault.trace_id`).
+
+- [ ] **Step 3: Implement extractor + wire into both observer call sites**
+
+In `packages/server-faults/src/server-faults.ts`, after the `FaultAttrs` interface, add the optional field:
+
+```ts
+export interface FaultAttrs {
+  "fault.kind": FaultKind;
+  "fault.path": string;
+  "fault.method": string;
+  "fault.target_status"?: number;
+  "fault.latency_ms"?: number;
+  /** Trace-id from incoming traceparent (W3C Trace Context). 32 lowercase hex. */
+  "fault.trace_id"?: string;
+}
+```
+
+Add the helper near `compileStatelessPattern`:
+
+```ts
+const TRACEPARENT_RE = /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/;
+
+function extractTraceId(req: Request): string | undefined {
+  const tp = req.headers.get("traceparent");
+  if (!tp) return undefined;
+  const m = TRACEPARENT_RE.exec(tp);
+  return m ? m[1] : undefined;
+}
+```
+
+In `serverFaults()`, replace each `observer.onFault?.(...)` call with one that conditionally sets `"fault.trace_id"`:
+
+```ts
+const traceId = extractTraceId(req);
+
+// 5xx branch:
+const attrs5xx: FaultAttrs = {
+  "fault.kind": "5xx",
+  "fault.path": url.pathname,
+  "fault.method": method,
+  "fault.target_status": status,
+};
+if (traceId !== undefined) attrs5xx["fault.trace_id"] = traceId;
+cfg.observer?.onFault?.("5xx", attrs5xx);
+
+// latency branch:
+const attrsLat: FaultAttrs = {
+  "fault.kind": "latency",
+  "fault.path": url.pathname,
+  "fault.method": method,
+  "fault.latency_ms": ms,
+};
+if (traceId !== undefined) attrsLat["fault.trace_id"] = traceId;
+cfg.observer?.onFault?.("latency", attrsLat);
+```
+
+- [ ] **Step 4: Run tests to verify**
+
+```bash
+pnpm --filter @mizchi/server-faults test
+```
+
+Expected: full suite green, including the 4 new trace_id tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/server-faults.ts packages/server-faults/src/server-faults.test.ts
+git commit -m "feat(server-faults): add fault.trace_id extracted from W3C traceparent"
+```
+
+---
+
+### Task 2: Refactor `maybeInject` return type to `FaultVerdict`
+
+**Files:**
+- Modify: `packages/server-faults/src/server-faults.ts`
+- Modify: `packages/server-faults/src/server-faults.test.ts`
+
+This is a breaking change. We update `serverFaults()` and its tests in this task; adapters break and are repaired in Tasks 4–7 — they are intentionally left broken between commits within this PR (the four `pnpm --filter ... test` runs in tasks 4–7 will fail until each adapter is updated).
+
+- [ ] **Step 1: Update existing test assertions to verdict shape**
+
+Edit each existing assertion in `packages/server-faults/src/server-faults.test.ts` that currently checks `Response | null` to check the new verdict. Search and replace patterns:
+
+| Old assertion | New assertion |
+| --- | --- |
+| `expect(await fault.maybeInject(req("/x"))).toBeNull();` | `expect(await fault.maybeInject(req("/x"))).toBeNull();` *(no change)* |
+| `const response = await fault.maybeInject(req("/x")); expect(response).not.toBeNull(); expect(response!.status).toBe(503);` | `const v = await fault.maybeInject(req("/x")); expect(v?.kind).toBe("synthetic"); expect((v as { kind: "synthetic"; response: Response }).response.status).toBe(503);` |
+| `expect(await fault.maybeInject(...)).not.toBeNull();` (used as a "fault occurred" probe) | `const v = await fault.maybeInject(...); expect(v).not.toBeNull();` *(stays — both `synthetic` and `annotate` are truthy non-null)* |
+
+For the two latency-fakeTimer tests (`delays the request by latencyMs (number)` / `returns null after latency`), update the resolved-value assertion: the latency verdict is now `{ kind: "annotate", attrs: ... }`, not `null`. Replace `expect(result).toBeNull();` with `expect(result?.kind).toBe("annotate");` and `expect(await promise).toBeNull();` with `expect((await promise)?.kind).toBe("annotate");`.
+
+- [ ] **Step 2: Run tests, observe what now needs fixing in source**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts
+```
+
+Expected: every test that exercises a fault path fails with a type or runtime mismatch — verdict properties are missing.
+
+- [ ] **Step 3: Implement the verdict in `serverFaults()`**
+
+In `packages/server-faults/src/server-faults.ts`:
+
+Add the verdict types (just below `FaultAttrs`):
+
+```ts
+export type FaultVerdict =
+  | { kind: "synthetic"; response: Response; attrs: FaultAttrs }
+  | { kind: "annotate"; attrs: FaultAttrs }
+  | null;
+```
+
+Change `ServerFaultHandle`:
+
+```ts
+export interface ServerFaultHandle {
+  maybeInject: (req: Request) => Promise<FaultVerdict>;
+}
+```
+
+Rewrite the `maybeInject` body so the 5xx branch returns `{ kind: "synthetic", response, attrs: attrs5xx }` and the latency branch returns `{ kind: "annotate", attrs: attrsLat }` after `await sleep(ms)`. The early-exit branches (bypass header, exempt path, no pattern match, no raffle won) keep returning `null`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts
+```
+
+Expected: full file green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/server-faults.ts packages/server-faults/src/server-faults.test.ts
+git commit -m "feat(server-faults)!: maybeInject returns FaultVerdict (synthetic/annotate/null)"
+```
+
+---
+
+### Task 3: Add `metadataHeader` option
+
+**Files:**
+- Modify: `packages/server-faults/src/server-faults.ts`
+- Modify: `packages/server-faults/src/server-faults.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/server-faults/src/server-faults.test.ts`:
+
+```ts
+describe("metadataHeader", () => {
+  const TP = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+  it("attaches all 5xx attrs as kebab-case headers on synthetic responses", async () => {
+    const fault = serverFaults({ status5xxRate: 1, metadataHeader: true });
+    const r = new Request("https://test.local/api/x", { headers: { traceparent: TP } });
+    const v = await fault.maybeInject(r);
+    expect(v?.kind).toBe("synthetic");
+    const resp = (v as { response: Response }).response;
+    expect(resp.headers.get("x-chaos-fault-kind")).toBe("5xx");
+    expect(resp.headers.get("x-chaos-fault-path")).toBe("/api/x");
+    expect(resp.headers.get("x-chaos-fault-method")).toBe("GET");
+    expect(resp.headers.get("x-chaos-fault-target-status")).toBe("503");
+    expect(resp.headers.get("x-chaos-fault-trace-id")).toBe("0af7651916cd43dd8448eb211c80319c");
+    expect(resp.headers.get("x-chaos-fault-latency-ms")).toBeNull();
+  });
+
+  it("does not attach headers when metadataHeader is unset", async () => {
+    const fault = serverFaults({ status5xxRate: 1 });
+    const v = await fault.maybeInject(new Request("https://test.local/api/x"));
+    const resp = (v as { kind: "synthetic"; response: Response }).response;
+    expect(resp.headers.get("x-chaos-fault-kind")).toBeNull();
+  });
+
+  it("honours custom prefix", async () => {
+    const fault = serverFaults({ status5xxRate: 1, metadataHeader: { prefix: "x-my-fault" } });
+    const v = await fault.maybeInject(new Request("https://test.local/api/x"));
+    const resp = (v as { kind: "synthetic"; response: Response }).response;
+    expect(resp.headers.get("x-my-fault-kind")).toBe("5xx");
+    expect(resp.headers.get("x-chaos-fault-kind")).toBeNull();
+  });
+
+  it("returns annotate verdict carrying full attrs for latency (adapter must apply headers)", async () => {
+    const fault = serverFaults({ latencyRate: 1, latencyMs: 1, metadataHeader: true });
+    const r = new Request("https://test.local/api/x", { headers: { traceparent: TP } });
+    const v = await fault.maybeInject(r);
+    expect(v?.kind).toBe("annotate");
+    const attrs = (v as { kind: "annotate"; attrs: FaultAttrs }).attrs;
+    expect(attrs["fault.kind"]).toBe("latency");
+    expect(attrs["fault.latency_ms"]).toBe(1);
+    expect(attrs["fault.trace_id"]).toBe("0af7651916cd43dd8448eb211c80319c");
+  });
+});
+```
+
+(Add `import type { FaultAttrs } from "./server-faults.js";` if not already imported.)
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts -t metadataHeader
+```
+
+Expected: all four tests fail (`x-chaos-fault-kind` is null, `metadataHeader` config field doesn't exist).
+
+- [ ] **Step 3: Implement option + helpers**
+
+In `packages/server-faults/src/server-faults.ts`:
+
+1. Extend `ServerFaultConfig`:
+
+```ts
+export interface ServerFaultConfig {
+  // … existing fields …
+  /**
+   * When set, server-faults mirrors `FaultAttrs` onto response headers so
+   * out-of-process consumers (e.g. chaosbringer's `chaos()` crawler) can
+   * observe server-side faults without sharing memory with the server.
+   *
+   * Header naming: `{prefix}-{key}`, where `key` is the attrs key with
+   * `fault.` stripped and `_` replaced by `-` (e.g. `fault.target_status`
+   * → `{prefix}-target-status`). `true` uses the default prefix
+   * `"x-chaos-fault"`.
+   */
+  metadataHeader?: boolean | { prefix?: string };
+}
+```
+
+2. Add a helper to materialise the header set:
+
+```ts
+const DEFAULT_METADATA_PREFIX = "x-chaos-fault";
+
+function attrsToHeaderEntries(attrs: FaultAttrs, prefix: string): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v === undefined) continue;
+    // Strip "fault." prefix; underscore → kebab.
+    const tail = k.replace(/^fault\./, "").replace(/_/g, "-");
+    out.push([`${prefix}-${tail}`, String(v)]);
+  }
+  return out;
+}
+
+function resolveMetadataPrefix(opt: ServerFaultConfig["metadataHeader"]): string | null {
+  if (!opt) return null;
+  if (opt === true) return DEFAULT_METADATA_PREFIX;
+  return opt.prefix ?? DEFAULT_METADATA_PREFIX;
+}
+```
+
+3. In `serverFaults()`, capture the prefix once: `const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);`. In the 5xx branch, after building `attrs5xx`, build the synthetic response's `Headers`:
+
+```ts
+const headers = new Headers();
+if (metadataPrefix) {
+  for (const [name, value] of attrsToHeaderEntries(attrs5xx, metadataPrefix)) {
+    headers.set(name, value);
+  }
+}
+const response = Response.json(
+  { error: "chaos: synthetic 5xx", path: url.pathname, status },
+  { status, headers },
+);
+return { kind: "synthetic", response, attrs: attrs5xx };
+```
+
+The latency branch returns `{ kind: "annotate", attrs: attrsLat }`. The `metadataPrefix` value is not consumed there — adapters look up `cfg` themselves, see Tasks 4–7. (Adapters import `attrsToHeaderEntries` and `resolveMetadataPrefix` indirectly: we re-export them privately from server-faults.ts so adapters can reuse the same encoding without redefining the rule. Add `export` to both helpers.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- server-faults.test.ts
+```
+
+Expected: full file green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/server-faults.ts packages/server-faults/src/server-faults.test.ts
+git commit -m "feat(server-faults): add metadataHeader option (mirror fault attrs to response headers)"
+```
+
+---
+
+### Task 4: Update Hono adapter for verdict + annotate path
+
+**Files:**
+- Modify: `packages/server-faults/src/adapters/hono.ts`
+- Modify: `packages/server-faults/src/adapters/adapters.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to the `describe("honoMiddleware", …)` block in `packages/server-faults/src/adapters/adapters.test.ts`:
+
+```ts
+it("returns synthetic 5xx response unchanged (headers already attached)", async () => {
+  const mw = honoMiddleware({ status5xxRate: 1, metadataHeader: true });
+  const next = vi.fn();
+  const c = { req: { raw: new Request("https://test.local/api/x") } };
+  const out = await mw(c, next);
+  expect((out as Response).status).toBe(503);
+  expect((out as Response).headers.get("x-chaos-fault-kind")).toBe("5xx");
+});
+
+it("calls next() and stamps headers on c.res for latency annotate verdict", async () => {
+  const mw = honoMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+  const headers = new Headers();
+  const c = {
+    req: { raw: new Request("https://test.local/api/x") },
+    res: { headers },
+  };
+  const next = vi.fn(async () => undefined);
+  await mw(c as never, next);
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(headers.get("x-chaos-fault-kind")).toBe("latency");
+  expect(headers.get("x-chaos-fault-latency-ms")).toBe("0");
+});
+
+it("does not stamp latency headers when metadataHeader is off", async () => {
+  const mw = honoMiddleware({ latencyRate: 1, latencyMs: 0 });
+  const headers = new Headers();
+  const c = {
+    req: { raw: new Request("https://test.local/api/x") },
+    res: { headers },
+  };
+  const next = vi.fn(async () => undefined);
+  await mw(c as never, next);
+  expect(headers.get("x-chaos-fault-kind")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t honoMiddleware
+```
+
+Expected: existing passing tests now fail (verdict shape changed) plus the new 3 fail.
+
+- [ ] **Step 3: Update `hono.ts`**
+
+Replace the contents of `packages/server-faults/src/adapters/hono.ts` with:
+
+```ts
+/**
+ * Hono adapter for @mizchi/server-faults.
+ *
+ * `c.req.raw` is a Web Standard Request, so the adapter is mostly a thin
+ * wrapper around `serverFaults({...}).maybeInject(req)`. The latency
+ * (annotate) path requires running the real handler first and then
+ * stamping the metadata headers onto `c.res.headers` afterwards.
+ */
+
+import {
+  serverFaults,
+  attrsToHeaderEntries,
+  resolveMetadataPrefix,
+  type ServerFaultConfig,
+} from "../server-faults.js";
+
+interface HonoLikeContext {
+  req: { raw: Request };
+  res?: { headers: Headers };
+}
+interface HonoLikeNext {
+  (): Promise<unknown>;
+}
+type HonoLikeMiddleware = (c: HonoLikeContext, next: HonoLikeNext) => Promise<Response | undefined | void>;
+
+export function honoMiddleware(cfg: ServerFaultConfig): HonoLikeMiddleware {
+  const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
+  return async (c, next) => {
+    const verdict = await fault.maybeInject(c.req.raw);
+    if (!verdict) return next().then(() => undefined);
+    if (verdict.kind === "synthetic") return verdict.response;
+    // annotate: real handler runs, then stamp headers if requested.
+    await next();
+    if (metadataPrefix && c.res?.headers) {
+      for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+        c.res.headers.set(name, value);
+      }
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t honoMiddleware
+```
+
+Expected: 5 hono tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/adapters/hono.ts packages/server-faults/src/adapters/adapters.test.ts
+git commit -m "feat(server-faults/hono): support FaultVerdict + metadataHeader stamping"
+```
+
+---
+
+### Task 5: Update Express adapter
+
+**Files:**
+- Modify: `packages/server-faults/src/adapters/express.ts`
+- Modify: `packages/server-faults/src/adapters/adapters.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to the `describe("expressMiddleware", …)` block:
+
+```ts
+it("stamps metadata headers on res for the latency annotate verdict", async () => {
+  const mw = expressMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+  const next = vi.fn();
+  const req = { method: "GET", originalUrl: "/api/x", headers: { host: "test.local" } };
+  const res = makeRes();
+  await mw(req, res, next);
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(res.headers["x-chaos-fault-kind"]).toBe("latency");
+  expect(res.headers["x-chaos-fault-path"]).toBe("/api/x");
+});
+
+it("does not stamp latency headers when metadataHeader is off", async () => {
+  const mw = expressMiddleware({ latencyRate: 1, latencyMs: 0 });
+  const next = vi.fn();
+  const req = { method: "GET", originalUrl: "/api/x", headers: {} };
+  const res = makeRes();
+  await mw(req, res, next);
+  expect(res.headers["x-chaos-fault-kind"]).toBeUndefined();
+});
+
+it("attaches metadata headers to synthetic 5xx response", async () => {
+  const mw = expressMiddleware({ status5xxRate: 1, metadataHeader: true });
+  const next = vi.fn();
+  const req = { method: "GET", originalUrl: "/api/x", headers: { host: "test.local" } };
+  const res = makeRes();
+  await mw(req, res, next);
+  expect(res.statusCode).toBe(503);
+  expect(res.headers["x-chaos-fault-kind"]).toBe("5xx");
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t expressMiddleware
+```
+
+Expected: pre-existing tests fail (verdict shape changed) plus new tests fail.
+
+- [ ] **Step 3: Update `express.ts`**
+
+Replace the body of `expressMiddleware()`:
+
+```ts
+export function expressMiddleware(
+  cfg: ServerFaultConfig,
+): (req: ExpressLikeRequest, res: ExpressLikeResponse, next: ExpressLikeNext) => Promise<void> {
+  const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
+  return async (req, res, next) => {
+    try {
+      const verdict = await fault.maybeInject(toWebRequest(req));
+      if (!verdict) return next();
+      if (verdict.kind === "synthetic") {
+        res.status(verdict.response.status);
+        verdict.response.headers.forEach((value, key) => {
+          if (key.toLowerCase() === "content-type") return;
+          res.setHeader(key, value);
+        });
+        res.json(await verdict.response.json());
+        return;
+      }
+      // annotate: stamp headers, then hand off to the real handler.
+      if (metadataPrefix) {
+        for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+          res.setHeader(name, value);
+        }
+      }
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+```
+
+Update imports:
+
+```ts
+import {
+  serverFaults,
+  attrsToHeaderEntries,
+  resolveMetadataPrefix,
+  type ServerFaultConfig,
+} from "../server-faults.js";
+```
+
+(Express writes headers before the response body is flushed. Stamping the metadata headers *before* calling `next()` is safe — Express buffers them on the response object until the handler responds, so when the real handler eventually calls `res.send(...)` the metadata headers ride along.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t expressMiddleware
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/adapters/express.ts packages/server-faults/src/adapters/adapters.test.ts
+git commit -m "feat(server-faults/express): support FaultVerdict + metadataHeader stamping"
+```
+
+---
+
+### Task 6: Update Fastify adapter
+
+**Files:**
+- Modify: `packages/server-faults/src/adapters/fastify.ts`
+- Modify: `packages/server-faults/src/adapters/adapters.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `describe("fastifyPlugin", …)`:
+
+```ts
+it("stamps metadata headers via reply.header() for latency annotate verdict", async () => {
+  const plugin = fastifyPlugin({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+  let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+  const fastify = {
+    addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+      registered = h;
+    },
+  };
+  await plugin(fastify);
+  const req = { method: "GET", url: "/api/x", headers: { host: "test.local" } };
+  const reply = {
+    _headers: {} as Record<string, string>,
+    code() { return this; },
+    header(k: string, v: string) { this._headers[k] = v; return this; },
+    send() { return undefined; },
+  };
+  await registered!(req, reply);
+  expect(reply._headers["x-chaos-fault-kind"]).toBe("latency");
+});
+
+it("attaches metadata headers to synthetic 5xx reply", async () => {
+  const plugin = fastifyPlugin({ status5xxRate: 1, metadataHeader: true });
+  let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+  const fastify = {
+    addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+      registered = h;
+    },
+  };
+  await plugin(fastify);
+  const req = { method: "GET", url: "/api/x", headers: { host: "test.local" } };
+  const reply = {
+    _code: 0,
+    _headers: {} as Record<string, string>,
+    _body: undefined as unknown,
+    code(c: number) { this._code = c; return this; },
+    header(k: string, v: string) { this._headers[k] = v; return this; },
+    send(body: unknown) { this._body = body; return body; },
+  };
+  await registered!(req, reply);
+  expect(reply._code).toBe(503);
+  expect(reply._headers["x-chaos-fault-kind"]).toBe("5xx");
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t fastifyPlugin
+```
+
+Expected: pre-existing tests fail + new tests fail.
+
+- [ ] **Step 3: Update `fastify.ts`**
+
+Replace `fastifyPlugin()`:
+
+```ts
+export function fastifyPlugin(cfg: ServerFaultConfig) {
+  const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
+  return async function plugin(fastify: FastifyLikeInstance) {
+    fastify.addHook("onRequest", async (req, reply) => {
+      const verdict = await fault.maybeInject(toWebRequest(req));
+      if (!verdict) return;
+      if (verdict.kind === "synthetic") {
+        reply.code(verdict.response.status);
+        verdict.response.headers.forEach((value, key) => {
+          reply.header(key, value);
+        });
+        await reply.send(await verdict.response.json());
+        return;
+      }
+      // annotate: stamp headers; the real route runs after the onRequest hook returns.
+      if (metadataPrefix) {
+        for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+          reply.header(name, value);
+        }
+      }
+    });
+  };
+}
+```
+
+Update imports the same way as Tasks 4–5.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t fastifyPlugin
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/adapters/fastify.ts packages/server-faults/src/adapters/adapters.test.ts
+git commit -m "feat(server-faults/fastify): support FaultVerdict + metadataHeader stamping"
+```
+
+---
+
+### Task 7: Update Koa adapter
+
+**Files:**
+- Modify: `packages/server-faults/src/adapters/koa.ts`
+- Modify: `packages/server-faults/src/adapters/adapters.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `describe("koaMiddleware", …)`:
+
+```ts
+it("stamps metadata headers via ctx.set() for latency annotate verdict", async () => {
+  const mw = koaMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+  const next = vi.fn(async () => undefined);
+  const ctx = {
+    req: { method: "GET", url: "/api/x", headers: { host: "test.local" } },
+    status: 0,
+    body: undefined as unknown,
+    _headers: {} as Record<string, string>,
+    set(k: string, v: string) { this._headers[k] = v; },
+  };
+  await mw(ctx, next);
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(ctx._headers["x-chaos-fault-kind"]).toBe("latency");
+});
+
+it("attaches metadata headers to synthetic 5xx ctx", async () => {
+  const mw = koaMiddleware({ status5xxRate: 1, metadataHeader: true });
+  const next = vi.fn();
+  const ctx = {
+    req: { method: "GET", url: "/api/x", headers: { host: "test.local" } },
+    status: 0,
+    body: undefined as unknown,
+    _headers: {} as Record<string, string>,
+    set(k: string, v: string) { this._headers[k] = v; },
+  };
+  await mw(ctx, next);
+  expect(ctx.status).toBe(503);
+  expect(ctx._headers["x-chaos-fault-kind"]).toBe("5xx");
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t koaMiddleware
+```
+
+Expected: pre-existing fail + new fail.
+
+- [ ] **Step 3: Update `koa.ts`**
+
+Replace `koaMiddleware()`:
+
+```ts
+export function koaMiddleware(
+  cfg: ServerFaultConfig,
+): (ctx: KoaLikeContext, next: KoaLikeNext) => Promise<void> {
+  const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
+  return async (ctx, next) => {
+    const verdict = await fault.maybeInject(toWebRequest(ctx.req));
+    if (!verdict) {
+      await next();
+      return;
+    }
+    if (verdict.kind === "synthetic") {
+      ctx.status = verdict.response.status;
+      verdict.response.headers.forEach((value, key) => {
+        ctx.set(key, value);
+      });
+      ctx.body = await verdict.response.json();
+      return;
+    }
+    // annotate: stamp headers, then continue to the real handler.
+    if (metadataPrefix) {
+      for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+        ctx.set(name, value);
+      }
+    }
+    await next();
+  };
+}
+```
+
+Update imports.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @mizchi/server-faults test -- adapters.test.ts -t koaMiddleware
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server-faults/src/adapters/koa.ts packages/server-faults/src/adapters/adapters.test.ts
+git commit -m "feat(server-faults/koa): support FaultVerdict + metadataHeader stamping"
+```
+
+---
+
+### Task 8: Run full server-faults suite + build
+
+**Files:** none modified.
+
+- [ ] **Step 1: Full test run**
+
+```bash
+pnpm --filter @mizchi/server-faults test
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Type check + build**
+
+```bash
+pnpm --filter @mizchi/server-faults build
+```
+
+Expected: tsc reports zero errors and `dist/` is regenerated.
+
+- [ ] **Step 3: Commit any package-json changes if `engines` / exports needed updating**
+
+If no changes, skip. Otherwise:
+
+```bash
+git add packages/server-faults/package.json
+git commit -m "chore(server-faults): refresh build artefacts"
+```
+
+---
+
+### Task 9: Open PR 1
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin feat/server-faults-metadata-header
+gh pr create --title "feat(server-faults)!: trace_id, FaultVerdict, metadataHeader" --body "$(cat <<'EOF'
+## Summary
+- `FaultAttrs` gains `fault.trace_id` extracted from incoming W3C `traceparent`
+- `maybeInject` now returns `FaultVerdict` (`synthetic` | `annotate` | `null`); the latency path returns `annotate` so adapters can stamp metadata headers on the real response
+- `metadataHeader` option mirrors fault attrs onto kebab-case response headers (`x-chaos-fault-*` by default)
+- All four adapters (hono / express / fastify / koa) updated for the new verdict + header stamping
+
+Spec: `docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`
+
+Refs: closes part of #56 (server-faults side).
+
+## Test plan
+- [x] `pnpm --filter @mizchi/server-faults test` passes locally
+- [x] `pnpm --filter @mizchi/server-faults build` succeeds
+- [ ] Will be exercised end-to-end by the chaosbringer integration in PR 2 + the otel-chaos-lab adoption PR
+EOF
+)"
+```
+
+(`origin` = `git@github.com:mizchi/chaosbringer`. Branch must be created off main: `git checkout -b feat/server-faults-metadata-header` before Task 1.)
+
+---
+
+## PR 2 — chaosbringer: ingest server-side faults via response headers
+
+**Pre-requisite:** PR 1 must be merged. Create branch: `git checkout main && git pull && git checkout -b feat/chaos-server-mode-remote`. The chaosbringer monorepo's workspace symlink keeps `@mizchi/server-faults` pointed at the in-tree package, so PR 1's changes are immediately consumable.
+
+### Task 10: Add response-header parser
+
+**Files:**
+- Create: `packages/chaosbringer/src/server-fault-events.ts`
+- Create: `packages/chaosbringer/src/server-fault-events.test.ts`
+
+This module is the unit responsible for translating raw response headers back into a `FaultAttrs`-shaped event. Pure function, no Playwright surface, easy to unit-test.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/chaosbringer/src/server-fault-events.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { parseServerFaultHeaders } from "./server-fault-events.js";
+
+const make = (entries: Record<string, string>) => {
+  const h = new Headers();
+  for (const [k, v] of Object.entries(entries)) h.set(k, v);
+  return h;
+};
+
+describe("parseServerFaultHeaders", () => {
+  it("returns null when the prefix marker is absent", () => {
+    const h = make({ "content-type": "application/json" });
+    expect(parseServerFaultHeaders(h, "x-chaos-fault")).toBeNull();
+  });
+
+  it("parses a 5xx event with all headers present", () => {
+    const h = make({
+      "x-chaos-fault-kind": "5xx",
+      "x-chaos-fault-path": "/api/todos",
+      "x-chaos-fault-method": "GET",
+      "x-chaos-fault-target-status": "503",
+      "x-chaos-fault-trace-id": "0af7651916cd43dd8448eb211c80319c",
+    });
+    expect(parseServerFaultHeaders(h, "x-chaos-fault")).toEqual({
+      attrs: {
+        "fault.kind": "5xx",
+        "fault.path": "/api/todos",
+        "fault.method": "GET",
+        "fault.target_status": 503,
+        "fault.trace_id": "0af7651916cd43dd8448eb211c80319c",
+      },
+      traceId: "0af7651916cd43dd8448eb211c80319c",
+    });
+  });
+
+  it("parses a latency event without target-status", () => {
+    const h = make({
+      "x-chaos-fault-kind": "latency",
+      "x-chaos-fault-path": "/api/x",
+      "x-chaos-fault-method": "POST",
+      "x-chaos-fault-latency-ms": "350",
+    });
+    const r = parseServerFaultHeaders(h, "x-chaos-fault");
+    expect(r?.attrs).toEqual({
+      "fault.kind": "latency",
+      "fault.path": "/api/x",
+      "fault.method": "POST",
+      "fault.latency_ms": 350,
+    });
+    expect(r?.traceId).toBeUndefined();
+  });
+
+  it("returns null for unknown kind", () => {
+    const h = make({
+      "x-chaos-fault-kind": "abort",
+      "x-chaos-fault-path": "/x",
+      "x-chaos-fault-method": "GET",
+    });
+    expect(parseServerFaultHeaders(h, "x-chaos-fault")).toBeNull();
+  });
+
+  it("honours custom prefix", () => {
+    const h = make({
+      "x-my-fault-kind": "5xx",
+      "x-my-fault-path": "/api",
+      "x-my-fault-method": "GET",
+      "x-my-fault-target-status": "500",
+    });
+    expect(parseServerFaultHeaders(h, "x-my-fault")?.attrs["fault.kind"]).toBe("5xx");
+    expect(parseServerFaultHeaders(h, "x-chaos-fault")).toBeNull();
+  });
+
+  it("ignores numeric headers that fail to parse", () => {
+    const h = make({
+      "x-chaos-fault-kind": "latency",
+      "x-chaos-fault-path": "/api",
+      "x-chaos-fault-method": "GET",
+      "x-chaos-fault-latency-ms": "not-a-number",
+    });
+    const r = parseServerFaultHeaders(h, "x-chaos-fault");
+    // Latency event still parses; the bad number is dropped (no fault.latency_ms).
+    expect(r?.attrs["fault.kind"]).toBe("latency");
+    expect(r?.attrs["fault.latency_ms"]).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter chaosbringer test -- server-fault-events.test.ts
+```
+
+Expected: file not found / module not resolved.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `packages/chaosbringer/src/server-fault-events.ts`:
+
+```ts
+/**
+ * Parser for the `x-chaos-fault-*` response headers emitted by
+ * `@mizchi/server-faults` when its `metadataHeader` option is set.
+ * Pure function: no I/O, no Playwright surface — invoked from
+ * `page.on('response', …)` once per response.
+ */
+
+const KNOWN_KINDS = new Set(["5xx", "latency"]);
+
+export interface ServerFaultEventAttrs {
+  "fault.kind": "5xx" | "latency";
+  "fault.path": string;
+  "fault.method": string;
+  "fault.target_status"?: number;
+  "fault.latency_ms"?: number;
+  "fault.trace_id"?: string;
+}
+
+export interface ParsedServerFault {
+  attrs: ServerFaultEventAttrs;
+  traceId?: string;
+}
+
+export function parseServerFaultHeaders(
+  headers: Headers,
+  prefix: string,
+): ParsedServerFault | null {
+  const kind = headers.get(`${prefix}-kind`);
+  if (!kind || !KNOWN_KINDS.has(kind)) return null;
+
+  const path = headers.get(`${prefix}-path`);
+  const method = headers.get(`${prefix}-method`);
+  if (!path || !method) return null;
+
+  const attrs: ServerFaultEventAttrs = {
+    "fault.kind": kind as "5xx" | "latency",
+    "fault.path": path,
+    "fault.method": method,
+  };
+
+  const targetStatus = headers.get(`${prefix}-target-status`);
+  if (targetStatus !== null) {
+    const n = Number.parseInt(targetStatus, 10);
+    if (Number.isFinite(n)) attrs["fault.target_status"] = n;
+  }
+
+  const latencyMs = headers.get(`${prefix}-latency-ms`);
+  if (latencyMs !== null) {
+    const n = Number.parseFloat(latencyMs);
+    if (Number.isFinite(n)) attrs["fault.latency_ms"] = n;
+  }
+
+  const traceId = headers.get(`${prefix}-trace-id`) ?? undefined;
+  if (traceId) attrs["fault.trace_id"] = traceId;
+
+  return { attrs, traceId };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter chaosbringer test -- server-fault-events.test.ts
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/chaosbringer/src/server-fault-events.ts packages/chaosbringer/src/server-fault-events.test.ts
+git commit -m "feat(chaosbringer): parse x-chaos-fault-* response headers into events"
+```
+
+---
+
+### Task 11: Wire `ChaosRemoteServer` option through `ChaosRunOptions` and types
+
+**Files:**
+- Modify: `packages/chaosbringer/src/chaos.ts`
+- Modify: `packages/chaosbringer/src/types.ts`
+- Modify: `packages/chaosbringer/src/index.ts`
+
+This task adds the public type surface and threads it down into the crawler's options bag. No behaviour change yet — Task 12 attaches the listener and Task 13 surfaces events on the report.
+
+- [ ] **Step 1: Add types**
+
+In `packages/chaosbringer/src/types.ts`, append at the bottom:
+
+```ts
+/**
+ * Server-side fault ingestion mode. Phase 1 supports `"remote"`: the server
+ * runs in a different process and emits `x-chaos-fault-*` response headers
+ * via `@mizchi/server-faults`'s `metadataHeader` option. chaos() listens for
+ * those headers and surfaces the events on `CrawlReport.serverFaults`.
+ */
+export interface ChaosRemoteServer {
+  mode: "remote";
+  /** Header prefix to look for. Default `"x-chaos-fault"`. */
+  responseHeaderPrefix?: string;
+}
+
+export interface ServerFaultEvent {
+  /** Trace-id from the response headers (W3C traceparent's trace-id segment). */
+  traceId?: string;
+  attrs: {
+    "fault.kind": "5xx" | "latency";
+    "fault.path": string;
+    "fault.method": string;
+    "fault.target_status"?: number;
+    "fault.latency_ms"?: number;
+    "fault.trace_id"?: string;
+  };
+  /** Wall-clock ms when chaos observed the response. */
+  observedAt: number;
+  /** URL of the page that triggered the request. */
+  pageUrl: string;
+}
+```
+
+In the same file, find the `CrawlReport` interface and add the optional field at the end of its body:
+
+```ts
+  /**
+   * Server-side fault events ingested via response headers (present only
+   * when `chaos({ server: { mode: "remote" } })` was set and the server
+   * was emitting `x-chaos-fault-*` headers via `@mizchi/server-faults`).
+   * Flat list across the whole run; consumers join by `traceId` for
+   * per-action correlation.
+   */
+  serverFaults?: ServerFaultEvent[];
+```
+
+- [ ] **Step 2: Add to `ChaosRunOptions`**
+
+In `packages/chaosbringer/src/chaos.ts`, import the new types and extend the interface:
+
+```ts
+import type {
+  CrawlerEvents,
+  CrawlerOptions,
+  CrawlReport,
+  ChaosRemoteServer,
+} from "./types.js";
+```
+
+Inside `ChaosRunOptions`, after the `setup` field:
+
+```ts
+  /**
+   * Surface server-side fault events into `report.serverFaults`. Phase 1:
+   * `{ mode: "remote" }` reads `x-chaos-fault-*` response headers emitted
+   * by `@mizchi/server-faults` running in the server process.
+   */
+  server?: ChaosRemoteServer;
+```
+
+In the destructuring of `chaos()`, pull `server` out:
+
+```ts
+const { strict, baseline, baselineStrict, setup, server, ...crawlerOptions } = options;
+```
+
+Pass it into the crawler options (we extend `CrawlerOptions` to carry it through):
+
+```ts
+const crawler = new ChaosCrawler({ ...crawlerOptions, server } as CrawlerOptions, events);
+```
+
+- [ ] **Step 3: Mirror onto `CrawlerOptions`**
+
+In `packages/chaosbringer/src/types.ts`, locate `CrawlerOptions`. Add inside its body:
+
+```ts
+  /** @internal Set by `chaos({ server })`. */
+  server?: ChaosRemoteServer;
+```
+
+- [ ] **Step 4: Re-export from index**
+
+In `packages/chaosbringer/src/index.ts`, add to the type re-export block (where `TraceparentInjectionOptions` lives):
+
+```ts
+  ChaosRemoteServer,
+  ServerFaultEvent,
+```
+
+(Both go in the existing `export type {` from `./types.js` block.)
+
+- [ ] **Step 5: Type-check**
+
+```bash
+pnpm --filter chaosbringer build
+```
+
+Expected: tsc reports zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/chaosbringer/src/chaos.ts packages/chaosbringer/src/types.ts packages/chaosbringer/src/index.ts
+git commit -m "feat(chaosbringer): add ChaosRemoteServer option type (no behaviour yet)"
+```
+
+---
+
+### Task 12: Attach `page.on('response')` listener and collect events
+
+**Files:**
+- Modify: `packages/chaosbringer/src/crawler.ts`
+- Create: `packages/chaosbringer/src/server-fault-collector.ts`
+- Create: `packages/chaosbringer/src/server-fault-collector.test.ts`
+
+The collector is its own module so we can unit-test it without spinning up a real Page. The crawler holds one collector per crawl and pushes its events into the final report.
+
+- [ ] **Step 1: Write failing collector test**
+
+Create `packages/chaosbringer/src/server-fault-collector.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { ServerFaultCollector } from "./server-fault-collector.js";
+
+describe("ServerFaultCollector", () => {
+  it("records 5xx events with pageUrl and observedAt", () => {
+    const c = new ServerFaultCollector("x-chaos-fault");
+    const headers = new Headers({
+      "x-chaos-fault-kind": "5xx",
+      "x-chaos-fault-path": "/api/todos",
+      "x-chaos-fault-method": "GET",
+      "x-chaos-fault-target-status": "503",
+      "x-chaos-fault-trace-id": "0af7651916cd43dd8448eb211c80319c",
+    });
+    c.observe({ headers, pageUrl: "https://app/todos" });
+    const events = c.drain();
+    expect(events).toHaveLength(1);
+    expect(events[0].pageUrl).toBe("https://app/todos");
+    expect(events[0].traceId).toBe("0af7651916cd43dd8448eb211c80319c");
+    expect(events[0].attrs["fault.kind"]).toBe("5xx");
+    expect(typeof events[0].observedAt).toBe("number");
+  });
+
+  it("ignores responses without the prefix", () => {
+    const c = new ServerFaultCollector("x-chaos-fault");
+    c.observe({ headers: new Headers({ "x-other": "1" }), pageUrl: "https://app" });
+    expect(c.drain()).toHaveLength(0);
+  });
+
+  it("preserves event order across pages", () => {
+    const c = new ServerFaultCollector("x-chaos-fault");
+    const headers = (kind: string, path: string) =>
+      new Headers({
+        "x-chaos-fault-kind": kind,
+        "x-chaos-fault-path": path,
+        "x-chaos-fault-method": "GET",
+      });
+    c.observe({ headers: headers("5xx", "/a"), pageUrl: "https://app/a" });
+    c.observe({ headers: headers("latency", "/b"), pageUrl: "https://app/b" });
+    const events = c.drain();
+    expect(events.map((e) => e.attrs["fault.path"])).toEqual(["/a", "/b"]);
+  });
+
+  it("drain() empties the buffer", () => {
+    const c = new ServerFaultCollector("x-chaos-fault");
+    c.observe({
+      headers: new Headers({
+        "x-chaos-fault-kind": "5xx",
+        "x-chaos-fault-path": "/x",
+        "x-chaos-fault-method": "GET",
+      }),
+      pageUrl: "https://app",
+    });
+    expect(c.drain()).toHaveLength(1);
+    expect(c.drain()).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm --filter chaosbringer test -- server-fault-collector.test.ts
+```
+
+Expected: module not resolved.
+
+- [ ] **Step 3: Implement the collector**
+
+Create `packages/chaosbringer/src/server-fault-collector.ts`:
+
+```ts
+import { parseServerFaultHeaders } from "./server-fault-events.js";
+import type { ServerFaultEvent } from "./types.js";
+
+export interface ObserveArgs {
+  headers: Headers;
+  pageUrl: string;
+}
+
+/**
+ * Buffers server-side fault events parsed from response headers across
+ * the lifetime of a single crawl. The crawler creates one instance,
+ * page-level listeners feed it, and the report generator drains it.
+ */
+export class ServerFaultCollector {
+  private buffer: ServerFaultEvent[] = [];
+
+  constructor(private readonly prefix: string) {}
+
+  observe(args: ObserveArgs): void {
+    const parsed = parseServerFaultHeaders(args.headers, this.prefix);
+    if (!parsed) return;
+    this.buffer.push({
+      traceId: parsed.traceId,
+      attrs: parsed.attrs,
+      observedAt: Date.now(),
+      pageUrl: args.pageUrl,
+    });
+  }
+
+  drain(): ServerFaultEvent[] {
+    const out = this.buffer;
+    this.buffer = [];
+    return out;
+  }
+
+  size(): number {
+    return this.buffer.length;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter chaosbringer test -- server-fault-collector.test.ts
+```
+
+Expected: green.
+
+- [ ] **Step 5: Wire into the crawler**
+
+In `packages/chaosbringer/src/crawler.ts`:
+
+a) Add an import at the top with the other internal imports:
+
+```ts
+import { ServerFaultCollector } from "./server-fault-collector.js";
+```
+
+b) Inside `ChaosCrawler` (the class), declare a private field near the other private state:
+
+```ts
+  private readonly serverFaultCollector: ServerFaultCollector | null;
+```
+
+c) Initialise it in the constructor (after options are stored). Search for where `this.options` is assigned and append below it:
+
+```ts
+    this.serverFaultCollector = this.options.server?.mode === "remote"
+      ? new ServerFaultCollector(this.options.server.responseHeaderPrefix ?? "x-chaos-fault")
+      : null;
+```
+
+d) Inside the per-page listener block (the section near line 1364 that sets up `page.on("console", …)` etc), add:
+
+```ts
+    if (this.serverFaultCollector) {
+      const collector = this.serverFaultCollector;
+      page.on("response", (response) => {
+        if (!collecting) return;
+        // Playwright's APIResponse / Response gives a plain object via headers().
+        // Wrap in Headers so the collector's parser sees a Web-Standard surface.
+        const h = new Headers();
+        for (const [k, v] of Object.entries(response.headers())) h.set(k, v);
+        collector.observe({ headers: h, pageUrl: page.url() });
+      });
+    }
+```
+
+(`collecting` is the local boolean declared earlier in the same method that gates listeners during the page recovery window. Reusing it keeps server-fault events scoped to the same lifetime as console / pageerror listeners.)
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+pnpm --filter chaosbringer test
+```
+
+Expected: green (no behaviour change to report yet — Task 13 surfaces drained events).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/chaosbringer/src/server-fault-collector.ts packages/chaosbringer/src/server-fault-collector.test.ts packages/chaosbringer/src/crawler.ts
+git commit -m "feat(chaosbringer): collect server-fault events from response headers per page"
+```
+
+---
+
+### Task 13: Surface events on `CrawlReport.serverFaults`
+
+**Files:**
+- Modify: `packages/chaosbringer/src/crawler.ts`
+- Modify: `packages/chaosbringer/src/chaos.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/chaosbringer/src/chaos.test.ts` (or wherever `chaos.test.ts` lives — assert by `grep -l "describe(\"chaos" packages/chaosbringer/src/`). The new test exercises the integration without Playwright — by calling `generateReport` indirectly we'd need a full crawl. Instead, add a unit-level test that calls the crawler's report-generation path with the collector pre-seeded.
+
+Use a smaller test file scope: create `packages/chaosbringer/src/server-fault-report.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { ServerFaultCollector } from "./server-fault-collector.js";
+
+describe("server-fault report integration", () => {
+  it("collector.drain() produces the shape CrawlReport.serverFaults expects", () => {
+    const c = new ServerFaultCollector("x-chaos-fault");
+    c.observe({
+      headers: new Headers({
+        "x-chaos-fault-kind": "5xx",
+        "x-chaos-fault-path": "/api/x",
+        "x-chaos-fault-method": "GET",
+        "x-chaos-fault-target-status": "503",
+        "x-chaos-fault-trace-id": "abcdef0123456789abcdef0123456789",
+      }),
+      pageUrl: "https://app/x",
+    });
+    const drained = c.drain();
+    // Shape contract that CrawlReport.serverFaults exposes:
+    expect(drained[0]).toMatchObject({
+      traceId: "abcdef0123456789abcdef0123456789",
+      pageUrl: "https://app/x",
+      attrs: {
+        "fault.kind": "5xx",
+        "fault.path": "/api/x",
+        "fault.method": "GET",
+        "fault.target_status": 503,
+        "fault.trace_id": "abcdef0123456789abcdef0123456789",
+      },
+    });
+    expect(typeof drained[0].observedAt).toBe("number");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm it passes**
+
+```bash
+pnpm --filter chaosbringer test -- server-fault-report.test.ts
+```
+
+Expected: green (this test is a contract anchor — it pins the shape so future refactors break loudly).
+
+- [ ] **Step 3: Wire drain into report generation**
+
+In `packages/chaosbringer/src/crawler.ts`, find `generateReport` (around line 2236). Inside the returned `CrawlReport`, after the existing optional fields (`coverage`, `advisor`, etc.), add:
+
+```ts
+      ...(this.serverFaultCollector && this.serverFaultCollector.size() > 0
+        ? { serverFaults: this.serverFaultCollector.drain() }
+        : {}),
+```
+
+Order doesn't matter for the consumer, but keep it next to similarly conditional fields for readability.
+
+If `generateReport` builds the object via property assignments rather than a single literal, append:
+
+```ts
+    if (this.serverFaultCollector && this.serverFaultCollector.size() > 0) {
+      report.serverFaults = this.serverFaultCollector.drain();
+    }
+```
+
+- [ ] **Step 4: Run full chaosbringer test suite**
+
+```bash
+pnpm --filter chaosbringer test
+pnpm --filter chaosbringer build
+```
+
+Expected: green + tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/chaosbringer/src/server-fault-report.test.ts packages/chaosbringer/src/crawler.ts
+git commit -m "feat(chaosbringer): surface server fault events on CrawlReport.serverFaults"
+```
+
+---
+
+### Task 14: Open PR 2
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin feat/chaos-server-mode-remote
+gh pr create --title "feat(chaosbringer): server: { mode: 'remote' } ingests x-chaos-fault-* headers" --body "$(cat <<'EOF'
+## Summary
+- New `chaos({ server: { mode: "remote" } })` option attaches a `page.on('response', …)` listener that parses `x-chaos-fault-*` response headers emitted by `@mizchi/server-faults`'s `metadataHeader`.
+- Events surface on `CrawlReport.serverFaults` as a flat list with `traceId`, `attrs` (FaultAttrs schema), `observedAt`, `pageUrl`.
+- Per-action correlation is left to consumers via `traceId` join — explicitly Phase 2 territory.
+
+Spec: `docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`
+
+Refs: closes part of #56 (chaosbringer side). Depends on the server-faults release shipped with the previous PR.
+
+## Test plan
+- [x] `pnpm --filter chaosbringer test` passes locally
+- [x] `pnpm --filter chaosbringer build` succeeds
+- [ ] otel-chaos-lab adoption PR will be the live end-to-end verification (separate PR)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** server-faults trace_id (Task 1), verdict refactor (Task 2), metadataHeader option (Task 3), all four adapters updated (Tasks 4–7), chaosbringer remote mode option (Task 11), response listener (Task 12), report surface (Task 13). otel-chaos-lab adoption is intentionally a separate plan as per spec.
+- **No placeholders:** every TDD step has concrete code. Adapter test deltas show the full new test bodies, not "similar to above".
+- **Type consistency:** `FaultAttrs`, `FaultVerdict`, `metadataHeader`, `ChaosRemoteServer`, `ServerFaultEvent`, `ServerFaultCollector` are introduced in Tasks 1–3 and 10–12 in the order they're consumed; `parseServerFaultHeaders` (Task 10) is consumed by `ServerFaultCollector` (Task 12); `ChaosRemoteServer` (Task 11) is read by the crawler init in Task 12.
+- **Sequencing:** `attrsToHeaderEntries` and `resolveMetadataPrefix` are exported from server-faults.ts in Task 3, then consumed in Tasks 4–7 — the export must land before the adapter PRs are run, which is enforced by Task ordering within PR 1.
+- **Breaking change discipline:** Tasks 4–7 are intentionally broken between commits inside PR 1; CI on the branch will fail until Task 7 lands. Reviewers should review the PR as a unit, not commit-by-commit. Documented inside Task 2.

--- a/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md
+++ b/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md
@@ -38,8 +38,8 @@ Bun, …) run as **different processes**, communicating only over HTTP.
 - Response-header-based event channel (server-faults annotates synthetic
   / latency-affected responses; chaos parses headers in
   `page.on('response', …)`).
-- `fault.trace_id` joining the W3C `traceparent` already injected by
-  chaosbringer's network layer (PR #72).
+- `traceId` (OTel-mapped to `fault.trace_id`) joining the W3C
+  `traceparent` already injected by chaosbringer's network layer (PR #72).
 - A breaking `maybeInject` API change on server-faults to surface
   fault attrs to adapters even on the latency path.
 
@@ -63,9 +63,9 @@ chaosbringer's Playwright route layer already injects on every request
 trace-id back from response headers, so the same id flows through both
 layers without a parallel id system.
 
-This also means OTel exporters wired to either side automatically get a
-`fault.trace_id` attribute that joins to spans the rest of the system
-already emits.
+This also means OTel exporters wired to either side — via the
+`toOtelAttrs(attrs)` translator — automatically get a `fault.trace_id`
+attribute that joins to spans the rest of the system already emits.
 
 ### Event channel: response headers
 
@@ -102,23 +102,45 @@ hook handles both fault kinds.
 
 ### `@mizchi/server-faults`
 
-#### `FaultAttrs` gains `fault.trace_id`
+#### `FaultAttrs` becomes flat camelCase + gains `traceId`
+
+The PR #69 schema used dotted keys (`"fault.kind"`, `"fault.target_status"`,
+…) modelled directly on OTel attribute names. Those keys require quoting
+in TypeScript and force every consumer to write `attrs["fault.kind"]`
+instead of `attrs.kind`. We treat the OTel-style dotted form as a *wire
+format* and keep the in-memory TS shape flat:
 
 ```ts
 export interface FaultAttrs {
-  "fault.kind": FaultKind;
-  "fault.path": string;
-  "fault.method": string;
-  "fault.target_status"?: number;
-  "fault.latency_ms"?: number;
-  "fault.trace_id"?: string;  // NEW
+  kind: FaultKind;
+  path: string;
+  method: string;
+  targetStatus?: number;
+  latencyMs?: number;
+  traceId?: string;
 }
 ```
 
-Extracted from the incoming request's `traceparent` header per W3C
-Trace Context (segment 2 of `00-{trace-id}-{span-id}-{flags}`,
+`traceId` is extracted from the incoming request's `traceparent` header
+per W3C Trace Context (segment 2 of `00-{trace-id}-{span-id}-{flags}`,
 32 lowercase hex). Absent if the request has no traceparent or the
 header is malformed.
+
+A small adapter exposes the OTel attribute form for consumers that pipe
+fault events directly into an OTel exporter:
+
+```ts
+export function toOtelAttrs(attrs: FaultAttrs): Record<string, string | number> {
+  // Returns { "fault.kind": "5xx", "fault.target_status": 503, … }
+  // following the OTel semantic convention naming.
+}
+```
+
+This is a breaking change to PR #69's landed `observer.onFault` callback
+signature. The package is at `0.x`; bumping to `0.2.0` is acceptable, and
+the only known consumer (the four in-tree adapters + `otel-chaos-lab`'s
+`hono` wiring) is migrated in the same release. A migration note in the
+PR body documents the rename map.
 
 #### `metadataHeader` option
 
@@ -135,9 +157,14 @@ export interface ServerFaultConfig {
 }
 ```
 
-Header naming rule: `{prefix}-{key}` where `key` is the attrs key after
-stripping `fault.` and replacing `_` with `-`. So
-`fault.target_status` → `x-chaos-fault-target-status`.
+Header naming rule: `{prefix}-{kebab(key)}` where `key` is a TS attrs
+property name and `kebab` lower-cases the camelCase boundary. So
+`targetStatus` → `x-chaos-fault-target-status`,
+`latencyMs` → `x-chaos-fault-latency-ms`,
+`traceId` → `x-chaos-fault-trace-id`. The on-the-wire header names match
+what the previous PR #69 schema would have produced, so a downstream
+consumer (e.g. an OTel exporter that ingests these headers) is
+unaffected by the in-memory rename.
 
 #### Breaking: `maybeInject` returns a verdict
 
@@ -265,8 +292,10 @@ After this lands, `otel-chaos-lab` adopts the new wiring in a follow-up:
 - `metadataHeader` unit tests: 5xx case includes all expected headers;
   latency case carries headers via the `annotate` verdict; `prefix`
   override works; absent option means no headers.
-- `fault.trace_id` extraction: valid traceparent yields the 32-hex
-  segment; malformed / absent traceparent yields no `trace_id` key.
+- `traceId` extraction: valid traceparent yields the 32-hex segment;
+  malformed / absent traceparent yields no `traceId` key.
+- `toOtelAttrs(attrs)` translator: every camelCase property maps to its
+  dotted OTel form; absent optional keys do not appear in the output.
 - Verdict migration: existing tests that asserted `Response | null`
   switch to verdict-shaped expectations. Each fault kind is exercised
   through every adapter (`hono` / `express` / `fastify` / `koa`).
@@ -308,8 +337,9 @@ round-trip and lands the adoption.
 
 ## Sequencing
 
-1. **server-faults**: `fault.trace_id`, verdict refactor, adapters
-   updated, `metadataHeader` plumbed (one PR; breaking, bumps minor).
+1. **server-faults**: flat camelCase `FaultAttrs` (with `traceId`),
+   `toOtelAttrs(attrs)` translator, verdict refactor, adapters updated,
+   `metadataHeader` plumbed (one PR; breaking, bumps minor).
 2. **chaosbringer**: `server` option, `page.on('response')` listener,
    `CrawlReport.serverFaults`, fixture test (one PR).
 3. **otel-chaos-lab**: adoption + verification PR.

--- a/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md
+++ b/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md
@@ -1,0 +1,317 @@
+# Chaos × server-faults orchestration (C2 Phase 1)
+
+**Date:** 2026-05-06
+**Issue:** [chaosbringer#56](https://github.com/mizchi/chaosbringer/issues/56)
+**Status:** Approved (awaiting implementation plan)
+
+## Problem
+
+`chaosbringer` injects faults at the **Playwright route layer** (between
+browser and server). `@mizchi/server-faults` injects faults **inside the
+server**. They are intentionally separate concerns, but today there is
+no shared way to drive both from one chaos run:
+
+- Server-side fault events live only in the server process. The chaos
+  report has no record of them.
+- The two layers' RNGs are seeded independently. Reproducing a "503 from
+  network + slow server response" combo across runs requires the operator
+  to align two seeds by hand.
+- The user reads two separate observability surfaces (chaos report +
+  whatever the server emits to OTel/Prometheus).
+
+The most realistic chaos scenarios are *combined* — a 503 returned by the
+network layer **and** the server is also degraded — and orchestrating
+those compound failures across runs is the missing piece.
+
+## Scope
+
+This spec covers **Phase 1, separate-process mode** (option C2 in
+brainstorming). The motivating consumer is `otel-chaos-lab`-shaped
+deployments: `pnpm chaos` and the server (`wrangler dev`, Node, Deno,
+Bun, …) run as **different processes**, communicating only over HTTP.
+
+**In scope:**
+
+- A new `server: { mode: "remote", … }` field on `chaos()` that lets the
+  Playwright crawler ingest server-side fault events emitted by
+  `@mizchi/server-faults`.
+- Response-header-based event channel (server-faults annotates synthetic
+  / latency-affected responses; chaos parses headers in
+  `page.on('response', …)`).
+- `fault.trace_id` joining the W3C `traceparent` already injected by
+  chaosbringer's network layer (PR #72).
+- A breaking `maybeInject` API change on server-faults to surface
+  fault attrs to adapters even on the latency path.
+
+**Explicitly out of scope (Phase 2 / separate issues):**
+
+- Same-process integration (`server: ServerFaultHandle` direct passing,
+  `reseed()` / `subscribe()` methods).
+- Per-action correlation in the report (trace-id-indexed dict per action;
+  Phase 1 surfaces a flat list and lets consumers join post-hoc).
+- Automatic seed propagation between processes (Phase 1 documents the
+  env-var convention; full automation can land later).
+
+## Architecture
+
+### Correlation primitive: `trace_id`
+
+Layer correlation rides on the W3C `traceparent` header that
+chaosbringer's Playwright route layer already injects on every request
+(PR #72). server-faults extracts the trace-id segment from incoming
+`traceparent` and stamps it onto every fault event. chaos parses the
+trace-id back from response headers, so the same id flows through both
+layers without a parallel id system.
+
+This also means OTel exporters wired to either side automatically get a
+`fault.trace_id` attribute that joins to spans the rest of the system
+already emits.
+
+### Event channel: response headers
+
+server-faults mirrors its `FaultAttrs` schema onto kebab-case response
+headers under a configurable prefix (default `x-chaos-fault`):
+
+```
+x-chaos-fault-kind: 5xx
+x-chaos-fault-path: /api/todos
+x-chaos-fault-method: GET
+x-chaos-fault-target-status: 503
+x-chaos-fault-trace-id: 0a1b2c3d4e5f60718293a4b5c6d7e8f9
+```
+
+For latency faults, the server returns its real (200/whatever) response
+after sleeping; the headers ride on that real response. chaosbringer's
+`page.on('response', …)` fires for both cases identically, so a single
+hook handles both fault kinds.
+
+### Why this shape
+
+- **Headers, not a sidechannel control plane.** The server-faults
+  process needs no extra endpoints, no IPC, no shared filesystem. The
+  fault metadata is already attached to the response that triggered it.
+- **Individual headers, not a JSON blob.** The attrs values are scalars;
+  individual headers map 1:1 to the `fault.*` schema and parse with a
+  single `headers.get(...)` per key. JSON-in-a-header would add a parse
+  step and an error path with no benefit.
+- **trace-id as the join key, not chaos-internal request ids.** PR #72
+  already injects traceparent. Inventing a parallel `x-chaos-req-id`
+  duplicates what's there and fragments the OTel story.
+
+## Component changes
+
+### `@mizchi/server-faults`
+
+#### `FaultAttrs` gains `fault.trace_id`
+
+```ts
+export interface FaultAttrs {
+  "fault.kind": FaultKind;
+  "fault.path": string;
+  "fault.method": string;
+  "fault.target_status"?: number;
+  "fault.latency_ms"?: number;
+  "fault.trace_id"?: string;  // NEW
+}
+```
+
+Extracted from the incoming request's `traceparent` header per W3C
+Trace Context (segment 2 of `00-{trace-id}-{span-id}-{flags}`,
+32 lowercase hex). Absent if the request has no traceparent or the
+header is malformed.
+
+#### `metadataHeader` option
+
+```ts
+export interface ServerFaultConfig {
+  // … existing fields …
+  /**
+   * When set, fault attributes are mirrored to response headers so an
+   * out-of-process consumer (e.g. chaosbringer's `chaos()` crawler) can
+   * observe server-side faults without sharing memory with the server.
+   * `true` uses the default prefix `x-chaos-fault`.
+   */
+  metadataHeader?: boolean | { prefix?: string };
+}
+```
+
+Header naming rule: `{prefix}-{key}` where `key` is the attrs key after
+stripping `fault.` and replacing `_` with `-`. So
+`fault.target_status` → `x-chaos-fault-target-status`.
+
+#### Breaking: `maybeInject` returns a verdict
+
+```ts
+export type FaultVerdict =
+  | { kind: "synthetic"; response: Response; attrs: FaultAttrs }
+  | { kind: "annotate"; attrs: FaultAttrs }
+  | null;
+
+export interface ServerFaultHandle {
+  maybeInject: (req: Request) => Promise<FaultVerdict>;
+}
+```
+
+- `synthetic` — server-faults already produced a `Response` (5xx case).
+  Adapter returns it as-is; if `metadataHeader` is on, the response was
+  built with the headers already attached.
+- `annotate` — the latency raffle won. server-faults already slept, but
+  the real handler must run; the adapter is responsible for setting the
+  headers on the resulting response after `next()` returns. `attrs`
+  carries the data the adapter writes.
+- `null` — no fault, no instrumentation.
+
+The four bundled adapters (`hono` / `express` / `fastify` / `koa`) are
+updated to handle the three-way verdict. The 4 adapter files become the
+canonical reference for how a custom adapter wires the `annotate` case.
+
+### `chaosbringer`
+
+#### `ChaosRunOptions.server`
+
+```ts
+export interface ChaosRemoteServer {
+  mode: "remote";
+  /** Header prefix to look for. Default `"x-chaos-fault"`. */
+  responseHeaderPrefix?: string;
+}
+
+export interface ChaosRunOptions extends CrawlerOptions {
+  // … existing fields …
+  server?: ChaosRemoteServer;
+}
+```
+
+Other shapes (e.g. direct handle for same-process integration) are
+reserved for Phase 2 and rejected at runtime in Phase 1.
+
+#### Response-header listener
+
+`chaos()` (or the underlying `ChaosCrawler`) attaches
+`page.on('response', resp => ...)` for every page it drives. When the
+response carries `{prefix}-kind`, all matching headers are read and
+parsed back into a `FaultAttrs` shape.
+
+The parser tolerates missing optional headers (`target-status` for
+latency faults, `latency-ms` for 5xx faults, `trace-id` for requests
+without a traceparent) and rejects responses where `kind` is not a
+known `FaultKind`.
+
+#### `CrawlReport.serverFaults`
+
+```ts
+export interface ServerFaultEvent {
+  traceId?: string;
+  attrs: FaultAttrs;
+  /** Wall-clock ms when chaos observed the response. */
+  observedAt: number;
+  /** URL of the page that triggered the request. */
+  pageUrl: string;
+}
+
+export interface CrawlReport {
+  // … existing fields …
+  serverFaults?: ServerFaultEvent[];
+}
+```
+
+Phase 1 keeps this as a flat list. Per-action joining (a dict keyed by
+trace-id, surfaced inside `ActionResult`) is intentionally deferred so
+we can ship the channel before designing how the report tree should
+look. Consumers wanting per-action correlation in Phase 1 join by
+trace-id manually.
+
+## Data flow
+
+```
+Browser (Playwright)              Server process
+  |                                  |
+  |-- request, traceparent injected->|
+  |                                  |-- server-faults rolls dice
+  |                                  |     [synthetic 5xx]:
+  |                                  |       response.headers +=
+  |                                  |         x-chaos-fault-*
+  |                                  |     [latency]:
+  |                                  |       sleep, then handler runs,
+  |                                  |       adapter adds headers
+  |                                  |       on the way back
+  |<--------- response (with --------|
+  |                  fault headers)  |
+  |
+  page.on('response') fires
+  prefix matches → parse attrs → push ServerFaultEvent
+  |
+report.serverFaults = [...events]
+```
+
+## otel-chaos-lab adoption (separate PR)
+
+After this lands, `otel-chaos-lab` adopts the new wiring in a follow-up:
+
+1. Worker `serverFaults({ ..., metadataHeader: true })`.
+2. `chaos/run.ts` adds `server: { mode: "remote" }` to its `chaos(...)`
+   call.
+3. Operations doc in `docs/notes/` records the env-var convention for
+   matching seeds across processes (e.g. `CHAOS_SEED=42` exported once
+   in `justfile`, consumed by both the worker and `chaos/run.ts`).
+4. Verify the round trip: induced 5xx and latency events both show up
+   in `report.serverFaults` with matching `trace_id` against the chaos
+   action that produced the request.
+
+## Testing strategy
+
+### server-faults
+
+- `metadataHeader` unit tests: 5xx case includes all expected headers;
+  latency case carries headers via the `annotate` verdict; `prefix`
+  override works; absent option means no headers.
+- `fault.trace_id` extraction: valid traceparent yields the 32-hex
+  segment; malformed / absent traceparent yields no `trace_id` key.
+- Verdict migration: existing tests that asserted `Response | null`
+  switch to verdict-shaped expectations. Each fault kind is exercised
+  through every adapter (`hono` / `express` / `fastify` / `koa`).
+
+### chaosbringer
+
+- `page.on('response')` parser unit tests with synthetic Playwright
+  responses: known headers parse correctly; unknown `kind` is rejected;
+  missing optional headers don't error.
+- An end-to-end fixture test: a Hono app wired with server-faults
+  + `metadataHeader`, served via a real port (existing chaosbringer
+  fixture pattern), driven by `chaos({ server: { mode: "remote" } })`.
+  Assertion: `report.serverFaults` non-empty with the expected
+  `kind` mix and trace-ids that intersect the page's request set.
+
+### otel-chaos-lab
+
+Separate follow-up PR. Real `wrangler dev` + `pnpm chaos`, asserts the
+round-trip and lands the adoption.
+
+## Risks and mitigations
+
+- **Breaking `maybeInject`**. server-faults is on 0.x and externally
+  has only the in-tree adapters as consumers. The blast radius is
+  the four adapter files we own. No downstream releases yet pin the
+  pre-verdict shape. (`otel-chaos-lab` uses `serverFaults` via the
+  hono adapter; it's covered by the adapter migration.)
+- **Header name collision**. The `x-chaos-fault-*` namespace is
+  unique enough that production traffic should never carry it.
+  `responseHeaderPrefix` is configurable for environments that
+  enforce header allow-lists.
+- **`page.on('response')` overhead**. Every response on every page
+  hits the parser. The parser short-circuits on the absence of
+  `{prefix}-kind`, so the cost is one `headers.get()` per response.
+- **Latency-fault headers leaking real response state**. The adapter
+  appends headers; it doesn't read the response body. Consumers that
+  `Object.freeze` their response headers will fail loudly — documented
+  in adapter source comments.
+
+## Sequencing
+
+1. **server-faults**: `fault.trace_id`, verdict refactor, adapters
+   updated, `metadataHeader` plumbed (one PR; breaking, bumps minor).
+2. **chaosbringer**: `server` option, `page.on('response')` listener,
+   `CrawlReport.serverFaults`, fixture test (one PR).
+3. **otel-chaos-lab**: adoption + verification PR.
+
+Step 2 depends on step 1's released package. Step 3 depends on step 2.

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -129,6 +129,37 @@ describe("expressMiddleware", () => {
     await mw(req, res, next);
     expect(res.statusCode).toBe(503);
   });
+
+  it("stamps metadata headers on res for the latency annotate verdict", async () => {
+    const mw = expressMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+    const next = vi.fn();
+    const req = { method: "GET", originalUrl: "/api/x", headers: { host: "test.local" } };
+    const res = makeRes();
+    await mw(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.headers["x-chaos-fault-kind"]).toBe("latency");
+    expect(res.headers["x-chaos-fault-path"]).toBe("/api/x");
+  });
+
+  it("does not stamp any chaos headers when metadataHeader is off", async () => {
+    const mw = expressMiddleware({ latencyRate: 1, latencyMs: 0 });
+    const next = vi.fn();
+    const req = { method: "GET", originalUrl: "/api/x", headers: {} };
+    const res = makeRes();
+    await mw(req, res, next);
+    // No chaos headers leaked.
+    expect(Object.keys(res.headers).length).toBe(0);
+  });
+
+  it("attaches metadata headers to synthetic 5xx response", async () => {
+    const mw = expressMiddleware({ status5xxRate: 1, metadataHeader: true });
+    const next = vi.fn();
+    const req = { method: "GET", originalUrl: "/api/x", headers: { host: "test.local" } };
+    const res = makeRes();
+    await mw(req, res, next);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers["x-chaos-fault-kind"]).toBe("5xx");
+  });
 });
 
 describe("fastifyPlugin", () => {

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { honoMiddleware } from "./hono.js";
+import { honoMiddleware, type HonoLikeContext } from "./hono.js";
 import { expressMiddleware } from "./express.js";
 import { fastifyPlugin } from "./fastify.js";
 import { koaMiddleware } from "./koa.js";
@@ -43,27 +43,29 @@ describe("honoMiddleware", () => {
   it("calls next() and stamps headers on c.res for latency annotate verdict", async () => {
     const mw = honoMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
     const headers = new Headers();
-    const c = {
+    const c: HonoLikeContext = {
       req: { raw: new Request("https://test.local/api/x") },
       res: { headers },
     };
     const next = vi.fn(async () => undefined);
-    await mw(c as never, next);
+    await mw(c, next);
     expect(next).toHaveBeenCalledTimes(1);
     expect(headers.get("x-chaos-fault-kind")).toBe("latency");
     expect(headers.get("x-chaos-fault-latency-ms")).toBe("0");
   });
 
-  it("does not stamp latency headers when metadataHeader is off", async () => {
+  it("does not stamp any chaos headers when metadataHeader is off", async () => {
     const mw = honoMiddleware({ latencyRate: 1, latencyMs: 0 });
     const headers = new Headers();
-    const c = {
+    const c: HonoLikeContext = {
       req: { raw: new Request("https://test.local/api/x") },
       res: { headers },
     };
     const next = vi.fn(async () => undefined);
-    await mw(c as never, next);
-    expect(headers.get("x-chaos-fault-kind")).toBeNull();
+    await mw(c, next);
+    // Stronger than checking just one header: the entire Headers object stays
+    // empty so no other fault.* key sneaks through.
+    expect([...headers.entries()]).toHaveLength(0);
   });
 });
 

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -227,6 +227,69 @@ describe("fastifyPlugin", () => {
     await registered!(req, reply);
     expect(reply._code).toBe(0);
   });
+
+  it("stamps metadata headers via reply.header() for latency annotate verdict", async () => {
+    const plugin = fastifyPlugin({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+    let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+    const fastify = {
+      addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+        registered = h;
+      },
+    };
+    await plugin(fastify);
+    const req = { method: "GET", url: "/api/x", headers: { host: "test.local" } };
+    const reply = {
+      _headers: {} as Record<string, string>,
+      code() { return this; },
+      header(k: string, v: string) { this._headers[k] = v; return this; },
+      send() { return undefined; },
+    };
+    await registered!(req, reply);
+    expect(reply._headers["x-chaos-fault-kind"]).toBe("latency");
+  });
+
+  it("does not stamp any chaos headers when metadataHeader is off", async () => {
+    const plugin = fastifyPlugin({ latencyRate: 1, latencyMs: 0 });
+    let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+    const fastify = {
+      addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+        registered = h;
+      },
+    };
+    await plugin(fastify);
+    const req = { method: "GET", url: "/api/x", headers: {} };
+    const reply = {
+      _headers: {} as Record<string, string>,
+      code() { return this; },
+      header(k: string, v: string) { this._headers[k] = v; return this; },
+      send() { return undefined; },
+    };
+    await registered!(req, reply);
+    expect(Object.keys(reply._headers).length).toBe(0);
+  });
+
+  it("attaches metadata headers to synthetic 5xx reply", async () => {
+    const plugin = fastifyPlugin({ status5xxRate: 1, metadataHeader: true });
+    let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+    const fastify = {
+      addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+        registered = h;
+      },
+    };
+    await plugin(fastify);
+    const req = { method: "GET", url: "/api/x", headers: { host: "test.local" } };
+    const reply = {
+      _code: 0,
+      _headers: {} as Record<string, string>,
+      _body: undefined as unknown,
+      code(c: number) { this._code = c; return this; },
+      header(k: string, v: string) { this._headers[k] = v; return this; },
+      send(body: unknown) { this._body = body; return body; },
+    };
+    await registered!(req, reply);
+    expect(reply._code).toBe(503);
+    expect(reply._headers["x-chaos-fault-kind"]).toBe("5xx");
+  });
 });
 
 describe("koaMiddleware", () => {

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -30,6 +30,41 @@ describe("honoMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(out).toBeUndefined();
   });
+
+  it("returns synthetic 5xx response unchanged (headers already attached)", async () => {
+    const mw = honoMiddleware({ status5xxRate: 1, metadataHeader: true });
+    const next = vi.fn();
+    const c = { req: { raw: new Request("https://test.local/api/x") } };
+    const out = await mw(c, next);
+    expect((out as Response).status).toBe(503);
+    expect((out as Response).headers.get("x-chaos-fault-kind")).toBe("5xx");
+  });
+
+  it("calls next() and stamps headers on c.res for latency annotate verdict", async () => {
+    const mw = honoMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+    const headers = new Headers();
+    const c = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: { headers },
+    };
+    const next = vi.fn(async () => undefined);
+    await mw(c as never, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(headers.get("x-chaos-fault-kind")).toBe("latency");
+    expect(headers.get("x-chaos-fault-latency-ms")).toBe("0");
+  });
+
+  it("does not stamp latency headers when metadataHeader is off", async () => {
+    const mw = honoMiddleware({ latencyRate: 1, latencyMs: 0 });
+    const headers = new Headers();
+    const c = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: { headers },
+    };
+    const next = vi.fn(async () => undefined);
+    await mw(c as never, next);
+    expect(headers.get("x-chaos-fault-kind")).toBeNull();
+  });
 });
 
 describe("expressMiddleware", () => {

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -324,4 +324,54 @@ describe("koaMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(ctx.status).toBe(0);
   });
+
+  it("stamps metadata headers via ctx.set() for latency annotate verdict", async () => {
+    const mw = koaMiddleware({ latencyRate: 1, latencyMs: 0, metadataHeader: true });
+    const next = vi.fn(async () => undefined);
+    const ctx = {
+      req: { method: "GET", url: "/api/x", headers: { host: "test.local" } },
+      status: 0,
+      body: undefined as unknown,
+      _headers: {} as Record<string, string>,
+      set(k: string, v: string) {
+        this._headers[k] = v;
+      },
+    };
+    await mw(ctx, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx._headers["x-chaos-fault-kind"]).toBe("latency");
+  });
+
+  it("does not stamp any chaos headers when metadataHeader is off", async () => {
+    const mw = koaMiddleware({ latencyRate: 1, latencyMs: 0 });
+    const next = vi.fn(async () => undefined);
+    const ctx = {
+      req: { method: "GET", url: "/api/x", headers: {} },
+      status: 0,
+      body: undefined as unknown,
+      _headers: {} as Record<string, string>,
+      set(k: string, v: string) {
+        this._headers[k] = v;
+      },
+    };
+    await mw(ctx, next);
+    expect(Object.keys(ctx._headers).length).toBe(0);
+  });
+
+  it("attaches metadata headers to synthetic 5xx ctx", async () => {
+    const mw = koaMiddleware({ status5xxRate: 1, metadataHeader: true });
+    const next = vi.fn();
+    const ctx = {
+      req: { method: "GET", url: "/api/x", headers: { host: "test.local" } },
+      status: 0,
+      body: undefined as unknown,
+      _headers: {} as Record<string, string>,
+      set(k: string, v: string) {
+        this._headers[k] = v;
+      },
+    };
+    await mw(ctx, next);
+    expect(ctx.status).toBe(503);
+    expect(ctx._headers["x-chaos-fault-kind"]).toBe("5xx");
+  });
 });

--- a/packages/server-faults/src/adapters/express.ts
+++ b/packages/server-faults/src/adapters/express.ts
@@ -8,7 +8,12 @@
  * which we always have, so we never need to read the request body.
  */
 
-import { serverFaults, type ServerFaultConfig } from "../server-faults.js";
+import {
+  attrsToHeaderEntries,
+  resolveMetadataPrefix,
+  serverFaults,
+  type ServerFaultConfig,
+} from "../server-faults.js";
 
 // Loosely-typed Express surface to keep server-faults zero-dep.
 interface ExpressLikeRequest {
@@ -46,16 +51,40 @@ export function expressMiddleware(
   cfg: ServerFaultConfig,
 ): (req: ExpressLikeRequest, res: ExpressLikeResponse, next: ExpressLikeNext) => Promise<void> {
   const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async (req, res, next) => {
     try {
-      const response = await fault.maybeInject(toWebRequest(req));
-      if (!response) return next();
-      res.status(response.status);
-      response.headers.forEach((value, key) => {
-        if (key.toLowerCase() === "content-type") return; // res.json sets this
-        res.setHeader(key, value);
-      });
-      res.json(await response.json());
+      const verdict = await fault.maybeInject(toWebRequest(req));
+      if (!verdict) {
+        next();
+        return;
+      }
+      if (verdict.kind === "synthetic") {
+        res.status(verdict.response.status);
+        verdict.response.headers.forEach((value, key) => {
+          if (key.toLowerCase() === "content-type") return; // res.json sets this
+          res.setHeader(key, value);
+        });
+        res.json(await verdict.response.json());
+        return;
+      }
+      if (verdict.kind === "annotate") {
+        // Stamp headers BEFORE calling next() — Express buffers headers on the
+        // response object until the handler responds. Stamping after `next()`
+        // would race the handler's own `res.send` / `res.json`. If a downstream
+        // layer hands back a `Response` with frozen headers (some custom
+        // bridges do this), `res.setHeader(...)` will throw — that is the
+        // documented contract.
+        if (metadataPrefix) {
+          for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+            res.setHeader(name, value);
+          }
+        }
+        next();
+        return;
+      }
+      const _exhaustive: never = verdict;
+      void _exhaustive;
     } catch (err) {
       next(err);
     }

--- a/packages/server-faults/src/adapters/fastify.ts
+++ b/packages/server-faults/src/adapters/fastify.ts
@@ -6,7 +6,12 @@
  * synthetic 5xx (or sleep for latency) and let normal flow continue.
  */
 
-import { serverFaults, type ServerFaultConfig } from "../server-faults.js";
+import {
+  attrsToHeaderEntries,
+  resolveMetadataPrefix,
+  serverFaults,
+  type ServerFaultConfig,
+} from "../server-faults.js";
 
 interface FastifyLikeRequest {
   method: string;
@@ -45,15 +50,33 @@ function toWebRequest(req: FastifyLikeRequest): Request {
 
 export function fastifyPlugin(cfg: ServerFaultConfig) {
   const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async function plugin(fastify: FastifyLikeInstance) {
     fastify.addHook("onRequest", async (req, reply) => {
-      const response = await fault.maybeInject(toWebRequest(req));
-      if (!response) return;
-      reply.code(response.status);
-      response.headers.forEach((value, key) => {
-        reply.header(key, value);
-      });
-      await reply.send(await response.json());
+      const verdict = await fault.maybeInject(toWebRequest(req));
+      if (!verdict) return;
+      if (verdict.kind === "synthetic") {
+        reply.code(verdict.response.status);
+        verdict.response.headers.forEach((value, key) => {
+          reply.header(key, value);
+        });
+        await reply.send(await verdict.response.json());
+        return;
+      }
+      if (verdict.kind === "annotate") {
+        // Stamp headers; the real route runs after this hook returns. If a
+        // downstream handler later returns a Response with frozen headers,
+        // any subsequent `reply.header(...)` would throw — that is the
+        // documented contract.
+        if (metadataPrefix) {
+          for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+            reply.header(name, value);
+          }
+        }
+        return;
+      }
+      const _exhaustive: never = verdict;
+      void _exhaustive;
     });
   };
 }

--- a/packages/server-faults/src/adapters/hono.ts
+++ b/packages/server-faults/src/adapters/hono.ts
@@ -5,17 +5,23 @@
  * wrapper around `serverFaults({...}).maybeInject(req)`. The latency
  * (annotate) path requires running the real handler first and then
  * stamping the metadata headers onto `c.res.headers` afterwards.
+ *
+ * No `import "hono"` on purpose — server-faults stays zero-dep and
+ * consumers compile against their own Hono version.
  */
 
 import {
-  serverFaults,
   attrsToHeaderEntries,
   resolveMetadataPrefix,
+  serverFaults,
   type ServerFaultConfig,
 } from "../server-faults.js";
 
-interface HonoLikeContext {
+export interface HonoLikeContext {
   req: { raw: Request };
+  // c.res is always populated in real Hono (lazy getter that synthesizes a
+  // Response if none was set). The optional marker here is for structurally-
+  // typed test mocks that omit it on the no-fault path.
   res?: { headers: Headers };
 }
 interface HonoLikeNext {
@@ -28,14 +34,25 @@ export function honoMiddleware(cfg: ServerFaultConfig): HonoLikeMiddleware {
   const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async (c, next) => {
     const verdict = await fault.maybeInject(c.req.raw);
-    if (!verdict) return next().then(() => undefined);
-    if (verdict.kind === "synthetic") return verdict.response;
-    // annotate: real handler runs, then stamp headers if requested.
-    await next();
-    if (metadataPrefix && c.res?.headers) {
-      for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
-        c.res.headers.set(name, value);
-      }
+    if (!verdict) {
+      await next();
+      return;
     }
+    if (verdict.kind === "synthetic") return verdict.response;
+    if (verdict.kind === "annotate") {
+      // Real handler runs, then stamp headers. Mutating `c.res.headers` after
+      // the handler returns relies on Hono's live `Headers` object — if a
+      // handler returns a Response built with frozen headers, this `.set()`
+      // throws loudly. That is the documented contract.
+      await next();
+      if (metadataPrefix && c.res?.headers) {
+        for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+          c.res.headers.set(name, value);
+        }
+      }
+      return;
+    }
+    const _exhaustive: never = verdict;
+    void _exhaustive;
   };
 }

--- a/packages/server-faults/src/adapters/hono.ts
+++ b/packages/server-faults/src/adapters/hono.ts
@@ -1,17 +1,22 @@
 /**
  * Hono adapter for @mizchi/server-faults.
  *
- * Hono already exposes `c.req.raw` (a Web Standard Request), so the adapter
- * is a one-liner around `serverFaults({...}).maybeInject(c.req.raw)` plus
- * the customary `next()` plumbing.
+ * `c.req.raw` is a Web Standard Request, so the adapter is mostly a thin
+ * wrapper around `serverFaults({...}).maybeInject(req)`. The latency
+ * (annotate) path requires running the real handler first and then
+ * stamping the metadata headers onto `c.res.headers` afterwards.
  */
 
-import { serverFaults, type ServerFaultConfig } from "../server-faults.js";
+import {
+  serverFaults,
+  attrsToHeaderEntries,
+  resolveMetadataPrefix,
+  type ServerFaultConfig,
+} from "../server-faults.js";
 
-// Loosely-typed Hono surface — we intentionally avoid importing from "hono"
-// so server-faults stays zero-dep. Consumers compile against their own Hono.
 interface HonoLikeContext {
   req: { raw: Request };
+  res?: { headers: Headers };
 }
 interface HonoLikeNext {
   (): Promise<unknown>;
@@ -20,9 +25,17 @@ type HonoLikeMiddleware = (c: HonoLikeContext, next: HonoLikeNext) => Promise<Re
 
 export function honoMiddleware(cfg: ServerFaultConfig): HonoLikeMiddleware {
   const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async (c, next) => {
-    const response = await fault.maybeInject(c.req.raw);
-    if (response) return response;
+    const verdict = await fault.maybeInject(c.req.raw);
+    if (!verdict) return next().then(() => undefined);
+    if (verdict.kind === "synthetic") return verdict.response;
+    // annotate: real handler runs, then stamp headers if requested.
     await next();
+    if (metadataPrefix && c.res?.headers) {
+      for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+        c.res.headers.set(name, value);
+      }
+    }
   };
 }

--- a/packages/server-faults/src/adapters/koa.ts
+++ b/packages/server-faults/src/adapters/koa.ts
@@ -6,7 +6,12 @@
  * response back through `ctx.status` / `ctx.body`.
  */
 
-import { serverFaults, type ServerFaultConfig } from "../server-faults.js";
+import {
+  attrsToHeaderEntries,
+  resolveMetadataPrefix,
+  serverFaults,
+  type ServerFaultConfig,
+} from "../server-faults.js";
 
 interface KoaLikeRequest {
   method?: string;
@@ -42,13 +47,35 @@ export function koaMiddleware(
   cfg: ServerFaultConfig,
 ): (ctx: KoaLikeContext, next: KoaLikeNext) => Promise<void> {
   const fault = serverFaults(cfg);
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async (ctx, next) => {
-    const response = await fault.maybeInject(toWebRequest(ctx.req));
-    if (!response) return next().then(() => undefined);
-    ctx.status = response.status;
-    response.headers.forEach((value, key) => {
-      ctx.set(key, value);
-    });
-    ctx.body = await response.json();
+    const verdict = await fault.maybeInject(toWebRequest(ctx.req));
+    if (!verdict) {
+      await next();
+      return;
+    }
+    if (verdict.kind === "synthetic") {
+      ctx.status = verdict.response.status;
+      verdict.response.headers.forEach((value, key) => {
+        ctx.set(key, value);
+      });
+      ctx.body = await verdict.response.json();
+      return;
+    }
+    if (verdict.kind === "annotate") {
+      // Stamp BEFORE next() — Koa's ctx.set just wraps res.setHeader, which
+      // buffers headers until the response is flushed. A downstream handler
+      // that bypasses ctx (writing to ctx.res directly) would skip these
+      // headers; that is the documented escape hatch.
+      if (metadataPrefix) {
+        for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+          ctx.set(name, value);
+        }
+      }
+      await next();
+      return;
+    }
+    const _exhaustive: never = verdict;
+    void _exhaustive;
   };
 }

--- a/packages/server-faults/src/index.ts
+++ b/packages/server-faults/src/index.ts
@@ -1,5 +1,6 @@
 export {
   serverFaults,
+  toOtelAttrs,
   type FaultAttrs,
   type FaultKind,
   type ServerFaultConfig,

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -13,18 +13,19 @@ describe("serverFaults", () => {
 
   it("always returns a 503 when status5xxRate=1", async () => {
     const fault = serverFaults({ status5xxRate: 1 });
-    const response = await fault.maybeInject(req("/api/x"));
-    expect(response).not.toBeNull();
-    expect(response!.status).toBe(503);
-    const body = await response!.json();
+    const v = await fault.maybeInject(req("/api/x"));
+    expect(v?.kind).toBe("synthetic");
+    const response = (v as { kind: "synthetic"; response: Response }).response;
+    expect(response.status).toBe(503);
+    const body = await response.json();
     expect(body.error).toMatch(/chaos/);
     expect(body.path).toBe("/api/x");
   });
 
   it("honours status5xxCode override", async () => {
     const fault = serverFaults({ status5xxRate: 1, status5xxCode: 500 });
-    const response = await fault.maybeInject(req("/api/x"));
-    expect(response!.status).toBe(500);
+    const v = await fault.maybeInject(req("/api/x"));
+    expect((v as { kind: "synthetic"; response: Response }).response.status).toBe(500);
   });
 
   it("filters by pathPattern (RegExp form)", async () => {
@@ -83,14 +84,14 @@ describe("serverFaults", () => {
       expect(resolved).toBe(false);
       await vi.advanceTimersByTimeAsync(2);
       const result = await promise;
-      expect(result).toBeNull();
+      expect(result?.kind).toBe("annotate");
     });
 
     it("returns null after latency (handler runs after delay)", async () => {
       const fault = serverFaults({ latencyRate: 1, latencyMs: 50 });
       const promise = fault.maybeInject(req("/api/x"));
       await vi.advanceTimersByTimeAsync(50);
-      expect(await promise).toBeNull();
+      expect((await promise)?.kind).toBe("annotate");
     });
   });
 

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { serverFaults, toOtelAttrs } from "./server-faults.js";
+import type { FaultAttrs } from "./server-faults.js";
 
 const req = (path: string) => new Request(`https://test.local${path}`);
 
@@ -359,6 +360,50 @@ describe("serverFaults", () => {
       });
       expect("fault.target_status" in out).toBe(false);
       expect("fault.trace_id" in out).toBe(false);
+    });
+  });
+
+  describe("metadataHeader", () => {
+    const TP = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+    it("attaches all 5xx attrs as kebab-case headers on synthetic responses", async () => {
+      const fault = serverFaults({ status5xxRate: 1, metadataHeader: true });
+      const r = new Request("https://test.local/api/x", { headers: { traceparent: TP } });
+      const v = await fault.maybeInject(r);
+      expect(v?.kind).toBe("synthetic");
+      const resp = (v as { response: Response }).response;
+      expect(resp.headers.get("x-chaos-fault-kind")).toBe("5xx");
+      expect(resp.headers.get("x-chaos-fault-path")).toBe("/api/x");
+      expect(resp.headers.get("x-chaos-fault-method")).toBe("GET");
+      expect(resp.headers.get("x-chaos-fault-target-status")).toBe("503");
+      expect(resp.headers.get("x-chaos-fault-trace-id")).toBe("0af7651916cd43dd8448eb211c80319c");
+      expect(resp.headers.get("x-chaos-fault-latency-ms")).toBeNull();
+    });
+
+    it("does not attach headers when metadataHeader is unset", async () => {
+      const fault = serverFaults({ status5xxRate: 1 });
+      const v = await fault.maybeInject(new Request("https://test.local/api/x"));
+      const resp = (v as { kind: "synthetic"; response: Response }).response;
+      expect(resp.headers.get("x-chaos-fault-kind")).toBeNull();
+    });
+
+    it("honours custom prefix", async () => {
+      const fault = serverFaults({ status5xxRate: 1, metadataHeader: { prefix: "x-my-fault" } });
+      const v = await fault.maybeInject(new Request("https://test.local/api/x"));
+      const resp = (v as { kind: "synthetic"; response: Response }).response;
+      expect(resp.headers.get("x-my-fault-kind")).toBe("5xx");
+      expect(resp.headers.get("x-chaos-fault-kind")).toBeNull();
+    });
+
+    it("returns annotate verdict carrying full attrs for latency (adapter must apply headers)", async () => {
+      const fault = serverFaults({ latencyRate: 1, latencyMs: 1, metadataHeader: true });
+      const r = new Request("https://test.local/api/x", { headers: { traceparent: TP } });
+      const v = await fault.maybeInject(r);
+      expect(v?.kind).toBe("annotate");
+      const attrs = (v as { kind: "annotate"; attrs: FaultAttrs }).attrs;
+      expect(attrs.kind).toBe("latency");
+      expect(attrs.latencyMs).toBe(1);
+      expect(attrs.traceId).toBe("0af7651916cd43dd8448eb211c80319c");
     });
   });
 });

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { serverFaults } from "./server-faults.js";
+import { serverFaults, toOtelAttrs } from "./server-faults.js";
 
 const req = (path: string) => new Request(`https://test.local${path}`);
 
@@ -122,10 +122,10 @@ describe("serverFaults", () => {
     });
     await fault.maybeInject(req("/api/x"));
     expect(onFault).toHaveBeenCalledWith("5xx", {
-      "fault.kind": "5xx",
-      "fault.path": "/api/x",
-      "fault.method": "GET",
-      "fault.target_status": 503,
+      kind: "5xx",
+      path: "/api/x",
+      method: "GET",
+      targetStatus: 503,
     });
   });
 
@@ -138,10 +138,10 @@ describe("serverFaults", () => {
     });
     await fault.maybeInject(req("/api/x"));
     expect(onFault).toHaveBeenCalledWith("latency", {
-      "fault.kind": "latency",
-      "fault.path": "/api/x",
-      "fault.method": "GET",
-      "fault.latency_ms": 1,
+      kind: "latency",
+      path: "/api/x",
+      method: "GET",
+      latencyMs: 1,
     });
   });
 
@@ -153,7 +153,7 @@ describe("serverFaults", () => {
     });
     const r = new Request("https://test.local/api/x", { method: "post" as string });
     await fault.maybeInject(r);
-    expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ "fault.method": "POST" }));
+    expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ method: "POST" }));
   });
 
   describe("bypassHeader", () => {
@@ -282,5 +282,82 @@ describe("serverFaults", () => {
     await fault.maybeInject(req("/api/x"));
     expect(onFault).toHaveBeenCalledTimes(1);
     expect(onFault).toHaveBeenCalledWith("5xx", expect.anything());
+  });
+
+  describe("traceId", () => {
+    const TP = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+    it("populates traceId from a valid traceparent header (5xx)", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
+      await fault.maybeInject(
+        new Request("https://test.local/api/x", { headers: { traceparent: TP } }),
+      );
+      expect(onFault).toHaveBeenCalledWith(
+        "5xx",
+        expect.objectContaining({ traceId: "0af7651916cd43dd8448eb211c80319c" }),
+      );
+    });
+
+    it("populates traceId on latency events too", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({ latencyRate: 1, latencyMs: 1, observer: { onFault } });
+      await fault.maybeInject(
+        new Request("https://test.local/api/x", { headers: { traceparent: TP } }),
+      );
+      expect(onFault).toHaveBeenCalledWith(
+        "latency",
+        expect.objectContaining({ traceId: "0af7651916cd43dd8448eb211c80319c" }),
+      );
+    });
+
+    it("omits traceId when traceparent is absent", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
+      await fault.maybeInject(new Request("https://test.local/api/x"));
+      const attrs = onFault.mock.calls[0][1] as Record<string, unknown>;
+      expect("traceId" in attrs).toBe(false);
+    });
+
+    it("omits traceId when traceparent is malformed", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({ status5xxRate: 1, observer: { onFault } });
+      await fault.maybeInject(
+        new Request("https://test.local/api/x", { headers: { traceparent: "garbage" } }),
+      );
+      const attrs = onFault.mock.calls[0][1] as Record<string, unknown>;
+      expect("traceId" in attrs).toBe(false);
+    });
+  });
+
+  describe("toOtelAttrs", () => {
+    it("maps every populated camelCase key to its OTel dotted equivalent", () => {
+      const out = toOtelAttrs({
+        kind: "5xx",
+        path: "/api/x",
+        method: "GET",
+        targetStatus: 503,
+        traceId: "0af7651916cd43dd8448eb211c80319c",
+      });
+      expect(out).toEqual({
+        "fault.kind": "5xx",
+        "fault.path": "/api/x",
+        "fault.method": "GET",
+        "fault.target_status": 503,
+        "fault.trace_id": "0af7651916cd43dd8448eb211c80319c",
+      });
+    });
+
+    it("omits keys that are undefined", () => {
+      const out = toOtelAttrs({ kind: "latency", path: "/x", method: "GET", latencyMs: 50 });
+      expect(out).toEqual({
+        "fault.kind": "latency",
+        "fault.path": "/x",
+        "fault.method": "GET",
+        "fault.latency_ms": 50,
+      });
+      expect("fault.target_status" in out).toBe(false);
+      expect("fault.trace_id" in out).toBe(false);
+    });
   });
 });

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -34,6 +34,21 @@ export interface FaultAttrs {
   traceId?: string;
 }
 
+/**
+ * Outcome of a fault raffle.
+ *
+ * - `synthetic`: a fault response was minted; the adapter must short-circuit
+ *   the real handler and return `response`.
+ * - `annotate`: no synthetic response, but the request was perturbed (e.g.
+ *   latency was injected). The adapter should run the real handler and
+ *   surface `attrs` (as response headers, span attributes, etc.).
+ * - `null`: bypass / exempt / no raffle won — pass through unchanged.
+ */
+export type FaultVerdict =
+  | { kind: "synthetic"; response: Response; attrs: FaultAttrs }
+  | { kind: "annotate"; attrs: FaultAttrs }
+  | null;
+
 export interface ServerFaultObserver {
   onFault?: (kind: FaultKind, attrs: FaultAttrs) => void;
 }
@@ -68,7 +83,7 @@ export interface ServerFaultConfig {
 }
 
 export interface ServerFaultHandle {
-  maybeInject: (req: Request) => Promise<Response | null>;
+  maybeInject: (req: Request) => Promise<FaultVerdict>;
 }
 
 interface SeededRng {
@@ -132,7 +147,7 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
   const rng: SeededRng = cfg.seed !== undefined ? mulberry32(cfg.seed) : { next: () => Math.random() };
 
   return {
-    async maybeInject(req: Request): Promise<Response | null> {
+    async maybeInject(req: Request): Promise<FaultVerdict> {
       if (bypassHeader && req.headers.has(bypassHeader)) return null;
 
       const url = new URL(req.url);
@@ -152,10 +167,11 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         };
         if (traceId !== undefined) attrs5xx.traceId = traceId;
         cfg.observer?.onFault?.("5xx", attrs5xx);
-        return Response.json(
+        const response = Response.json(
           { error: "chaos: synthetic 5xx", path: url.pathname, status },
           { status },
         );
+        return { kind: "synthetic", response, attrs: attrs5xx };
       }
 
       const rL = cfg.latencyRate ?? 0;
@@ -170,6 +186,7 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         if (traceId !== undefined) attrsLat.traceId = traceId;
         cfg.observer?.onFault?.("latency", attrsLat);
         await sleep(ms);
+        return { kind: "annotate", attrs: attrsLat };
       }
       return null;
     },

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -80,6 +80,17 @@ export interface ServerFaultConfig {
   /** Optional. When set, fault selection (which raffles win) is reproducible across runs. */
   seed?: number;
   observer?: ServerFaultObserver;
+  /**
+   * When set, server-faults mirrors `FaultAttrs` onto response headers so
+   * out-of-process consumers (e.g. chaosbringer's `chaos()` crawler) can
+   * observe server-side faults without sharing memory with the server.
+   *
+   * Header naming: `{prefix}-{kebab(key)}` where `key` is a TS attrs
+   * property name and `kebab` lower-cases the camelCase boundary
+   * (e.g. `targetStatus` → `{prefix}-target-status`). `true` uses
+   * the default prefix `"x-chaos-fault"`.
+   */
+  metadataHeader?: boolean | { prefix?: string };
 }
 
 export interface ServerFaultHandle {
@@ -138,11 +149,45 @@ function extractTraceId(req: Request): string | undefined {
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+const DEFAULT_METADATA_PREFIX = "x-chaos-fault";
+
+/**
+ * Materialise a `FaultAttrs` value as a list of HTTP-header pairs.
+ *
+ * camelCase keys are lowered into kebab-case (`targetStatus` →
+ * `target-status`) and then prefixed. Undefined optional values are
+ * dropped. Exposed so framework adapters can apply the same headers
+ * to the `annotate` verdict path (where the real handler's response
+ * is what actually reaches the wire).
+ */
+export function attrsToHeaderEntries(attrs: FaultAttrs, prefix: string): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v === undefined) continue;
+    // camelCase → kebab-case (e.g. `targetStatus` → `target-status`).
+    const tail = k.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+    out.push([`${prefix}-${tail}`, String(v)]);
+  }
+  return out;
+}
+
+/**
+ * Resolve `metadataHeader` config to a concrete prefix string, or `null`
+ * if disabled. Exposed for adapters that handle the `annotate` branch.
+ */
+export function resolveMetadataPrefix(opt: ServerFaultConfig["metadataHeader"]): string | null {
+  if (!opt) return null;
+  if (opt === true) return DEFAULT_METADATA_PREFIX;
+  return opt.prefix ?? DEFAULT_METADATA_PREFIX;
+}
+
 export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
   const pattern = compileStatelessPattern(cfg.pathPattern);
   const exemptPattern = compileStatelessPattern(cfg.exemptPathPattern);
 
   const bypassHeader = cfg.bypassHeader?.toLowerCase();
+
+  const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
 
   const rng: SeededRng = cfg.seed !== undefined ? mulberry32(cfg.seed) : { next: () => Math.random() };
 
@@ -171,9 +216,15 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         // the other's view.
         Object.freeze(attrs5xx);
         cfg.observer?.onFault?.("5xx", attrs5xx);
+        const headers = new Headers();
+        if (metadataPrefix) {
+          for (const [name, value] of attrsToHeaderEntries(attrs5xx, metadataPrefix)) {
+            headers.set(name, value);
+          }
+        }
         const response = Response.json(
           { error: "chaos: synthetic 5xx", path: url.pathname, status },
-          { status },
+          { status, headers },
         );
         return { kind: "synthetic", response, attrs: attrs5xx };
       }

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -166,6 +166,10 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
           targetStatus: status,
         };
         if (traceId !== undefined) attrs5xx.traceId = traceId;
+        // Frozen because the same reference is handed to observer.onFault and
+        // returned in the verdict; either consumer mutating it would corrupt
+        // the other's view.
+        Object.freeze(attrs5xx);
         cfg.observer?.onFault?.("5xx", attrs5xx);
         const response = Response.json(
           { error: "chaos: synthetic 5xx", path: url.pathname, status },
@@ -184,6 +188,7 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
           latencyMs: ms,
         };
         if (traceId !== undefined) attrsLat.traceId = traceId;
+        Object.freeze(attrsLat);
         cfg.observer?.onFault?.("latency", attrsLat);
         await sleep(ms);
         return { kind: "annotate", attrs: attrsLat };

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -152,21 +152,44 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 const DEFAULT_METADATA_PREFIX = "x-chaos-fault";
 
 /**
+ * Header-name suffixes for each `FaultAttrs` key.
+ *
+ * `Record<keyof FaultAttrs, string>` forces every new key on `FaultAttrs`
+ * to be added here at type-check time. A naive camelCase→kebab regex
+ * silently mangles consecutive caps (`traceID` → `trace-i-d`) and leading
+ * caps; a hand-written map dodges both and keeps the wire format stable
+ * even if a contributor adds a key without thinking about encoding.
+ */
+const FAULT_HEADER_KEY_SUFFIX: Record<keyof FaultAttrs, string> = {
+  kind: "kind",
+  path: "path",
+  method: "method",
+  targetStatus: "target-status",
+  latencyMs: "latency-ms",
+  traceId: "trace-id",
+};
+
+// NOTE: attrsToHeaderEntries and resolveMetadataPrefix are exported for the
+// in-package framework adapters (hono / express / fastify / koa) to reuse the
+// canonical header encoding on the annotate path. They are intentionally NOT
+// re-exported from `index.ts` and carry no stability guarantee for external
+// consumers — deep-importing them is unsupported.
+
+/**
  * Materialise a `FaultAttrs` value as a list of HTTP-header pairs.
  *
- * camelCase keys are lowered into kebab-case (`targetStatus` →
- * `target-status`) and then prefixed. Undefined optional values are
- * dropped. Exposed so framework adapters can apply the same headers
- * to the `annotate` verdict path (where the real handler's response
- * is what actually reaches the wire).
+ * Keys are translated through `FAULT_HEADER_KEY_SUFFIX` (camelCase →
+ * kebab-case), then prefixed. Undefined optional values are dropped.
+ * Used by both the synthetic-response path here and by adapters on the
+ * annotate verdict path so the wire format stays identical across
+ * fault kinds.
  */
 export function attrsToHeaderEntries(attrs: FaultAttrs, prefix: string): Array<[string, string]> {
   const out: Array<[string, string]> = [];
-  for (const [k, v] of Object.entries(attrs)) {
+  for (const k of Object.keys(FAULT_HEADER_KEY_SUFFIX) as Array<keyof FaultAttrs>) {
+    const v = attrs[k];
     if (v === undefined) continue;
-    // camelCase → kebab-case (e.g. `targetStatus` → `target-status`).
-    const tail = k.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
-    out.push([`${prefix}-${tail}`, String(v)]);
+    out.push([`${prefix}-${FAULT_HEADER_KEY_SUFFIX[k]}`, String(v)]);
   }
   return out;
 }

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -181,15 +181,26 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
  * (`fault.kind`, `fault.target_status`, …) for consumers that pipe
  * fault events directly into an OTel exporter. Undefined optional
  * keys are dropped so the output is tight.
+ *
+ * The `Record<keyof FaultAttrs, string>` constraint forces every new
+ * `FaultAttrs` key to be added to the map at type-check time — adding
+ * a field to the interface without updating the map produces a
+ * compile error, so the translator never silently omits new attrs.
  */
+const FAULT_KEY_MAP: Record<keyof FaultAttrs, string> = {
+  kind: "fault.kind",
+  path: "fault.path",
+  method: "fault.method",
+  targetStatus: "fault.target_status",
+  latencyMs: "fault.latency_ms",
+  traceId: "fault.trace_id",
+};
+
 export function toOtelAttrs(a: FaultAttrs): Record<string, string | number> {
-  const out: Record<string, string | number> = {
-    "fault.kind": a.kind,
-    "fault.path": a.path,
-    "fault.method": a.method,
-  };
-  if (a.targetStatus !== undefined) out["fault.target_status"] = a.targetStatus;
-  if (a.latencyMs !== undefined) out["fault.latency_ms"] = a.latencyMs;
-  if (a.traceId !== undefined) out["fault.trace_id"] = a.traceId;
+  const out: Record<string, string | number> = {};
+  for (const k of Object.keys(FAULT_KEY_MAP) as Array<keyof FaultAttrs>) {
+    const v = a[k];
+    if (v !== undefined) out[FAULT_KEY_MAP[k]] = v;
+  }
   return out;
 }

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -25,16 +25,13 @@ export type FaultKind = "5xx" | "latency";
  * renames are not.
  */
 export interface FaultAttrs {
-  /** Mirror of the kind argument; included so an attrs object is self-describing if it ever travels without context. */
-  "fault.kind": FaultKind;
-  /** URL pathname (no host, no query). */
-  "fault.path": string;
-  /** Uppercase HTTP method. */
-  "fault.method": string;
-  /** Set when `fault.kind === "5xx"`. The synthetic HTTP status that was returned. */
-  "fault.target_status"?: number;
-  /** Set when `fault.kind === "latency"`. Milliseconds actually slept. */
-  "fault.latency_ms"?: number;
+  kind: FaultKind;
+  path: string;
+  method: string;
+  targetStatus?: number;
+  latencyMs?: number;
+  /** Trace-id from incoming traceparent (W3C Trace Context). 32 lowercase hex. */
+  traceId?: string;
 }
 
 export interface ServerFaultObserver {
@@ -115,6 +112,15 @@ function compileStatelessPattern(p: RegExp | string | undefined): RegExp | null 
   return new RegExp(p.source, p.flags.replace(/[gy]/g, ""));
 }
 
+const TRACEPARENT_RE = /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/;
+
+function extractTraceId(req: Request): string | undefined {
+  const tp = req.headers.get("traceparent");
+  if (!tp) return undefined;
+  const m = TRACEPARENT_RE.exec(tp);
+  return m ? m[1] : undefined;
+}
+
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
@@ -134,15 +140,18 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
       if (pattern && !pattern.test(url.pathname)) return null;
 
       const method = req.method.toUpperCase();
+      const traceId = extractTraceId(req);
       const r5 = cfg.status5xxRate ?? 0;
       if (r5 > 0 && rng.next() < r5) {
         const status = cfg.status5xxCode ?? 503;
-        cfg.observer?.onFault?.("5xx", {
-          "fault.kind": "5xx",
-          "fault.path": url.pathname,
-          "fault.method": method,
-          "fault.target_status": status,
-        });
+        const attrs5xx: FaultAttrs = {
+          kind: "5xx",
+          path: url.pathname,
+          method,
+          targetStatus: status,
+        };
+        if (traceId !== undefined) attrs5xx.traceId = traceId;
+        cfg.observer?.onFault?.("5xx", attrs5xx);
         return Response.json(
           { error: "chaos: synthetic 5xx", path: url.pathname, status },
           { status },
@@ -152,15 +161,35 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
       const rL = cfg.latencyRate ?? 0;
       if (rL > 0 && rng.next() < rL) {
         const ms = pickLatencyMs(cfg.latencyMs);
-        cfg.observer?.onFault?.("latency", {
-          "fault.kind": "latency",
-          "fault.path": url.pathname,
-          "fault.method": method,
-          "fault.latency_ms": ms,
-        });
+        const attrsLat: FaultAttrs = {
+          kind: "latency",
+          path: url.pathname,
+          method,
+          latencyMs: ms,
+        };
+        if (traceId !== undefined) attrsLat.traceId = traceId;
+        cfg.observer?.onFault?.("latency", attrsLat);
         await sleep(ms);
       }
       return null;
     },
   };
+}
+
+/**
+ * Map a flat `FaultAttrs` to the OTel-style dotted attribute schema
+ * (`fault.kind`, `fault.target_status`, …) for consumers that pipe
+ * fault events directly into an OTel exporter. Undefined optional
+ * keys are dropped so the output is tight.
+ */
+export function toOtelAttrs(a: FaultAttrs): Record<string, string | number> {
+  const out: Record<string, string | number> = {
+    "fault.kind": a.kind,
+    "fault.path": a.path,
+    "fault.method": a.method,
+  };
+  if (a.targetStatus !== undefined) out["fault.target_status"] = a.targetStatus;
+  if (a.latencyMs !== undefined) out["fault.latency_ms"] = a.latencyMs;
+  if (a.traceId !== undefined) out["fault.trace_id"] = a.traceId;
+  return out;
 }


### PR DESCRIPTION
## Summary
- `FaultAttrs` is now flat camelCase (`kind`, `path`, `method`, `targetStatus`, `latencyMs`, `traceId`); a new `toOtelAttrs(attrs)` translator emits the OTel-style dotted form (`fault.kind`, `fault.target_status`, …) for downstream exporters. **Breaking** rename of PR #69's landed schema.
- `traceId` extracted from incoming W3C `traceparent` header (32 lowercase hex). Carried on both 5xx and latency observer events.
- `maybeInject` now returns `FaultVerdict = { kind: "synthetic"; response; attrs } | { kind: "annotate"; attrs } | null`. The latency path returns ` annotate` so adapters can stamp metadata headers on the real response. **Breaking**.
- `metadataHeader` option mirrors fault attrs onto kebab-case response headers (`x-chaos-fault-*` by default, configurable prefix). Header key encoding is table-driven (`Record<keyof FaultAttrs, string>`) so future schema additions force a compile-time update.
- All four adapters (hono / express / fastify / koa) updated for the new verdict + header stamping with exhaustive verdict narrowing and a frozen-headers contract comment.
- `attrs` objects are `Object.freeze`d before being handed to observers / returned in verdicts to prevent aliasing mutation.

Spec: [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`](https://github.com/mizchi/chaosbringer/blob/feat/server-faults-metadata-header/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md)

Closes part of #56 (server-faults side). Chaosbringer integration follows in a separate PR.

## Migration notes (PR #69 → this PR)
| Before | After |
| --- | --- |
| `attrs["fault.kind"]` | `attrs.kind` |
| `attrs["fault.path"]` | `attrs.path` |
| `attrs["fault.method"]` | `attrs.method` |
| `attrs["fault.target_status"]` | `attrs.targetStatus` |
| `attrs["fault.latency_ms"]` | `attrs.latencyMs` |
| (new) | `attrs.traceId` |
| `await maybeInject(req)` returns \`Response \| null\` | returns \`FaultVerdict\` |

Consumers wiring observer events directly into OTel: replace your hand-built attribute object with `toOtelAttrs(attrs)`.

## Test plan
- [x] \`pnpm --filter @mizchi/server-faults test\` — 55/55 green (34 core + 21 adapter)
- [x] \`pnpm --filter @mizchi/server-faults build\` — tsc clean
- [ ] otel-chaos-lab adoption + chaosbringer integration are the live end-to-end verification (separate PR)