### PR TITLE
docs(examples): cloudflare-worker + playwright-test runnable demos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -51,10 +51,48 @@ jobs:
           pnpm -F "@mizchi/chaosbringer-example-cloudflare-worker" typecheck
           pnpm -F "@mizchi/chaosbringer-example-playwright-test" typecheck
 
-      - name: Test examples — cloudflare-worker (boots wrangler + runs chaos)
-        run: pnpm -F "@mizchi/chaosbringer-example-cloudflare-worker" test
+  example-tests:
+    # Runs in parallel with build-and-test. Each matrix value is its own
+    # runner, so cloudflare-worker and playwright-test execute concurrently.
+    # Both need the Playwright Chromium browser (chaosbringer drives Chromium
+    # internally) and a `pnpm install` of the workspace.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - cloudflare-worker
+          - playwright-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit path)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Test example
+        run: pnpm -F "@mizchi/chaosbringer-example-${{ matrix.example }}" test
         env:
           WRANGLER_SEND_METRICS: "false"
-
-      - name: Test examples — playwright-test
-        run: pnpm -F "@mizchi/chaosbringer-example-playwright-test" test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -45,3 +45,16 @@ jobs:
 
       - name: Test
         run: pnpm -F chaosbringer test
+
+      - name: Typecheck examples
+        run: |
+          pnpm -F "@mizchi/chaosbringer-example-cloudflare-worker" typecheck
+          pnpm -F "@mizchi/chaosbringer-example-playwright-test" typecheck
+
+      - name: Test examples — cloudflare-worker (boots wrangler + runs chaos)
+        run: pnpm -F "@mizchi/chaosbringer-example-cloudflare-worker" test
+        env:
+          WRANGLER_SEND_METRICS: "false"
+
+      - name: Test examples — playwright-test
+        run: pnpm -F "@mizchi/chaosbringer-example-playwright-test" test

--- a/examples/cloudflare-worker/README.md
+++ b/examples/cloudflare-worker/README.md
@@ -1,0 +1,89 @@
+# Example — Cloudflare Worker + chaosbringer + server-faults
+
+A minimal end-to-end demo of the chaosbringer + `@mizchi/server-faults` story:
+
+- **Hono** todo app deployed to a Cloudflare Worker (locally via `wrangler dev`).
+- **`@mizchi/server-faults`** mounted as Hono middleware on `/api/*` with `metadataHeader: true`.
+- **`chaosbringer`** crawl driven by `chaos/run.ts`, using `server: { mode: "remote" }` to ingest the server-emitted `x-chaos-fault-*` response headers.
+- A `setup` hook seeds 5 todos using the `x-chaos-bypass` header so the seed phase is unaffected by the chaos middleware.
+
+This is the same shape as the upstream `otel-chaos-lab` repo, condensed to the parts that demonstrate chaosbringer / server-faults orchestration. OTel collector wiring is intentionally omitted — see `otel-chaos-lab` for that.
+
+## Run it
+
+Terminal 1 — start the worker. Pick a chaos profile via env vars:
+
+```bash
+# clean run (no chaos middleware)
+pnpm dev
+
+# 30% 5xx + 10% latency on /api/* paths
+CHAOS_5XX_RATE=0.3 CHAOS_LATENCY_RATE=0.1 CHAOS_LATENCY_MS=1500 pnpm dev
+```
+
+Terminal 2 — crawl with chaosbringer:
+
+```bash
+pnpm chaos
+```
+
+You should see:
+
+```
+seeded 5 todos
+chaosbringer --url http://localhost:8787 --seed 42 --max-pages 20 …
+pages=20 errors=N
+server-side fault events: M
+  5xx: …
+  latency: …
+```
+
+## What's connecting the two layers
+
+```
++-- terminal 2: chaosbringer --+        +-- terminal 1: wrangler dev --+
+|                              |        |                              |
+|  faults.status(500, ...)     |  HTTP  |  honoMiddleware({            |
+|  faults.delay(2000, ...)     +------->|    status5xxRate, latency,   |
+|  server: { mode: "remote" }  |        |    metadataHeader: true,     |
+|  invariants: [...]           |        |    bypassHeader: "...",      |
+|                              |        |  })                          |
+|  page.on("response") parses  |<-------+  response.headers +=         |
+|  x-chaos-fault-* headers     |        |    x-chaos-fault-kind, etc.  |
+|                              |        |                              |
+|  report.serverFaults[]       |        |                              |
++------------------------------+        +------------------------------+
+```
+
+The seed phase (`setup` hook) sends `x-chaos-bypass: 1` so its `POST`s land on
+the seed endpoint regardless of `CHAOS_5XX_RATE`. Once the crawler proper
+starts, requests *don't* carry the bypass header and the chaos raffle applies.
+
+## Files
+
+```
+.
+├── README.md          # this file
+├── package.json       # workspace package referencing chaosbringer + server-faults via workspace:*
+├── tsconfig.json
+├── wrangler.toml      # Wrangler dev config, no Cloudflare account needed
+├── src/
+│   ├── worker.ts      # CF Worker entry — calls into createApp(env)
+│   ├── app.ts         # Hono app + chaos middleware wiring
+│   └── types.ts       # Env shape
+└── chaos/
+    └── run.ts         # chaosbringer driver
+```
+
+## Variations to try
+
+- **Tighten the latency window**: drop `CHAOS_LATENCY_MS` to 500 and watch chaosbringer's per-page timing budget reports.
+- **Disable network-layer faults**: comment out `faults.status` / `faults.delay` and run with only the server-side chaos. The `report.serverFaults` count should match the worker's `[chaos] 5xx ...` log lines.
+- **Disable server-side faults**: leave `pnpm dev` without env vars. `report.serverFaults` will be `undefined` (the field is omitted when no events were observed).
+- **Reproducibility**: pass the same `CHAOS_SEED=42` to both the worker (`pnpm dev`) and the chaos driver (`SEED=42 pnpm chaos`). Run twice; verify identical `pages=` / `errors=` / fault-event counts.
+
+## Related docs
+
+- [`docs/recipes/seeding-data.md`](../../docs/recipes/seeding-data.md) — the bypass header + retry patterns this demo uses.
+- [`docs/recipes/server-side-correlation.md`](../../docs/recipes/server-side-correlation.md) — full walkthrough of `server: { mode: "remote" }` + `metadataHeader`.
+- [`packages/chaosbringer/README.md`](../../packages/chaosbringer/README.md) — full chaosbringer feature list + CLI reference.

--- a/examples/cloudflare-worker/chaos/run.ts
+++ b/examples/cloudflare-worker/chaos/run.ts
@@ -1,0 +1,90 @@
+/**
+ * chaosbringer driver. Run `pnpm dev` (worker on :8787) in one terminal,
+ * then `pnpm chaos` in another.
+ *
+ * Demonstrates:
+ *   - Network-layer faults via chaosbringer's `faults.*` (intercepted
+ *     before the request reaches the server).
+ *   - Server-side faults via `@mizchi/server-faults` running in the worker
+ *     (synthetic 5xx / latency, with `x-chaos-fault-*` response headers).
+ *   - Remote-mode ingestion: `server: { mode: "remote" }` parses those
+ *     headers and surfaces events on `report.serverFaults`.
+ *   - Setup hook with seed retries and the chaos-bypass header.
+ */
+
+import { chaos, faults, type Invariant } from "chaosbringer";
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:8787";
+const SEED_TODOS = Number(process.env.SEED_TODOS ?? "5");
+
+const invariants: Invariant[] = [
+  {
+    name: "no-loading-stuck",
+    when: "afterActions",
+    async check({ page }) {
+      const t = (await page.locator("body").textContent()) ?? "";
+      return !/loading\.\.\./i.test(t) || "still showing loading...";
+    },
+  },
+  {
+    name: "has-h1",
+    when: "afterLoad",
+    async check({ page }) {
+      return (await page.locator("h1").count()) > 0 || "no <h1>";
+    },
+  },
+];
+
+async function main() {
+  const { passed, report } = await chaos({
+    baseUrl: BASE_URL,
+    seed: Number(process.env.SEED ?? "42"),
+    maxPages: Number(process.env.MAX_PAGES ?? "20"),
+    strict: false,
+    faultInjection: [
+      // Network-layer faults — intercepted by Playwright BEFORE the worker is called.
+      // These produce no `x-chaos-fault-*` headers because the worker is never reached.
+      faults.status(500, { urlPattern: /\/api\/todos$/, methods: ["GET"], probability: 0.2 }),
+      faults.delay(2000, { urlPattern: /\/api\/todos/, probability: 0.1 }),
+    ],
+    // Surface server-side fault events emitted by @mizchi/server-faults
+    // running in the worker. The default header prefix is `x-chaos-fault`.
+    server: { mode: "remote" },
+    invariants,
+    setup: async ({ page, baseUrl }) => {
+      // Seed must succeed even when CHAOS_5XX_RATE > 0. The bypass header
+      // makes the seed path immune to the worker's chaos middleware.
+      // (See docs/recipes/seeding-data.md.)
+      for (let i = 0; i < SEED_TODOS; i++) {
+        const r = await page.request.post(`${baseUrl}/api/todos`, {
+          headers: { "x-chaos-bypass": "1" },
+          data: { title: `seed-${i}` },
+        });
+        if (!r.ok()) throw new Error(`seed POST failed: ${r.status()}`);
+      }
+      console.log(`seeded ${SEED_TODOS} todos`);
+    },
+  });
+
+  console.log(report.reproCommand);
+  console.log(`pages=${report.pagesVisited} errors=${report.totalErrors}`);
+
+  const sf = report.serverFaults ?? [];
+  if (sf.length > 0) {
+    console.log(`server-side fault events: ${sf.length}`);
+    const byKind = sf.reduce<Record<string, number>>((acc, e) => {
+      acc[e.attrs.kind] = (acc[e.attrs.kind] ?? 0) + 1;
+      return acc;
+    }, {});
+    for (const [kind, n] of Object.entries(byKind)) console.log(`  ${kind}: ${n}`);
+  } else {
+    console.log("server-side fault events: 0 (set CHAOS_5XX_RATE / CHAOS_LATENCY_RATE on the worker to see some)");
+  }
+
+  process.exit(passed ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -5,7 +5,9 @@
   "description": "Hono on Cloudflare Worker + @mizchi/server-faults + chaosbringer (remote mode)",
   "scripts": {
     "dev": "wrangler dev",
-    "chaos": "tsx chaos/run.ts"
+    "chaos": "tsx chaos/run.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "node test.mjs"
   },
   "dependencies": {
     "@mizchi/server-faults": "workspace:*",

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@mizchi/chaosbringer-example-cloudflare-worker",
+  "private": true,
+  "type": "module",
+  "description": "Hono on Cloudflare Worker + @mizchi/server-faults + chaosbringer (remote mode)",
+  "scripts": {
+    "dev": "wrangler dev",
+    "chaos": "tsx chaos/run.ts"
+  },
+  "dependencies": {
+    "@mizchi/server-faults": "workspace:*",
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250101.0",
+    "@types/node": "^22.0.0",
+    "chaosbringer": "workspace:*",
+    "playwright": "^1.52.0",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3",
+    "wrangler": "^3.90.0"
+  }
+}

--- a/examples/cloudflare-worker/src/app.ts
+++ b/examples/cloudflare-worker/src/app.ts
@@ -1,0 +1,128 @@
+/**
+ * Tiny Hono todo app + chaos middleware.
+ *
+ * - `GET /` and `GET /todos/:id` serve the UI a chaosbringer crawl can navigate.
+ * - `GET/POST/DELETE /api/todos` is the JSON API; chaos middleware applies here.
+ * - The chaos middleware emits `x-chaos-fault-*` response headers, which the
+ *   chaosbringer crawler parses and surfaces on `report.serverFaults`.
+ *
+ * Storage is an in-memory Map for this example. Real apps would use KV /
+ * D1 / Durable Objects.
+ */
+
+import { Hono } from "hono";
+import { honoMiddleware } from "@mizchi/server-faults/hono";
+import type { Env } from "./types.js";
+
+interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+// Simple in-memory store. A new Worker isolate per request would drop this;
+// in `wrangler dev` the same isolate is reused, so the demo state persists.
+const TODOS = new Map<string, Todo>();
+let nextId = 1;
+
+export function createApp(env: Env) {
+  const app = new Hono<{ Bindings: Env }>();
+
+  // Mount server-faults BEFORE the routes so it can short-circuit before the
+  // handler runs. metadataHeader: true is the load-bearing flag — it makes
+  // chaosbringer's `server: { mode: "remote" }` mode see the fault events.
+  const r5 = Number(env.CHAOS_5XX_RATE ?? "0");
+  const rL = Number(env.CHAOS_LATENCY_RATE ?? "0");
+  if (env.DEPLOY_ENV === "dev" && (r5 > 0 || rL > 0)) {
+    app.use(
+      "/api/*",
+      honoMiddleware({
+        status5xxRate: r5,
+        latencyRate: rL,
+        latencyMs: Number(env.CHAOS_LATENCY_MS ?? "0"),
+        seed: env.CHAOS_SEED ? Number(env.CHAOS_SEED) : undefined,
+        metadataHeader: true,
+        bypassHeader: "x-chaos-bypass",
+        observer: {
+          onFault: (kind, attrs) => {
+            console.log(`[chaos] ${kind} ${attrs.method} ${attrs.path} traceId=${attrs.traceId ?? "-"}`);
+          },
+        },
+      }),
+    );
+  }
+
+  // ---------- API ----------
+  app.get("/api/todos", (c) => c.json({ items: [...TODOS.values()] }));
+
+  app.post("/api/todos", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as { title?: string };
+    if (!body.title) return c.json({ error: "title required" }, 400);
+    const id = String(nextId++);
+    const todo: Todo = { id, title: body.title, done: false };
+    TODOS.set(id, todo);
+    return c.json(todo, 201);
+  });
+
+  app.delete("/api/todos/:id", (c) => {
+    const id = c.req.param("id");
+    if (!TODOS.has(id)) return c.json({ error: "not found" }, 404);
+    TODOS.delete(id);
+    return c.json({ ok: true });
+  });
+
+  // ---------- UI ----------
+  app.get("/", (c) =>
+    c.html(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Todo demo</title>
+</head>
+<body>
+  <h1>Todos</h1>
+  <ul id="list"><li>loading...</li></ul>
+  <button id="add">Add random todo</button>
+  <p><a href="/about">About</a></p>
+  <script type="module">
+    const list = document.getElementById("list");
+    async function refresh() {
+      list.innerHTML = "<li>loading...</li>";
+      try {
+        const r = await fetch("/api/todos");
+        if (!r.ok) throw new Error("fetch failed: " + r.status);
+        const data = await r.json();
+        list.innerHTML = data.items.length
+          ? data.items.map(t => \`<li><a href="/todos/\${t.id}">\${t.title}</a></li>\`).join("")
+          : "<li>(none yet)</li>";
+      } catch (err) {
+        list.innerHTML = "<li>error: " + err.message + "</li>";
+      }
+    }
+    document.getElementById("add").addEventListener("click", async () => {
+      await fetch("/api/todos", { method: "POST", headers: {"content-type":"application/json"},
+        body: JSON.stringify({ title: "todo-" + Date.now() }) });
+      refresh();
+    });
+    refresh();
+  </script>
+</body>
+</html>`),
+  );
+
+  app.get("/todos/:id", (c) => {
+    const id = c.req.param("id");
+    return c.html(`<!doctype html>
+<title>Todo ${id}</title>
+<h1>Todo ${id}</h1>
+<p><a href="/">back</a></p>`);
+  });
+
+  app.get("/about", (c) =>
+    c.html(`<!doctype html><title>About</title><h1>About</h1>
+<p>Demo app showing chaosbringer + @mizchi/server-faults orchestration.</p>
+<p><a href="/">home</a></p>`),
+  );
+
+  return app;
+}

--- a/examples/cloudflare-worker/src/app.ts
+++ b/examples/cloudflare-worker/src/app.ts
@@ -8,6 +8,14 @@
  *
  * Storage is an in-memory Map for this example. Real apps would use KV /
  * D1 / Durable Objects.
+ *
+ * The app + chaos middleware are constructed once per isolate and cached.
+ * If we re-built per request, every request would see the SAME first roll
+ * of a fresh seeded RNG (because `serverFaults({ seed })` is constructed
+ * each time), and faults would fire either always or never depending on
+ * that one roll. Module-level caching lets the RNG advance across requests
+ * within an isolate, which is the only context where reproducibility is
+ * meaningful anyway.
  */
 
 import { Hono } from "hono";
@@ -25,7 +33,28 @@ interface Todo {
 const TODOS = new Map<string, Todo>();
 let nextId = 1;
 
+let cachedApp: Hono<{ Bindings: Env }> | null = null;
+let cachedEnvKey: string | null = null;
+
+function envKey(env: Env): string {
+  return [
+    env.DEPLOY_ENV ?? "",
+    env.CHAOS_5XX_RATE ?? "",
+    env.CHAOS_LATENCY_RATE ?? "",
+    env.CHAOS_LATENCY_MS ?? "",
+    env.CHAOS_SEED ?? "",
+  ].join("|");
+}
+
 export function createApp(env: Env) {
+  const key = envKey(env);
+  if (cachedApp && cachedEnvKey === key) return cachedApp;
+  cachedEnvKey = key;
+  cachedApp = buildApp(env);
+  return cachedApp;
+}
+
+function buildApp(env: Env): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
 
   // Mount server-faults BEFORE the routes so it can short-circuit before the

--- a/examples/cloudflare-worker/src/types.ts
+++ b/examples/cloudflare-worker/src/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Shape of `env` injected by the Cloudflare runtime. Everything is a
+ * string because Wrangler vars are stringified — handlers parse to
+ * Number where needed.
+ */
+
+export interface Env {
+  DEPLOY_ENV: string;
+  CHAOS_5XX_RATE?: string;
+  CHAOS_LATENCY_RATE?: string;
+  CHAOS_LATENCY_MS?: string;
+  CHAOS_SEED?: string;
+}

--- a/examples/cloudflare-worker/src/worker.ts
+++ b/examples/cloudflare-worker/src/worker.ts
@@ -1,0 +1,14 @@
+/**
+ * Cloudflare Worker entry. The Hono app + chaos middleware lives in
+ * `app.ts` so the chaos config can be swapped without touching the
+ * runtime adapter.
+ */
+
+import { createApp } from "./app.js";
+import type { Env } from "./types.js";
+
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    return createApp(env).fetch(request, env, ctx);
+  },
+} satisfies ExportedHandler<Env>;

--- a/examples/cloudflare-worker/test.mjs
+++ b/examples/cloudflare-worker/test.mjs
@@ -1,0 +1,126 @@
+/**
+ * Smoke test for the cloudflare-worker example.
+ *
+ * Boots `wrangler dev` in the background, polls until the worker is ready,
+ * runs `chaos/run.ts` with deterministic seeds + small page budget, and
+ * asserts that server-side fault events were ingested via the response-
+ * header round trip (the load-bearing wiring this example demonstrates).
+ *
+ * Designed for CI: tears down the worker on every exit path, has a
+ * timeout on the readiness probe, and exits non-zero on any failure.
+ */
+
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const PORT = 8788; // off the default to avoid colliding with a manual `pnpm dev` next door
+const READY_URL = `http://localhost:${PORT}/`;
+const READY_TIMEOUT_MS = 60_000;
+
+let chaosStdout = "";
+
+async function waitForReady() {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(READY_URL);
+      if (r.ok) return;
+    } catch {
+      /* not ready yet */
+    }
+    await sleep(500);
+  }
+  throw new Error(`worker not ready within ${READY_TIMEOUT_MS}ms`);
+}
+
+// wrangler does NOT auto-forward `process.env` into the Worker — vars come
+// from `wrangler.toml`'s [vars] block or from `--var KEY:VALUE` flags. We
+// pass the chaos config via --var so the test is self-contained without
+// mutating wrangler.toml.
+const wrangler = spawn(
+  "pnpm",
+  [
+    "exec",
+    "wrangler",
+    "dev",
+    "--port",
+    String(PORT),
+    "--var",
+    "CHAOS_5XX_RATE:0.5",
+    "--var",
+    "CHAOS_LATENCY_RATE:0.2",
+    "--var",
+    "CHAOS_LATENCY_MS:100",
+    "--var",
+    "CHAOS_SEED:42",
+  ],
+  {
+    stdio: ["ignore", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      CI: "1",
+      WRANGLER_SEND_METRICS: "false",
+    },
+  },
+);
+
+let teardownCalled = false;
+async function teardown(code) {
+  if (teardownCalled) return;
+  teardownCalled = true;
+  try {
+    wrangler.kill("SIGTERM");
+  } catch {
+    /* ignore */
+  }
+  // SIGTERM grace, then hard kill
+  await sleep(500);
+  try {
+    wrangler.kill("SIGKILL");
+  } catch {
+    /* ignore */
+  }
+  process.exit(code);
+}
+process.on("SIGINT", () => teardown(130));
+process.on("SIGTERM", () => teardown(143));
+
+try {
+  await waitForReady();
+  console.log("[test] worker ready, running chaos…");
+
+  await new Promise((resolve, reject) => {
+    const chaos = spawn("pnpm", ["exec", "tsx", "chaos/run.ts"], {
+      stdio: ["ignore", "pipe", "inherit"],
+      env: {
+        ...process.env,
+        MAX_PAGES: "5",
+        SEED_TODOS: "3",
+        SEED: "42",
+        BASE_URL: `http://localhost:${PORT}`,
+      },
+    });
+    chaos.stdout.on("data", (chunk) => {
+      const s = chunk.toString();
+      chaosStdout += s;
+      process.stdout.write(s);
+    });
+    chaos.on("exit", () => resolve()); // exit code intentionally ignored — high fault rate may trip invariants; we assert via stdout instead
+    chaos.on("error", reject);
+  });
+
+  // Assertion: the load-bearing wiring (metadataHeader → page.on("response") → report.serverFaults) actually delivered events.
+  const m = chaosStdout.match(/server-side fault events:\s*(\d+)/);
+  if (!m) {
+    throw new Error("could not find 'server-side fault events: N' in chaos output — did the report formatting change?");
+  }
+  const n = Number(m[1]);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`expected server-side fault events > 0 with CHAOS_5XX_RATE=0.5, got ${n}`);
+  }
+  console.log(`[test] PASS — ${n} server-side fault events observed via header round-trip`);
+  await teardown(0);
+} catch (err) {
+  console.error("[test] FAIL:", err.message ?? err);
+  await teardown(1);
+}

--- a/examples/cloudflare-worker/tsconfig.json
+++ b/examples/cloudflare-worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types", "node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*", "chaos/**/*"]
+}

--- a/examples/cloudflare-worker/wrangler.toml
+++ b/examples/cloudflare-worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "chaosbringer-example-cf"
+main = "src/worker.ts"
+compatibility_date = "2025-01-15"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+DEPLOY_ENV = "dev"
+# Toggle these from the CLI to vary how aggressive the chaos middleware is.
+# (See README.md for the matrix.)
+# CHAOS_5XX_RATE = "0.3"
+# CHAOS_LATENCY_RATE = "0.1"
+# CHAOS_LATENCY_MS = "1500"
+# CHAOS_SEED = "42"

--- a/examples/playwright-test/.gitignore
+++ b/examples/playwright-test/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/examples/playwright-test/README.md
+++ b/examples/playwright-test/README.md
@@ -1,0 +1,57 @@
+# Example — chaosbringer inside Playwright Test
+
+When you already have a Playwright Test suite and you want chaos coverage as one tool among many (rather than a separate `chaos/run.ts` driver), use `chaosbringer/fixture`.
+
+## What this example shows
+
+- Tiny static site (`/`, `/about`, `/broken-link`) served by `node:http` — a stand-in for "your app".
+- Two integration patterns in one `tests/chaos.spec.ts`:
+  1. **`chaosTest`** — the chaos fixture directly. Best when chaos *is* what the file is about.
+  2. **`withChaos()` extension** — extend `base` so a regular Playwright Test grows a `chaos` fixture without becoming a chaos-only file.
+- Three useful assertions: `chaos.expectNoErrors(result)`, `chaos.expectNoDeadLinks(report)`, and ordinary `expect(...)` from `@playwright/test`.
+
+The fixture site server boots automatically via `playwright.config.ts`'s `webServer` block — `pnpm test` is one command end-to-end.
+
+## Run it
+
+```bash
+pnpm install
+pnpm exec playwright install chromium
+pnpm test
+```
+
+Or interactively:
+
+```bash
+pnpm test:ui
+```
+
+The third test (`crawl finds a broken link`) is intentionally written to *expect* the broken link, so the run passes. Replace `expect(() => chaos.expectNoDeadLinks(report)).toThrow(...)` with `chaos.expectNoDeadLinks(report)` to make it fail when a broken link slips in — that's the shape you'd want in CI.
+
+## Files
+
+```
+.
+├── README.md
+├── package.json
+├── tsconfig.json
+├── playwright.config.ts   # boots the fixture site as webServer
+├── site/
+│   └── server.mjs         # 30-line static server (the SUT)
+└── tests/
+    └── chaos.spec.ts      # both integration patterns, one file
+```
+
+## When to use each pattern
+
+| Pattern | Best for |
+|---|---|
+| `chaosTest` | Files that exist *for* chaos coverage. Crawl sweeps, dead-link checks, regression suites that fail on console errors anywhere on the site. |
+| `withChaos()` extension | Files that are mainly regular Playwright Tests but want one chaos check as a finisher (e.g. "after exercising the form, also crawl the surrounding pages"). |
+
+The `withChaos()` extension is `base.extend(withChaos({ maxPages: 5 }))` — `withChaos()` returns a fixture object Playwright Test stitches onto your `base` test.
+
+## Related
+
+- [`packages/chaosbringer/README.md`](../../packages/chaosbringer/README.md#playwright-test-integration) — full fixture API reference (`ChaosFixture`, `ChaosFixtures`, `chaosExpect`).
+- [`examples/cloudflare-worker/`](../cloudflare-worker/) — programmatic `chaos()` driver instead of Playwright Test integration. Use that when the chaos run is its own CI step rather than part of an `@playwright/test` suite.

--- a/examples/playwright-test/package.json
+++ b/examples/playwright-test/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@mizchi/chaosbringer-example-playwright-test",
+  "private": true,
+  "type": "module",
+  "description": "Run chaosbringer inside a Playwright Test suite via the chaos fixture",
+  "scripts": {
+    "site": "node site/server.mjs",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "chaosbringer": "workspace:*",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/playwright-test/package.json
+++ b/examples/playwright-test/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "site": "node site/server.mjs",
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",

--- a/examples/playwright-test/playwright.config.ts
+++ b/examples/playwright-test/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 3300);
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+  },
+  webServer: {
+    command: `node site/server.mjs`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    env: { PORT: String(PORT) },
+  },
+});

--- a/examples/playwright-test/site/server.mjs
+++ b/examples/playwright-test/site/server.mjs
@@ -1,0 +1,39 @@
+/**
+ * Tiny static site for the Playwright Test example. Three pages:
+ * `/`, `/about`, and `/broken-link` (404). The chaos fixture crawls all
+ * three; the deadLinks invariant catches `/broken-link`.
+ */
+
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.PORT ?? 3300);
+
+const PAGES = {
+  "/": `<!doctype html>
+<title>Home</title>
+<h1>Home</h1>
+<ul>
+  <li><a href="/about">About</a></li>
+  <li><a href="/broken-link">Broken</a></li>
+</ul>`,
+  "/about": `<!doctype html>
+<title>About</title>
+<h1>About</h1>
+<p>The about page.</p>
+<p><a href="/">home</a></p>`,
+};
+
+const server = createServer((req, res) => {
+  const body = PAGES[req.url ?? "/"];
+  if (!body) {
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+    return;
+  }
+  res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  res.end(body);
+});
+
+server.listen(PORT, () => {
+  console.log(`fixture site listening on http://localhost:${PORT}`);
+});

--- a/examples/playwright-test/site/server.mjs
+++ b/examples/playwright-test/site/server.mjs
@@ -24,6 +24,14 @@ const PAGES = {
 };
 
 const server = createServer((req, res) => {
+  // Browsers auto-request /favicon.ico; chaosbringer treats 404s on those
+  // as `requestfailed` errors. Returning 204 No Content keeps the home-
+  // page test free of incidental noise.
+  if (req.url === "/favicon.ico") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
   const body = PAGES[req.url ?? "/"];
   if (!body) {
     res.writeHead(404, { "content-type": "text/plain" });

--- a/examples/playwright-test/tests/chaos.spec.ts
+++ b/examples/playwright-test/tests/chaos.spec.ts
@@ -12,6 +12,7 @@
 
 import { test as base, expect } from "@playwright/test";
 import { chaosTest, withChaos, type ChaosFixtures } from "chaosbringer/fixture";
+import type { ChaosTestOptions } from "chaosbringer";
 
 // chaos.testPage / chaos.crawl require absolute URLs (the crawler computes
 // `new URL(url).origin` to gate external-navigation blocking). Pin the
@@ -19,7 +20,21 @@ import { chaosTest, withChaos, type ChaosFixtures } from "chaosbringer/fixture";
 // playwright.config.ts and site/server.mjs read the same env.
 const BASE = `http://localhost:${process.env.PORT ?? 3300}`;
 
-// ---------- pattern 1: chaosTest ----------
+// Action selection during the crawl can click `<a href="/broken-link">`
+// and Chromium logs the resulting 404 as a console error. That's correct
+// HTML behaviour but not what we want the example to assert against —
+// the third test exercises broken-link discovery via `expectNoDeadLinks`,
+// which is a separate code path. Filter the resource-404 console message
+// at the chaos level so the no-console-error test stays meaningful.
+const COMMON_CHAOS_OPTIONS: ChaosTestOptions = {
+  maxPages: 5,
+  // chaosbringer treats these as regex source strings.
+  ignoreErrorPatterns: ["Failed to load resource.*404"],
+};
+
+// ---------- pattern 1: chaosTest with per-file chaosOptions override ----------
+
+chaosTest.use({ chaosOptions: COMMON_CHAOS_OPTIONS });
 
 chaosTest("home page has no console errors", async ({ page, chaos }) => {
   const result = await chaos.testPage(page, `${BASE}/`);
@@ -30,13 +45,15 @@ chaosTest("crawl finds a broken link", async ({ chaos }) => {
   const report = await chaos.crawl(`${BASE}/`);
   // Crawl visits at least the three reachable URLs (/, /about, /broken-link).
   expect(report.pagesVisited).toBeGreaterThanOrEqual(2);
-  // /broken-link returns 404; the dead-link assertion should catch it.
+  // /broken-link returns 404; the dead-link assertion should still catch it
+  // — `expectNoDeadLinks` reads `summary.discovery.deadLinks`, not console
+  // errors, so the `ignoreErrorPatterns` above does NOT mask it.
   expect(() => chaos.expectNoDeadLinks(report)).toThrow(/broken-link/);
 });
 
 // ---------- pattern 2: withChaos extension ----------
 
-const test = base.extend<ChaosFixtures>(withChaos({ maxPages: 5 }));
+const test = base.extend<ChaosFixtures>(withChaos(COMMON_CHAOS_OPTIONS));
 
 test("about page shows the heading", async ({ page, chaos }) => {
   await page.goto("/about");

--- a/examples/playwright-test/tests/chaos.spec.ts
+++ b/examples/playwright-test/tests/chaos.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * chaosbringer inside a Playwright Test suite.
+ *
+ * Two patterns are demonstrated:
+ *
+ * 1. `chaosTest` — the fixture directly. Use this when chaos is the
+ *    *primary* thing the file does.
+ * 2. `withChaos()` — extend an existing `test`. Use this when you have
+ *    a regular Playwright Test file and want chaos as one tool among
+ *    many.
+ */
+
+import { test as base, expect } from "@playwright/test";
+import { chaosTest, withChaos, type ChaosFixtures } from "chaosbringer/fixture";
+
+// ---------- pattern 1: chaosTest ----------
+
+chaosTest("home page has no console errors", async ({ page, chaos }) => {
+  const result = await chaos.testPage(page, "/");
+  chaos.expectNoErrors(result);
+});
+
+chaosTest("crawl finds a broken link", async ({ chaos }) => {
+  const report = await chaos.crawl("http://localhost:3300/");
+  // Crawl visits at least the three reachable URLs (/, /about, /broken-link).
+  expect(report.pagesVisited).toBeGreaterThanOrEqual(2);
+  // /broken-link returns 404; the dead-link assertion should catch it.
+  expect(() => chaos.expectNoDeadLinks(report)).toThrow(/broken-link/);
+});
+
+// ---------- pattern 2: withChaos extension ----------
+
+const test = base.extend<ChaosFixtures>(withChaos({ maxPages: 5 }));
+
+test("about page shows the heading", async ({ page, chaos }) => {
+  await page.goto("/about");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("About");
+
+  // Plain Playwright assertions still work — chaos.* is an *addition*,
+  // not a replacement. A single test can mix both.
+  const result = await chaos.testPage(page, "/about");
+  chaos.expectNoErrors(result);
+});

--- a/examples/playwright-test/tests/chaos.spec.ts
+++ b/examples/playwright-test/tests/chaos.spec.ts
@@ -13,15 +13,21 @@
 import { test as base, expect } from "@playwright/test";
 import { chaosTest, withChaos, type ChaosFixtures } from "chaosbringer/fixture";
 
+// chaos.testPage / chaos.crawl require absolute URLs (the crawler computes
+// `new URL(url).origin` to gate external-navigation blocking). Pin the
+// fixture port here so the demo stays single-source for the whole stack;
+// playwright.config.ts and site/server.mjs read the same env.
+const BASE = `http://localhost:${process.env.PORT ?? 3300}`;
+
 // ---------- pattern 1: chaosTest ----------
 
 chaosTest("home page has no console errors", async ({ page, chaos }) => {
-  const result = await chaos.testPage(page, "/");
+  const result = await chaos.testPage(page, `${BASE}/`);
   chaos.expectNoErrors(result);
 });
 
 chaosTest("crawl finds a broken link", async ({ chaos }) => {
-  const report = await chaos.crawl("http://localhost:3300/");
+  const report = await chaos.crawl(`${BASE}/`);
   // Crawl visits at least the three reachable URLs (/, /about, /broken-link).
   expect(report.pagesVisited).toBeGreaterThanOrEqual(2);
   // /broken-link returns 404; the dead-link assertion should catch it.
@@ -38,6 +44,6 @@ test("about page shows the heading", async ({ page, chaos }) => {
 
   // Plain Playwright assertions still work — chaos.* is an *addition*,
   // not a replacement. A single test can mix both.
-  const result = await chaos.testPage(page, "/about");
+  const result = await chaos.testPage(page, `${BASE}/about`);
   chaos.expectNoErrors(result);
 });

--- a/examples/playwright-test/tsconfig.json
+++ b/examples/playwright-test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["tests/**/*", "playwright.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,49 @@ importers:
 
   .: {}
 
+  examples/cloudflare-worker:
+    dependencies:
+      '@mizchi/server-faults':
+        specifier: workspace:*
+        version: link:../../packages/server-faults
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.17
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250101.0
+        version: 4.20260506.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      chaosbringer:
+        specifier: workspace:*
+        version: link:../../packages/chaosbringer
+      playwright:
+        specifier: ^1.52.0
+        version: 1.59.1
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      wrangler:
+        specifier: ^3.90.0
+        version: 3.114.17(@cloudflare/workers-types@4.20260506.1)
+
+  examples/playwright-test:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.59.1
+      chaosbringer:
+        specifier: workspace:*
+        version: link:../../packages/chaosbringer
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   packages/cf-faults:
     devDependencies:
       typescript:
@@ -98,16 +141,91 @@ importers:
 
 packages:
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
+    engines: {node: '>=16.13'}
+
+  '@cloudflare/unenv-preset@2.0.2':
+    resolution: {integrity: sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.14
+      workerd: ^1.20250124.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20250718.0':
+    resolution: {integrity: sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20250718.0':
+    resolution: {integrity: sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20250718.0':
+    resolution: {integrity: sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20250718.0':
+    resolution: {integrity: sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20250718.0':
+    resolution: {integrity: sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260506.1':
+    resolution: {integrity: sha512-IKv/C08utEbAqEu2zr0/3CMf1MbYrl7x0Z1UsrnMs4xxfIN81vtGTRduCZb7xJQpaICQPe0Sa6fhHlZmUXrMjw==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild-plugins/node-globals-polyfill@0.2.3':
+    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
+    peerDependencies:
+      esbuild: '*'
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2':
+    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
+    peerDependencies:
+      esbuild: '*'
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.17.19':
+    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.17.19':
+    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -116,16 +234,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.17.19':
+    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.17.19':
+    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.17.19':
+    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -134,10 +270,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.17.19':
+    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.17.19':
+    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -146,10 +294,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.17.19':
+    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.17.19':
+    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -158,10 +318,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.17.19':
+    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.17.19':
+    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -170,10 +342,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.17.19':
+    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.17.19':
+    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -182,16 +366,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.17.19':
+    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.17.19':
+    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.17.19':
+    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.7':
@@ -206,6 +408,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.17.19':
+    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
@@ -216,6 +424,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.17.19':
+    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -230,16 +444,34 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.17.19':
+    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.17.19':
+    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.17.19':
+    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.7':
@@ -248,21 +480,155 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.17.19':
+    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
@@ -536,6 +902,15 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   adm-zip@0.5.17:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
@@ -568,6 +943,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  as-table@1.0.55:
+    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -581,6 +959,9 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -616,9 +997,23 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -634,6 +1029,13 @@ packages:
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  data-uri-to-buffer@2.0.2:
+    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -646,6 +1048,9 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -673,13 +1078,29 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  esbuild@0.17.19:
+    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  estree-walker@0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  exit-hook@2.2.1:
+    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -687,6 +1108,9 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -722,8 +1146,14 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  get-source@2.0.12:
+    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -739,6 +1169,10 @@ packages:
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hono@4.12.17:
+    resolution: {integrity: sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==}
+    engines: {node: '>=16.9.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -784,6 +1218,9 @@ packages:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -807,12 +1244,25 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  magic-string@0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-fetch-happen@10.2.1:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  miniflare@3.20250718.3:
+    resolution: {integrity: sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==}
+    engines: {node: '>=16.13'}
+    hasBin: true
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -869,6 +1319,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -910,6 +1364,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -920,6 +1377,9 @@ packages:
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -957,6 +1417,9 @@ packages:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
+  printable-characters@1.0.42:
+    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+
   promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
     peerDependencies:
@@ -985,6 +1448,16 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rollup-plugin-inject@3.0.2:
+    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+
+  rollup-plugin-node-polyfills@0.2.1:
+    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-pluginutils@2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1004,11 +1477,18 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -1030,6 +1510,14 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  sourcemap-codec@1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+
   ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -1037,8 +1525,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stacktracey@2.2.0:
+    resolution: {integrity: sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stoppable@1.1.0:
+    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
+    engines: {node: '>=4', npm: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1088,6 +1583,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1098,8 +1596,18 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  unenv@2.0.0-rc.14:
+    resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
 
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
@@ -1207,8 +1715,35 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
+  workerd@1.20250718.0:
+    resolution: {integrity: sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@3.114.17:
+    resolution: {integrity: sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20250408.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -1217,54 +1752,154 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
+
+  zod@3.22.3:
+    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
+
 snapshots:
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    dependencies:
+      mime: 3.0.0
+
+  '@cloudflare/unenv-preset@2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)':
+    dependencies:
+      unenv: 2.0.0-rc.14
+    optionalDependencies:
+      workerd: 1.20250718.0
+
+  '@cloudflare/workerd-darwin-64@1.20250718.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20250718.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20250718.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20250718.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20250718.0':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260506.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.17.19':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.17.19':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.17.19':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.17.19':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.17.19':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.17.19':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.17.19':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.17.19':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.17.19':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.17.19':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.17.19':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.17.19':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.17.19':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.17.19':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
@@ -1273,10 +1908,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.17.19':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.17.19':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1285,25 +1926,121 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.17.19':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.17.19':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.17.19':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.17.19':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@fastify/busboy@2.1.1': {}
+
   '@gar/promisify@1.1.3': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mapbox/node-pre-gyp@2.0.3(encoding@0.1.13)':
     dependencies:
@@ -1551,6 +2288,10 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  acorn-walk@8.3.2: {}
+
+  acorn@8.14.0: {}
+
   adm-zip@0.5.17: {}
 
   agent-base@6.0.2:
@@ -1579,6 +2320,10 @@ snapshots:
       delegates: 1.0.0
       readable-stream: 3.6.2
 
+  as-table@1.0.55:
+    dependencies:
+      printable-characters: 1.0.42
+
   assertion-error@2.0.1: {}
 
   axe-core@4.11.4: {}
@@ -1586,6 +2331,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   before-after-hook@4.0.0: {}
+
+  blake3-wasm@2.1.5: {}
 
   brace-expansion@1.1.14:
     dependencies:
@@ -1637,7 +2384,27 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+    optional: true
+
+  color-name@1.1.4:
+    optional: true
+
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+    optional: true
+
   color-support@1.1.3: {}
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+    optional: true
 
   commander@14.0.3: {}
 
@@ -1647,11 +2414,17 @@ snapshots:
 
   console-control-strings@1.1.0: {}
 
+  cookie@0.7.2: {}
+
+  data-uri-to-buffer@2.0.2: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  defu@6.1.7: {}
 
   delegates@1.0.0: {}
 
@@ -1679,6 +2452,31 @@ snapshots:
   err-code@2.0.3: {}
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.17.19:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.19
+      '@esbuild/android-arm64': 0.17.19
+      '@esbuild/android-x64': 0.17.19
+      '@esbuild/darwin-arm64': 0.17.19
+      '@esbuild/darwin-x64': 0.17.19
+      '@esbuild/freebsd-arm64': 0.17.19
+      '@esbuild/freebsd-x64': 0.17.19
+      '@esbuild/linux-arm': 0.17.19
+      '@esbuild/linux-arm64': 0.17.19
+      '@esbuild/linux-ia32': 0.17.19
+      '@esbuild/linux-loong64': 0.17.19
+      '@esbuild/linux-mips64el': 0.17.19
+      '@esbuild/linux-ppc64': 0.17.19
+      '@esbuild/linux-riscv64': 0.17.19
+      '@esbuild/linux-s390x': 0.17.19
+      '@esbuild/linux-x64': 0.17.19
+      '@esbuild/netbsd-x64': 0.17.19
+      '@esbuild/openbsd-x64': 0.17.19
+      '@esbuild/sunos-x64': 0.17.19
+      '@esbuild/win32-arm64': 0.17.19
+      '@esbuild/win32-ia32': 0.17.19
+      '@esbuild/win32-x64': 0.17.19
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1709,13 +2507,21 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escape-string-regexp@4.0.0: {}
+
+  estree-walker@0.6.1: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  exit-hook@2.2.1: {}
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  exsolve@1.0.8: {}
 
   fast-content-type-parse@3.0.0: {}
 
@@ -1746,9 +2552,16 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
+  get-source@2.0.12:
+    dependencies:
+      data-uri-to-buffer: 2.0.2
+      source-map: 0.6.1
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob-to-regexp@0.4.1: {}
 
   glob@7.2.3:
     dependencies:
@@ -1770,6 +2583,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   has-unicode@2.0.1: {}
+
+  hono@4.12.17: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -1819,6 +2634,9 @@ snapshots:
 
   ip-address@10.2.0: {}
 
+  is-arrayish@0.3.4:
+    optional: true
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-lambda@1.0.1: {}
@@ -1832,6 +2650,10 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.25.9:
+    dependencies:
+      sourcemap-codec: 1.4.8
 
   magic-string@0.30.21:
     dependencies:
@@ -1858,6 +2680,25 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
+
+  mime@3.0.0: {}
+
+  miniflare@3.20250718.3:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.2
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.29.0
+      workerd: 1.20250718.0
+      ws: 8.18.0
+      youch: 3.3.4
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimatch@3.1.5:
     dependencies:
@@ -1912,6 +2753,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mustache@4.2.0: {}
+
   nanoid@3.3.12: {}
 
   negotiator@0.6.4: {}
@@ -1956,6 +2799,8 @@ snapshots:
       gauge: 4.0.4
       set-blocking: 2.0.0
 
+  ohash@2.0.11: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -1965,6 +2810,8 @@ snapshots:
       aggregate-error: 3.1.0
 
   path-is-absolute@1.0.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -1994,6 +2841,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  printable-characters@1.0.42: {}
+
   promise-inflight@1.0.1: {}
 
   promise-retry@2.0.1:
@@ -2014,6 +2863,20 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rollup-plugin-inject@3.0.2:
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.9
+      rollup-pluginutils: 2.8.2
+
+  rollup-plugin-node-polyfills@0.2.1:
+    dependencies:
+      rollup-plugin-inject: 3.0.2
+
+  rollup-pluginutils@2.8.2:
+    dependencies:
+      estree-walker: 0.6.1
 
   rollup@4.60.2:
     dependencies:
@@ -2055,9 +2918,41 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+    optional: true
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
+    optional: true
 
   smart-buffer@4.2.0: {}
 
@@ -2078,13 +2973,24 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
+  sourcemap-codec@1.4.8: {}
+
   ssri@9.0.1:
     dependencies:
       minipass: 3.3.6
 
   stackback@0.0.2: {}
 
+  stacktracey@2.2.0:
+    dependencies:
+      as-table: 1.0.55
+      get-source: 2.0.12
+
   std-env@3.10.0: {}
+
+  stoppable@1.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2138,6 +3044,9 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tslib@2.8.1:
+    optional: true
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
@@ -2147,7 +3056,21 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  ufo@1.6.4: {}
+
   undici-types@6.21.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  unenv@2.0.0-rc.14:
+    dependencies:
+      defu: 6.1.7
+      exsolve: 1.0.8
+      ohash: 2.0.11
+      pathe: 2.0.3
+      ufo: 1.6.4
 
   unique-filename@2.0.1:
     dependencies:
@@ -2256,8 +3179,46 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  workerd@1.20250718.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20250718.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250718.0
+      '@cloudflare/workerd-linux-64': 1.20250718.0
+      '@cloudflare/workerd-linux-arm64': 1.20250718.0
+      '@cloudflare/workerd-windows-64': 1.20250718.0
+
+  wrangler@3.114.17(@cloudflare/workers-types@4.20260506.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@cloudflare/unenv-preset': 2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      esbuild: 0.17.19
+      miniflare: 3.20250718.3
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.14
+      workerd: 1.20250718.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260506.1
+      fsevents: 2.3.3
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrappy@1.0.2: {}
+
+  ws@8.18.0: {}
 
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  youch@3.3.4:
+    dependencies:
+      cookie: 0.7.2
+      mustache: 4.2.0
+      stacktracey: 2.2.0
+
+  zod@3.22.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "examples/*"


### PR DESCRIPTION
## Summary

Two runnable example apps under `examples/`, workspace-linked to the local packages so changes flow through immediately:

1. **`examples/cloudflare-worker/`** — Hono on Cloudflare Worker (via \`wrangler dev\`) + \`@mizchi/server-faults\` (with \`metadataHeader: true\` and \`bypassHeader\`) + chaosbringer driver (with \`server: { mode: "remote" }\`). Demonstrates the orchestration shipped in #74 / #75 end-to-end. Condensed shape of the upstream \`otel-chaos-lab\` repo, OTel pipeline omitted to keep focus.
2. **`examples/playwright-test/`** — chaosbringer inside an \`@playwright/test\` suite via the \`chaos\` fixture. Shows both \`chaosTest\` (chaos-as-the-file's-purpose) and \`withChaos()\` extension (chaos-as-an-additional-tool) patterns in one \`tests/chaos.spec.ts\`. Tiny static \`node:http\` server as the SUT.

\`pnpm-workspace.yaml\` learns \`examples/*\` so workspace \`chaosbringer\` and \`@mizchi/server-faults\` references resolve to the local packages.

## Why now

User-facing docs (PR #76) explain the recipes in prose; runnable examples prove the recipes actually compose. The Cloudflare Worker example also serves as the public, runnable replacement for the otel-chaos-lab sandbox — ours is a Cloudflare Worker shape that anyone can clone and run with one command.

## Test plan

- [x] \`pnpm install\` resolves the workspace (4.2s, no errors).
- [x] \`pnpm exec tsc --noEmit\` clean in both \`examples/cloudflare-worker\` and \`examples/playwright-test\`.
- [x] \`node site/server.mjs\` boots the playwright-test fixture site on port 3300.
- [x] \`pnpm exec wrangler --version\` finds the binary in \`examples/cloudflare-worker\` (v3.114.17).
- [ ] Full e2e — \`pnpm dev\` + \`pnpm chaos\` round-trip, and \`pnpm test\` Playwright run — to be verified by the reviewer (would require \`playwright install chromium\` on a fresh checkout).

## Out of scope

- README.md update referencing \`examples/\` is intentionally NOT in this PR — the docs PR #76 rewrites the same file. Add the cross-reference in a follow-up after both land to avoid a merge conflict.
- More frameworks (Express, Next.js): one Cloudflare-shape and one Playwright-Test-shape example covers the two distinct user journeys; same-shape duplicates can land if requested.