### PR TITLE
docs: root README rewrite + seeding-data + server-side-correlation recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,79 @@
-# chaosbringer monorepo
+# chaosbringer
 
-This repository hosts `chaosbringer` plus future Layer-1 packages extracted from it.
+Chaos testing toolkit for web apps. A Playwright-based crawler injects faults at every layer a browser test can reach — network, page lifecycle, JS runtime — and a sibling `@mizchi/server-faults` covers the layer the browser cannot reach: inside the server process. Same `traceparent`, one report.
+
+## Where each package fits
+
+`chaosbringer` only injects faults that a **browser-driven** test can reach. Server-internal failure modes need a sibling library. Pick the layer before reaching for a fault provider:
+
+| Layer | Library | What it touches | When to use |
+|---|---|---|---|
+| **Application state** | `chaos({ setup })` hook | Backend rows, storage state, fixtures (via Playwright `page.request`) | "Crawler needs N todos to navigate" |
+| **Network** | [`chaosbringer`](packages/chaosbringer) `faults.*` | HTTP between browser and server (Playwright `route()`) | "What does the UI do when `/api/x` is 500 / slow / aborted" |
+| **Page lifecycle / runtime** | [`chaosbringer`](packages/chaosbringer) `lifecycleFaults` / `runtimeFaults` | Browser DOM, storage wipe, CPU throttle, `fetch` / clock monkey-patches | "Does the SPA recover when localStorage gets wiped mid-action" |
+| **Server-side** | [`@mizchi/server-faults`](packages/server-faults) | Inside the server process, before the handler runs | "Do the server's OTel traces / metrics show the fault, and does the handler degrade gracefully" |
+| **Cloudflare bindings** | [`@mizchi/cf-faults`](packages/cf-faults) | KV / Service Binding wrappers | "How does the Worker behave when its KV throws" |
+
+**Common confusion:** `faults.status(500, …)` from chaosbringer **does not produce server-side telemetry** — the route is intercepted in the browser, the server is never called. To see a fault inside the server's OTel trace, mount `@mizchi/server-faults` *and* run both layers together. See [`docs/recipes/server-side-correlation.md`](docs/recipes/server-side-correlation.md).
 
 ## Packages
 
-- [`chaosbringer`](packages/chaosbringer) — Playwright-based chaos testing CLI + library
-- [`@mizchi/playwright-faults`](packages/playwright-faults) — Playwright fault-injection primitives (network route, page lifecycle, JS runtime monkey-patch)
-- [`@mizchi/playwright-v8-coverage`](packages/playwright-v8-coverage) — V8 precise-coverage collector for Playwright (CDP `Profiler.takePreciseCoverage`) with novelty-scoring helpers
-- [`@mizchi/server-faults`](packages/server-faults) — framework-agnostic server-side fault injection (5xx + latency) for Web Standard Request / Response
+| Package | What it is |
+|---|---|
+| [`chaosbringer`](packages/chaosbringer) | Playwright-based chaos crawler — CLI + library |
+| [`@mizchi/server-faults`](packages/server-faults) | Framework-agnostic server-side fault injection (5xx + latency) for Web Standard `Request`/`Response`. Adapters for hono / express / fastify / koa. |
+| [`@mizchi/playwright-faults`](packages/playwright-faults) | Playwright fault-injection primitives (network route, page lifecycle, JS runtime monkey-patch) — extracted from chaosbringer for direct Playwright Test use |
+| [`@mizchi/playwright-v8-coverage`](packages/playwright-v8-coverage) | V8 precise-coverage collector for Playwright (CDP `Profiler.takePreciseCoverage`) with novelty-scoring helpers |
+| [`@mizchi/cf-faults`](packages/cf-faults) | Cloudflare Worker binding wrappers (KV / Service Binding) for chaos injection |
+
+## 30-second tour
+
+```bash
+pnpm add chaosbringer playwright @playwright/test
+npx playwright install chromium
+
+# crawl localhost, exit 0/1 on errors, print a Repro: line you can paste into CI
+chaosbringer --url http://localhost:3000 --max-pages 20 --strict
+```
+
+```ts
+// or programmatically — fault injection + invariants in 15 lines
+import { chaos, faults } from "chaosbringer";
+
+const { passed, report } = await chaos({
+  baseUrl: "http://localhost:3000",
+  seed: 42,
+  faultInjection: [
+    faults.status(500, { urlPattern: /\/api\//, probability: 0.3 }),
+    faults.delay(2000, { urlPattern: /\/api\//, probability: 0.1 }),
+  ],
+  invariants: [
+    { name: "has-h1", when: "afterLoad", check: async ({ page }) =>
+        (await page.locator("h1").count()) > 0 || "missing <h1>" },
+  ],
+});
+
+console.log(report.reproCommand); // chaosbringer --url … --seed 42 …
+process.exit(passed ? 0 : 1);
+```
+
+The full feature list, CLI reference, and report-shape walkthrough live in [`packages/chaosbringer/README.md`](packages/chaosbringer/README.md).
+
+## Recipes
+
+Common patterns extracted from real consumer code (rather than rediscovered every time):
+
+- [`docs/recipes/seeding-data.md`](docs/recipes/seeding-data.md) — How to seed backend state before a chaos run, including the gotcha where seed `POST`s get eaten by the chaos middleware itself.
+- [`docs/recipes/server-side-correlation.md`](docs/recipes/server-side-correlation.md) — Wire chaosbringer + `@mizchi/server-faults` so server-side fault events join chaosbringer's report by W3C `traceparent`.
+
+More recipes (auth via storageState, SPA-routing tips, Playwright Test integration, CI on GitHub Actions) live inline in `packages/chaosbringer/README.md` until split out.
+
+## Internal design docs
+
+- `docs/superpowers/specs/` — design specs for non-trivial features (kept under version control so the *why* survives the *what*).
+- `docs/superpowers/plans/` — implementation plans corresponding to specs.
+
+These are internal; users do not need to read them. They exist to keep design rationale next to the code.
 
 ## Development
 
@@ -24,10 +90,18 @@ pnpm -F chaosbringer test
 ```
 chaosbringer/
 ├── packages/
-│   └── chaosbringer/      # the npm `chaosbringer` package
-│       ├── flaker.toml    # package-local @mizchi/flaker config
-│       └── .flaker/       # storage (gitignored, persisted across CI runs via actions/cache)
-├── docs/                  # repo-wide design notes (see docs/superpowers/specs/)
-├── package.json           # workspace catalog (private, not published)
+│   ├── chaosbringer/             # the npm `chaosbringer` package
+│   ├── server-faults/            # `@mizchi/server-faults`
+│   ├── playwright-faults/        # `@mizchi/playwright-faults`
+│   ├── playwright-v8-coverage/   # `@mizchi/playwright-v8-coverage`
+│   └── cf-faults/                # `@mizchi/cf-faults`
+├── docs/
+│   ├── recipes/                  # task-oriented user docs
+│   └── superpowers/              # design specs + plans (internal)
+├── package.json                  # workspace root (private, not published)
 └── pnpm-workspace.yaml
 ```
+
+## License
+
+MIT

--- a/docs/recipes/seeding-data.md
+++ b/docs/recipes/seeding-data.md
@@ -1,0 +1,159 @@
+# Seeding backend state before a chaos run
+
+A chaos run that lands on an empty app discovers nothing — no list rows to click, no detail pages to navigate into, no forms with valid IDs. The crawler will exit clean while exercising 10% of the actual UI. You need seed data before the run starts.
+
+This recipe covers two patterns and one gotcha.
+
+## When you need this
+
+- The crawler sees `<h1>No items yet</h1>` instead of a populated list.
+- All your "interesting" pages are detail pages keyed by IDs that don't exist yet.
+- Your invariants assume some baseline state ("the dashboard always shows ≥1 chart").
+
+## Pattern A — `chaos({ setup })` hook
+
+`chaosbringer` exposes a `setup` hook that fires **after** the crawler is constructed (so it sees option-validation errors first) but **before** any chaos action runs:
+
+```ts
+import { chaos, faults } from "chaosbringer";
+
+await chaos({
+  baseUrl: "http://localhost:8787",
+  seed: 42,
+  faultInjection: [
+    faults.status(500, { urlPattern: /\/api\/todos$/, probability: 0.3 }),
+  ],
+  setup: async ({ page, baseUrl }) => {
+    // page is a one-shot Playwright page in a disposable browser context.
+    // It is closed before the crawler starts — its state does NOT carry
+    // into the crawl. Mutate the server (REST), or save storageState to
+    // disk and feed it to `options.storageState`.
+    for (let i = 0; i < 5; i++) {
+      const r = await page.request.post(`${baseUrl}/api/todos`, {
+        data: { title: `seed-${i}` },
+      });
+      if (!r.ok()) throw new Error(`seed POST failed: ${r.status()}`);
+    }
+  },
+});
+```
+
+The hook receives a fresh disposable Playwright context. Its `page.request` is a Web-standard request client (no browser navigation happens), so REST seeding is one line per row.
+
+## Pattern B — out-of-process seeding
+
+If your seeding logic is its own script (or your seed source is a fixture file you want to ship alongside the test), do it before calling `chaos()`:
+
+```ts
+import { execSync } from "node:child_process";
+import { chaos } from "chaosbringer";
+
+execSync("./scripts/seed.sh", { stdio: "inherit" });
+
+await chaos({ baseUrl: "http://localhost:8787", /* … */ });
+```
+
+This skips the disposable browser context entirely. Use it when:
+- Seed logic is non-trivial and already has its own tests.
+- You're sharing seed data between chaos runs and other tests.
+- The seed script is the same one CI uses to set up integration tests.
+
+The trade-off vs Pattern A: you lose `page.request`'s automatic cookie / CSRF handling. For unauthenticated REST endpoints this is a non-issue; for sessioned endpoints, prefer Pattern A.
+
+## The gotcha — seed `POST`s eaten by chaos middleware
+
+If your **server** is running with `@mizchi/server-faults` (or any other chaos middleware that rolls a per-request dice), the seed `POST`s themselves are subject to the fault raffle. With `status5xxRate: 0.3` and 5 seed rows, the probability that *all five* succeed is `0.7^5 ≈ 0.17` — your seed step fails ~83% of the time.
+
+Two ways out:
+
+### Option 1 (recommended): bypass the chaos middleware on the seed path
+
+`@mizchi/server-faults` ships a `bypassHeader` option. Configure the server with it:
+
+```ts
+import { honoMiddleware } from "@mizchi/server-faults/hono";
+
+app.use("*", honoMiddleware({
+  status5xxRate: Number(process.env.CHAOS_5XX_RATE ?? 0),
+  bypassHeader: "x-chaos-bypass",
+}));
+```
+
+Then send the bypass header from your seed call:
+
+```ts
+setup: async ({ page, baseUrl }) => {
+  for (let i = 0; i < 5; i++) {
+    const r = await page.request.post(`${baseUrl}/api/todos`, {
+      headers: { "x-chaos-bypass": "1" },
+      data: { title: `seed-${i}` },
+    });
+    if (!r.ok()) throw new Error(`seed POST failed: ${r.status()}`);
+  }
+},
+```
+
+Now the seed path is unconditionally exempt from the dice roll. The crawl traffic is not.
+
+### Option 2: retry until each row lands
+
+If you can't change the server (third-party chaos middleware, or a chaos layer outside your control), retry per row. The math still works in your favour: 10 attempts × 0.3 fail rate ≈ 0.3¹⁰ ≈ 0.0006% per-row failure.
+
+```ts
+setup: async ({ page, baseUrl }) => {
+  for (let i = 0; i < 5; i++) {
+    let lastStatus = 0;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const r = await page.request.post(`${baseUrl}/api/todos`, {
+        data: { title: `seed-${i}` },
+      });
+      if (r.ok()) {
+        lastStatus = 0;
+        break;
+      }
+      lastStatus = r.status();
+    }
+    if (lastStatus !== 0) {
+      throw new Error(`seed POST failed after 10 retries: ${lastStatus}`);
+    }
+  }
+},
+```
+
+This is what `otel-chaos-lab` does — it can't change the worker because the worker IS what's being tested.
+
+## Common invariants that depend on seed state
+
+If you seed `N` rows, codify the invariant that they actually arrived:
+
+```ts
+import { chaos, type Invariant } from "chaosbringer";
+
+const invariants: Invariant[] = [
+  {
+    name: "no-loading-stuck",
+    when: "afterActions",
+    async check({ page }) {
+      const t = (await page.locator("body").textContent()) ?? "";
+      return !/loading\.\.\./i.test(t) || "still showing loading...";
+    },
+  },
+  {
+    name: "has-h1",
+    when: "afterLoad",
+    async check({ page }) {
+      return (await page.locator("h1").count()) > 0 || "no <h1>";
+    },
+  },
+];
+
+await chaos({ baseUrl: "...", invariants, setup: /* … */ });
+```
+
+The `no-loading-stuck` invariant in particular catches the failure mode where a fault response (5xx / abort) leaves a SPA stuck in its loading skeleton — which is invisible to a navigation-status-only check.
+
+## Related
+
+- `chaos({ setup })` API: see `ChaosRunOptions.setup` in [`packages/chaosbringer/README.md`](../../packages/chaosbringer/README.md#pre-run-setup-hook).
+- `bypassHeader` option: see [`packages/server-faults/README.md`](../../packages/server-faults/README.md).
+- Reproducible seeds + chaos seeds: pass the same `seed` to both `chaos()` and (if applicable) the server-side chaos middleware. See the `seed` section of `packages/chaosbringer/README.md`.

--- a/docs/recipes/server-side-correlation.md
+++ b/docs/recipes/server-side-correlation.md
@@ -1,0 +1,199 @@
+# Correlate server-side faults with the chaosbringer report
+
+`chaosbringer` injects faults at the Playwright route layer (between browser and server). `@mizchi/server-faults` injects them inside the server process. Without coordination they produce two unrelated streams: chaosbringer's `chaos-report.json` and the server's OTel telemetry. This recipe wires them together so a single chaos run produces one report covering both layers, joined by W3C `traceparent`.
+
+## When you need this
+
+- You run `pnpm chaos` and `wrangler dev` (or `node server.js`) as **separate processes** and want one unified report.
+- You want to know "did the 503 in this report come from the chaos network layer (chaosbringer's `faults.status(500, …)`) or from inside the server (`@mizchi/server-faults`'s `status5xxRate`)?"
+- You want to grep the resulting report by `traceId` and find every fault — network and server-side — that affected a single Playwright action.
+
+## Architecture (Phase 1, separate-process mode)
+
+```
+Browser (Playwright)              Server process
+  |                                  |
+  |-- request, traceparent injected->|
+  |   (chaosbringer adds it)         |-- @mizchi/server-faults rolls dice
+  |                                  |     [synthetic 5xx]:
+  |                                  |       response.headers +=
+  |                                  |         x-chaos-fault-*
+  |                                  |     [latency]:
+  |                                  |       sleep, real handler runs,
+  |                                  |       adapter adds headers
+  |                                  |       on the way back
+  |<--------- response (with --------|
+  |                  fault headers)  |
+  |
+  page.on('response') fires
+  prefix matches → parse attrs → push ServerFaultEvent
+  |
+report.serverFaults = [...events]
+```
+
+Two ingredients have to be wired together:
+
+1. **chaosbringer injects `traceparent` on every request** it routes through Playwright (PR #72). The server-side middleware sees this header and stamps it on every fault it injects.
+2. **`@mizchi/server-faults` mirrors fault metadata onto kebab-case response headers** (`x-chaos-fault-*`) when its `metadataHeader` option is set. chaosbringer parses those headers in a `page.on('response', …)` listener and surfaces the events on `CrawlReport.serverFaults`.
+
+## Wiring it up
+
+### Step 1 — server: enable `metadataHeader` on `@mizchi/server-faults`
+
+The server-faults middleware turns its observer-callback events into response headers. Pick the adapter for your framework — the `metadataHeader` option works the same way in all four:
+
+```ts
+// Hono
+import { honoMiddleware } from "@mizchi/server-faults/hono";
+
+app.use("*", honoMiddleware({
+  status5xxRate: Number(process.env.CHAOS_5XX_RATE ?? 0),
+  latencyRate:   Number(process.env.CHAOS_LATENCY_RATE ?? 0),
+  latencyMs:     Number(process.env.CHAOS_LATENCY_MS ?? 0),
+  seed:          Number(process.env.CHAOS_SEED ?? 0),
+  metadataHeader: true,            // <-- the load-bearing line
+  bypassHeader:   "x-chaos-bypass", // optional, see `seeding-data.md`
+}));
+```
+
+```ts
+// Express
+import { expressMiddleware } from "@mizchi/server-faults/express";
+app.use(expressMiddleware({ status5xxRate: 0.3, metadataHeader: true }));
+
+// Fastify
+import { fastifyPlugin } from "@mizchi/server-faults/fastify";
+await fastify.register(fastifyPlugin({ status5xxRate: 0.3, metadataHeader: true }));
+
+// Koa
+import { koaMiddleware } from "@mizchi/server-faults/koa";
+app.use(koaMiddleware({ status5xxRate: 0.3, metadataHeader: true }));
+```
+
+After this change, every synthetic 5xx response and every latency-affected real response carries headers like:
+
+```
+x-chaos-fault-kind: 5xx
+x-chaos-fault-path: /api/todos
+x-chaos-fault-method: GET
+x-chaos-fault-target-status: 503
+x-chaos-fault-trace-id: 0af7651916cd43dd8448eb211c80319c
+```
+
+The default prefix is `x-chaos-fault`. To change it, pass `metadataHeader: { prefix: "x-my-fault" }` and feed the same prefix to chaosbringer below.
+
+### Step 2 — chaosbringer: enable remote-server ingestion
+
+```ts
+import { chaos, faults } from "chaosbringer";
+
+const { passed, report } = await chaos({
+  baseUrl: "http://localhost:8787",
+  seed: 42,
+  faultInjection: [
+    faults.status(500, { urlPattern: /\/api\//, probability: 0.3 }),
+  ],
+  server: { mode: "remote" },        // <-- the load-bearing line
+});
+
+console.log(report.serverFaults);    // ServerFaultEvent[] | undefined
+```
+
+`server: { mode: "remote" }` attaches a `page.on('response', …)` listener that parses `x-chaos-fault-*` headers and accumulates events. After the crawl, `report.serverFaults` contains a flat array of:
+
+```ts
+interface ServerFaultEvent {
+  traceId?: string;        // 32-hex, from the request's traceparent
+  attrs: {
+    kind: "5xx" | "latency";
+    path: string;          // URL pathname (no host, no query)
+    method: string;        // uppercase HTTP method
+    targetStatus?: number; // set when kind === "5xx"
+    latencyMs?: number;    // set when kind === "latency"
+    traceId?: string;      // duplicated here for OTel-attribute parity
+  };
+  observedAt: number;      // Date.now() at the moment chaos saw the response
+  pageUrl: string;         // page that triggered the request
+}
+```
+
+The field is `undefined` when no events were observed (matches the `coverage` / `advisor` convention in `CrawlReport`).
+
+To override the prefix:
+```ts
+server: { mode: "remote", responseHeaderPrefix: "x-my-fault" },
+```
+
+### Step 3 — share the chaos seed across both processes
+
+Network and server-side fault layers use independent RNGs. Reproducibility means **every layer sees the same seed at process start**. Phase 1 pushes this onto the operator: pass the seed via env var to both processes.
+
+```bash
+export CHAOS_SEED=42
+
+# server
+CHAOS_5XX_RATE=0.3 CHAOS_SEED=$CHAOS_SEED node server.js &
+
+# chaosbringer
+SEED=$CHAOS_SEED pnpm chaos
+```
+
+The chaosbringer report's `Repro:` line includes only chaosbringer's own seed (the network-layer roll). The server-side seed is the operator's responsibility — write it next to the Repro line or in your run log.
+
+## Verification
+
+After a run with `CHAOS_5XX_RATE=0.3`:
+
+```ts
+const fivexx = report.serverFaults?.filter(e => e.attrs.kind === "5xx") ?? [];
+console.log(`server-side 5xx: ${fivexx.length}`);
+
+// join with chaosbringer actions by traceparent (when implemented in your stack):
+for (const action of report.actions) {
+  const trace = action.traceparent?.match(/^00-([0-9a-f]{32})/)?.[1];
+  if (!trace) continue;
+  const matchingFaults = report.serverFaults?.filter(e => e.traceId === trace) ?? [];
+  if (matchingFaults.length > 0) {
+    console.log(`action ${action.target} → ${matchingFaults.length} server fault(s)`);
+  }
+}
+```
+
+The `traceId` join is the load-bearing primitive: same `traceparent` on the wire → same value in `report.serverFaults[].traceId` → same value emitted on OTel attributes via `toOtelAttrs(attrs)` in any downstream observability layer.
+
+## OTel exporter integration
+
+If your server already pipes `@mizchi/server-faults` events into OTel via the `observer.onFault` callback, `toOtelAttrs(attrs)` translates the in-memory flat camelCase shape to the wire-level dotted attribute schema:
+
+```ts
+import { serverFaults, toOtelAttrs } from "@mizchi/server-faults";
+
+const fault = serverFaults({
+  status5xxRate: 0.3,
+  metadataHeader: true,
+  observer: {
+    onFault: (kind, attrs) => {
+      span.setAttributes(toOtelAttrs(attrs));
+      // produces: { "fault.kind": "5xx", "fault.path": "/api/todos",
+      //             "fault.method": "GET", "fault.target_status": 503,
+      //             "fault.trace_id": "0af7651916cd…" }
+    },
+  },
+});
+```
+
+Now any downstream OTel consumer (Jaeger, Tempo, Honeycomb, Datadog) can filter spans by `fault.kind="5xx"` or join chaos events to user spans by `fault.trace_id`.
+
+## Limitations of Phase 1
+
+- **Seed propagation is manual.** Future work may add automatic seed broadcast.
+- **Same-process integration (`server: ServerFaultHandle`) is not implemented.** Phase 2 will let the test runner pass the handle directly, share an in-memory observer, and skip the response-header round-trip. Useful for unit tests where the test driver imports the app.
+- **Per-action correlation is post-hoc.** `report.serverFaults` is a flat list; consumers join by `traceId` themselves. A trace-id-indexed dict on `ActionResult` is design-deferred.
+
+## Related
+
+- Spec: [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`](../superpowers/specs/2026-05-06-chaos-server-orchestration-design.md) (internal design rationale)
+- Issue: [`#56`](https://github.com/mizchi/chaosbringer/issues/56)
+- PR 1 (server-faults): [`#74`](https://github.com/mizchi/chaosbringer/pull/74)
+- PR 2 (chaosbringer): [`#75`](https://github.com/mizchi/chaosbringer/pull/75)
+- Seeding pattern: [`docs/recipes/seeding-data.md`](seeding-data.md)


### PR DESCRIPTION
## Summary

Three doc additions, no code changes:

1. **Root `README.md` rewrite** (33 → 96 lines). Promotes the chaos-layering table to the top of the monorepo (was buried inside `packages/chaosbringer/README.md`), adds a 30-second tour with both CLI and programmatic usage, and lists every package with a one-line role description. Anyone landing on github.com now sees the product story before the package list.

2. **`docs/recipes/seeding-data.md`** — How to seed backend state before a chaos run. Covers the `chaos({ setup })` hook pattern, out-of-process seeding alternative, and the gotcha where seed `POST`s get eaten by chaos middleware (real bug from `otel-chaos-lab`'s `chaos/run.ts`). Includes the recommended `bypassHeader` fix and the retry-loop fallback.

3. **`docs/recipes/server-side-correlation.md`** — Wire chaosbringer + `@mizchi/server-faults` together so server-side fault events join chaosbringer's report by W3C `traceparent`. This is the only user-facing doc for the work shipped in #74 + #75; the spec lives in `docs/superpowers/specs/` (internal). Walks through the `metadataHeader: true` server config, the `server: { mode: "remote" }` chaosbringer config, the seed-sharing convention, and `toOtelAttrs(attrs)` for OTel exporter integration.

## Why now

Reviewing usability on a freshly-merged feature exposed three concrete gaps:
- The 1091-line `packages/chaosbringer/README.md` mixes concept docs with API reference; new users have no obvious entry point.
- The most recent breaking change (#74) shipped without a user-facing doc explaining how to consume the new orchestration.
- Real consumer code (`otel-chaos-lab/chaos/run.ts`) hand-rolled the seed-retry pattern because no recipe existed.

## Out of scope (Tier 2 / Tier 3)

- Splitting the 1091-line package README into per-topic files.
- `examples/` directory with runnable apps.
- TypeDoc → GH Pages API reference.
- More recipes (auth, SPA-routing, Playwright Test integration, CI on GitHub Actions).
- Migration guide for the v0.1 → v0.2 breaking change in `@mizchi/server-faults`.

## Test plan

- [x] Markdown renders cleanly in `gh pr view --web`.
- [x] All cross-links resolve (`packages/chaosbringer/README.md`, `packages/server-faults/README.md`, `docs/recipes/seeding-data.md`, `docs/recipes/server-side-correlation.md`, `docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`).
- [x] Code samples are typed correctly against the current API surface (`chaos`, `faults`, `Invariant`, `ChaosSetupContext`, `ServerFaultEvent`).