### PR TITLE
feat(chaosbringer): per-page + per-action server-fault correlation (#56 Phase 2)

### DIFF
--- a/docs/recipes/server-side-correlation.md
+++ b/docs/recipes/server-side-correlation.md
@@ -140,26 +140,52 @@ SEED=$CHAOS_SEED pnpm chaos
 
 The chaosbringer report's `Repro:` line includes only chaosbringer's own seed (the network-layer roll). The server-side seed is the operator's responsibility — write it next to the Repro line or in your run log.
 
+## Activation matrix
+
+Two chaos options interact to populate the four fault-related fields on the report:
+
+| `chaos({ traceparent })` | `chaos({ server: { mode: "remote" } })` | What's populated |
+|---|---|---|
+| absent | absent | nothing |
+| absent | set | `report.serverFaults`, `pages[].serverFaultEvents`. No per-action attribution (no trace-ids to join on). |
+| set | absent | `actions[].traceIds` (record-only). No fault events anywhere. |
+| set | set | All four. The intended Phase 2 surface — see the example at `examples/cloudflare-worker/chaos/run.ts`. |
+
+If the per-action `serverFaultEvents` field is empty when you expected it to be populated, the
+diagnosis is almost always one of:
+- `traceparent: true` was not set on `chaos()`.
+- The action triggered no requests (scroll, hover) — it carried no trace-ids to join on.
+- The fault fired during a navigation that ended on a different page than the one the action
+  was issued on. The flat `report.serverFaults[]` is still the source of truth in those cases.
+
 ## Verification
 
 After a run with `CHAOS_5XX_RATE=0.3`:
 
 ```ts
-const fivexx = report.serverFaults?.filter(e => e.attrs.kind === "5xx") ?? [];
+const fivexx = report.serverFaults?.filter((e) => e.attrs.kind === "5xx") ?? [];
 console.log(`server-side 5xx: ${fivexx.length}`);
 
-// join with chaosbringer actions by traceparent (when implemented in your stack):
-for (const action of report.actions) {
-  const trace = action.traceparent?.match(/^00-([0-9a-f]{32})/)?.[1];
-  if (!trace) continue;
-  const matchingFaults = report.serverFaults?.filter(e => e.traceId === trace) ?? [];
-  if (matchingFaults.length > 0) {
-    console.log(`action ${action.target} → ${matchingFaults.length} server fault(s)`);
+// "What server faults fired on the page that broke?"
+const failed = report.pages.filter((p) => p.errors.length > 0);
+for (const p of failed) {
+  const events = p.serverFaultEvents ?? [];
+  if (events.length > 0) {
+    console.log(p.url, events.map((e) => `${e.attrs.kind} ${e.attrs.path}`));
   }
+}
+
+// "Which click triggered the 503?"
+for (const f of fivexx) {
+  const action = report.actions.find((a) => a.serverFaultEvents?.includes(f));
+  console.log(`5xx on ${f.attrs.path} → triggered by`, action?.target ?? "(no action attribution)");
 }
 ```
 
-The `traceId` join is the load-bearing primitive: same `traceparent` on the wire → same value in `report.serverFaults[].traceId` → same value emitted on OTel attributes via `toOtelAttrs(attrs)` in any downstream observability layer.
+The trace-id join is the load-bearing primitive: same `traceparent` on the wire → same value in
+`report.actions[i].traceIds` → same value in `report.serverFaults[].traceId` → the report
+pre-computes the per-action match for you. Same value emitted on OTel attributes via
+`toOtelAttrs(attrs)` in any downstream observability layer.
 
 ## OTel exporter integration
 

--- a/docs/recipes/server-side-correlation.md
+++ b/docs/recipes/server-side-correlation.md
@@ -8,7 +8,7 @@
 - You want to know "did the 503 in this report come from the chaos network layer (chaosbringer's `faults.status(500, …)`) or from inside the server (`@mizchi/server-faults`'s `status5xxRate`)?"
 - You want to grep the resulting report by `traceId` and find every fault — network and server-side — that affected a single Playwright action.
 
-## Architecture (Phase 1, separate-process mode)
+## Architecture (separate-process mode)
 
 ```
 Browser (Playwright)              Server process
@@ -210,16 +210,15 @@ const fault = serverFaults({
 
 Now any downstream OTel consumer (Jaeger, Tempo, Honeycomb, Datadog) can filter spans by `fault.kind="5xx"` or join chaos events to user spans by `fault.trace_id`.
 
-## Limitations of Phase 1
+## Limitations
 
-- **Seed propagation is manual.** Future work may add automatic seed broadcast.
-- **Same-process integration (`server: ServerFaultHandle`) is not implemented.** Phase 2 will let the test runner pass the handle directly, share an in-memory observer, and skip the response-header round-trip. Useful for unit tests where the test driver imports the app.
-- **Per-action correlation is post-hoc.** `report.serverFaults` is a flat list; consumers join by `traceId` themselves. A trace-id-indexed dict on `ActionResult` is design-deferred.
+- **Seed propagation is manual.** Both processes must be started with the same seed env var. Future work may add automatic seed broadcast.
+- **Same-process integration (`server: ServerFaultHandle`) is not implemented.** Useful for unit tests where the test driver imports the app and calls `app.fetch()` directly; would skip the response-header round-trip and share an in-memory observer. No demand surfaced yet, deferred.
 
 ## Related
 
-- Spec: [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`](../superpowers/specs/2026-05-06-chaos-server-orchestration-design.md) (internal design rationale)
+- Phase 1 spec: [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-design.md`](../superpowers/specs/2026-05-06-chaos-server-orchestration-design.md) (header round-trip + flat `report.serverFaults`)
+- Phase 2 spec: [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md`](../superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md) (per-page + per-action joins)
 - Issue: [`#56`](https://github.com/mizchi/chaosbringer/issues/56)
-- PR 1 (server-faults): [`#74`](https://github.com/mizchi/chaosbringer/pull/74)
-- PR 2 (chaosbringer): [`#75`](https://github.com/mizchi/chaosbringer/pull/75)
 - Seeding pattern: [`docs/recipes/seeding-data.md`](seeding-data.md)
+- Runnable demo: [`examples/cloudflare-worker/`](../../examples/cloudflare-worker/)

--- a/docs/superpowers/plans/2026-05-06-chaos-correlation-phase-2.md
+++ b/docs/superpowers/plans/2026-05-06-chaos-correlation-phase-2.md
@@ -1,0 +1,983 @@
+# Chaos × server-faults orchestration Phase 2 — per-page + per-action correlation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface server-side fault events on `PageResult` (filtered by `pageUrl`) and on `ActionResult` (joined by W3C trace-id), eliminating the manual filter boilerplate the Phase 1 recipe gestures at.
+
+**Architecture:** Both fields are derived views computed in `ChaosCrawler.generateReport()` from the existing flat `report.serverFaults`. Per-page join is by `pageUrl`. Per-action join requires capturing trace-ids during the action's execution window via a new `currentAction` pointer in the crawler that the traceparent injection site appends into.
+
+**Tech Stack:** TypeScript, vitest, Playwright (existing chaosbringer dependencies).
+
+**Spec:** [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md`](../specs/2026-05-06-chaos-server-orchestration-phase-2-design.md)
+
+**Repository root for paths:** `/Users/mz/ghq/github.com/mizchi/chaosbringer/`. All file paths below are relative to it. Branch (already created): `feat/chaos-correlation-phase-2`. Spec commit `ca99aa8` is the base.
+
+**Sequencing:** All tasks land on the same branch, one PR. Tasks are ordered so each commit leaves the repo green (`pnpm -F chaosbringer test` + `pnpm -F chaosbringer build`).
+
+---
+
+## Task 1: Extend `types.ts` with the three new optional fields
+
+**Files:**
+- Modify: `packages/chaosbringer/src/types.ts:432-489` (`PageResult` and `ActionResult` interfaces)
+
+This task adds the public type surface. No behaviour change — `serverFaultEvents` and `traceIds` stay `undefined` everywhere until Tasks 2-4 populate them. Tests that introspect types still compile.
+
+- [ ] **Step 1: Add `serverFaultEvents` to `PageResult`**
+
+In `packages/chaosbringer/src/types.ts`, locate `export interface PageResult { … }` (starts at line 432). Append the new optional field at the END of the interface body, immediately before the closing `}`:
+
+```ts
+  /**
+   * Server-side fault events that fired while this page was active.
+   * Pre-computed view of `report.serverFaults` filtered by `pageUrl`.
+   * Populated only when `chaos({ server: { mode: "remote" } })` was set
+   * AND faults were observed on this page; absent otherwise.
+   *
+   * References are shared with `report.serverFaults[]` — no duplication.
+   */
+  serverFaultEvents?: ServerFaultEvent[];
+```
+
+- [ ] **Step 2: Add `traceIds` and `serverFaultEvents` to `ActionResult`**
+
+In the same file, locate `export interface ActionResult { … }` (starts at line 484). Append the two new optional fields at the END of the interface body, immediately before the closing `}`:
+
+```ts
+  /**
+   * W3C trace-ids of requests triggered while this action was executing.
+   * Populated only when `chaos({ traceparent: true })` is set. Absent for
+   * actions that triggered no requests (scroll, hover) or when traceparent
+   * injection is off.
+   */
+  traceIds?: string[];
+  /**
+   * Server-side fault events whose `traceId` is in `traceIds[]`. Pre-
+   * computed view of `report.serverFaults` per action. Populated only when
+   * `chaos({ traceparent: true, server: { mode: "remote" } })` is BOTH set
+   * AND at least one fault joined to this action.
+   */
+  serverFaultEvents?: ServerFaultEvent[];
+```
+
+- [ ] **Step 3: Verify build is clean**
+
+```bash
+cd /Users/mz/ghq/github.com/mizchi/chaosbringer
+pnpm -F chaosbringer build
+```
+
+Expected: `tsc` reports zero errors. (No tests should break — fields are optional.)
+
+- [ ] **Step 4: Verify tests are still green**
+
+```bash
+pnpm -F chaosbringer test
+```
+
+Expected: all green. The shape change is additive; nothing tests against the *absence* of these fields with type-equality strictness.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/chaosbringer/src/types.ts
+git commit -m "feat(chaosbringer): add PageResult.serverFaultEvents + ActionResult.traceIds/serverFaultEvents (no behaviour)"
+```
+
+---
+
+## Task 2: Capture trace-ids per action via `currentAction` pointer
+
+**Files:**
+- Modify: `packages/chaosbringer/src/crawler.ts` — add private field, hook into traceparent injection, manage lifecycle in the action loop.
+
+This task wires the crawler so that every traceparent injected during action `N` lands in `actions[N].traceIds`. No join with serverFaults yet — that's Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/chaosbringer/src/server-fault-correlation.test.ts`:
+
+```ts
+/**
+ * Phase 2 — per-action and per-page correlation in `generateReport`.
+ *
+ * These tests exercise the join logic via a thin harness that manipulates
+ * a `ChaosCrawler` instance's internal state (results, actions, collector)
+ * and then triggers report generation. We avoid spinning up Playwright /
+ * the fixture server because the join logic is pure data manipulation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ChaosCrawler } from "./crawler.js";
+import { ServerFaultCollector } from "./server-fault-collector.js";
+import type { PageResult, ActionResult, ServerFaultEvent } from "./types.js";
+
+function freshCrawler(): ChaosCrawler {
+  // baseUrl is the only required option; everything else defaults.
+  return new ChaosCrawler({ baseUrl: "https://app.test" });
+}
+
+function pushPage(crawler: ChaosCrawler, url: string): PageResult {
+  const result: PageResult = {
+    url,
+    status: "success",
+    statusCode: 200,
+    loadTime: 0,
+    errors: [],
+    warnings: [],
+    blockedNavigations: [],
+    discoveredLinks: [],
+    actions: [],
+    metrics: {},
+    hasErrors: false,
+  };
+  // The crawler tracks visited pages in `this.results`. Tests reach in via
+  // the same field name the production code uses.
+  (crawler as unknown as { results: PageResult[] }).results.push(result);
+  return result;
+}
+
+function pushAction(crawler: ChaosCrawler, action: ActionResult): ActionResult {
+  (crawler as unknown as { actions: ActionResult[] }).actions.push(action);
+  return action;
+}
+
+function pushFault(crawler: ChaosCrawler, ev: ServerFaultEvent): void {
+  // The crawler holds a `serverFaultCollector` only when
+  // `server.mode === "remote"`; for the test we install one ourselves.
+  const internal = crawler as unknown as { serverFaultCollector: ServerFaultCollector | null };
+  if (!internal.serverFaultCollector) {
+    internal.serverFaultCollector = new ServerFaultCollector("x-chaos-fault");
+  }
+  // Build matching headers for the collector to parse.
+  const headers = new Headers({
+    "x-chaos-fault-kind": ev.attrs.kind,
+    "x-chaos-fault-path": ev.attrs.path,
+    "x-chaos-fault-method": ev.attrs.method,
+  });
+  if (ev.attrs.targetStatus !== undefined) {
+    headers.set("x-chaos-fault-target-status", String(ev.attrs.targetStatus));
+  }
+  if (ev.attrs.latencyMs !== undefined) {
+    headers.set("x-chaos-fault-latency-ms", String(ev.attrs.latencyMs));
+  }
+  if (ev.traceId) {
+    headers.set("x-chaos-fault-trace-id", ev.traceId);
+  }
+  internal.serverFaultCollector.observe({ headers, pageUrl: ev.pageUrl });
+}
+
+describe("traceIds capture during action execution", () => {
+  it("appends trace-ids to currentAction during the action's window", () => {
+    const crawler = freshCrawler();
+    const action: ActionResult = {
+      type: "click",
+      target: "Save",
+      success: true,
+      timestamp: Date.now(),
+    };
+    // Simulate the action loop: set currentAction before execution.
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = action;
+    // Simulate the injection site calling the internal hook for two requests.
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+      "00000000000000000000000000000001",
+    );
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+      "00000000000000000000000000000002",
+    );
+    expect(action.traceIds).toEqual([
+      "00000000000000000000000000000001",
+      "00000000000000000000000000000002",
+    ]);
+  });
+
+  it("ignores recordTraceId calls when no action is current", () => {
+    const crawler = freshCrawler();
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = null;
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+      "00000000000000000000000000000003",
+    );
+    // No state to assert against; just verify it does not throw.
+    expect(true).toBe(true);
+  });
+
+  it("attributes trace-ids to the most recent action when called between actions", () => {
+    const crawler = freshCrawler();
+    const a1: ActionResult = { type: "click", target: "A", success: true, timestamp: 0 };
+    const a2: ActionResult = { type: "click", target: "B", success: true, timestamp: 1 };
+
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = a1;
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("a1-trace");
+
+    // Next iteration begins — currentAction is reassigned.
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = a2;
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("a2-trace");
+
+    expect(a1.traceIds).toEqual(["a1-trace"]);
+    expect(a2.traceIds).toEqual(["a2-trace"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm -F chaosbringer test -- server-fault-correlation.test.ts
+```
+
+Expected: 3 tests fail. Likely shapes:
+- `currentAction` field doesn't exist on the crawler — assignment via cast appears to "succeed" but the production code never reads it; the `recordTraceId` cast fails because the method doesn't exist (`recordTraceId is not a function`).
+
+- [ ] **Step 3: Add `currentAction` field + `recordTraceId` method**
+
+In `packages/chaosbringer/src/crawler.ts`, locate the `ChaosCrawler` class (search for `export class ChaosCrawler`). Find the section where private fields are declared (look for the cluster of `private readonly` and `private` declarations in the constructor area, near `private readonly serverFaultCollector`). Append a new private field next to `serverFaultCollector`:
+
+```ts
+  /**
+   * Set by the action loop immediately before each `performActionOnTarget`
+   * call; cleared at the start of the next iteration. The traceparent
+   * injection site uses `recordTraceId` to append captured trace-ids onto
+   * this action's `traceIds[]`.
+   */
+  private currentAction: ActionResult | null = null;
+```
+
+Add a private method on the same class. Place it next to similar utility methods (e.g. near `coverageWeightFor`):
+
+```ts
+  /**
+   * Append a trace-id to the currently-executing action, if any. Called
+   * from the per-request traceparent injection in `setupNavigationBlocking`.
+   * No-op when no action is in flight (e.g. during initial page load).
+   */
+  private recordTraceId(traceId: string): void {
+    if (!this.currentAction) return;
+    if (!this.currentAction.traceIds) this.currentAction.traceIds = [];
+    this.currentAction.traceIds.push(traceId);
+  }
+```
+
+- [ ] **Step 4: Run unit tests, observe pass**
+
+```bash
+pnpm -F chaosbringer test -- server-fault-correlation.test.ts
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Wire `currentAction` into the action loop**
+
+In `crawler.ts`, locate the action loop (search for `actionsPerformed < this.options.maxActionsPerPage`, around line 1989). The current loop body looks like:
+
+```ts
+const result = await this.performActionOnTarget(page, selectedTarget, url);
+
+// Skip null results (element not visible)
+if (result === null) {
+  this.logger.debug("action_skipped", { target: selectedTarget.name || selectedTarget.selector, reason: "not visible" });
+  continue;
+}
+
+actionsPerformed++;
+this.actions.push(result);
+```
+
+Wrap so `currentAction` is set immediately before `performActionOnTarget` and cleared at the start of the *next* loop iteration (so late-firing requests still attach to the action that triggered them). Replace the loop's prelude to look like:
+
+```ts
+while (actionsPerformed < this.options.maxActionsPerPage && attempts < maxAttempts) {
+  attempts++;
+
+  // Clear at the start of each iteration. Late-firing requests from the
+  // previous action attach to the previous action; once we begin the next,
+  // attribution is the current iteration's responsibility.
+  this.currentAction = null;
+
+  const advisorPick = await this.consultAdvisorIfStalled(page, url, targets);
+  const selectedTarget =
+    advisorPick ??
+    weightedPick(
+      targets,
+      (t) => t.weight * this.coverageWeightFor(url, t.selector),
+      this.rng,
+    );
+
+  // Build a placeholder ActionResult ahead of the call so traceIds captured
+  // during execution land on the right object. We mutate the SAME instance
+  // returned by performActionOnTarget below.
+  const placeholder: ActionResult = {
+    type: "click", // overwritten by performActionOnTarget on success
+    target: selectedTarget.name ?? selectedTarget.selector,
+    selector: selectedTarget.selector,
+    success: false,
+    timestamp: Date.now(),
+  };
+  this.currentAction = placeholder;
+
+  const result = await this.performActionOnTarget(page, selectedTarget, url);
+
+  if (result === null) {
+    this.logger.debug("action_skipped", { target: selectedTarget.name || selectedTarget.selector, reason: "not visible" });
+    continue;
+  }
+
+  // Carry over any traceIds captured against the placeholder onto the
+  // real result. (performActionOnTarget returns a fresh ActionResult.)
+  if (placeholder.traceIds) result.traceIds = placeholder.traceIds;
+  this.currentAction = result;
+
+  actionsPerformed++;
+  this.actions.push(result);
+```
+
+Leave the rest of the loop body unchanged.
+
+After the loop exits (the `}` that closes the `while`), add one line so trace-ids fired AFTER the loop's last iteration but BEFORE the page closes still attach to the last action:
+
+```ts
+} // end while
+// Last action stays current until the page closes — late-firing requests
+// from the final iteration are still attributed correctly. The crawler
+// will set currentAction = null at the next page's loop entry.
+```
+
+(If the loop's closing brace already has trailing code, place the comment as a comment-only line; no functional change is needed at the bottom.)
+
+- [ ] **Step 6: Verify the wiring compiles**
+
+```bash
+pnpm -F chaosbringer build
+```
+
+Expected: tsc reports zero errors.
+
+- [ ] **Step 7: Verify the unit-test suite is still green**
+
+```bash
+pnpm -F chaosbringer test -- server-fault-correlation.test.ts
+```
+
+Expected: 3 tests still pass (the placeholder/result carry-over doesn't affect the unit test, which manipulates `currentAction` directly).
+
+- [ ] **Step 8: Verify the full chaosbringer suite is green**
+
+```bash
+pnpm -F chaosbringer test
+```
+
+Expected: full suite green. Action loop continues to work the same way; we just added bookkeeping.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/chaosbringer/src/crawler.ts packages/chaosbringer/src/server-fault-correlation.test.ts
+git commit -m "feat(chaosbringer): track currentAction + recordTraceId for per-action correlation"
+```
+
+---
+
+## Task 3: Hook `recordTraceId` into the traceparent injection site
+
+**Files:**
+- Modify: `packages/chaosbringer/src/crawler.ts:1170-1200` (the `setupNavigationBlocking` route handler — synthesised-traceparent branch).
+
+The previous task added the bookkeeping; this one connects the existing traceparent generator to it. After this task, the crawler's behaviour matches what Task 2's tests asserted *via direct hook calls*.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `packages/chaosbringer/src/server-fault-correlation.test.ts`:
+
+```ts
+describe("traceparent.onInject feeds recordTraceId", () => {
+  it("invokes recordTraceId for each synthesised traceparent", () => {
+    const crawler = freshCrawler();
+    const action: ActionResult = { type: "click", target: "x", success: true, timestamp: 0 };
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = action;
+
+    // Simulate two synthesised injections by calling recordTraceId directly,
+    // mirroring what the in-route handler does.
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("aa".repeat(16));
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("bb".repeat(16));
+
+    expect(action.traceIds).toEqual(["aa".repeat(16), "bb".repeat(16)]);
+  });
+});
+```
+
+This is a smoke check that the call surface exists and the trace-ids land. The actual route-handler integration is exercised end-to-end by the `examples/cloudflare-worker` test (Task 5).
+
+- [ ] **Step 2: Run, observe pass**
+
+```bash
+pnpm -F chaosbringer test -- server-fault-correlation.test.ts
+```
+
+Expected: 4 tests pass (the new one + the 3 from Task 2).
+
+- [ ] **Step 3: Wire the route handler to call `recordTraceId`**
+
+In `packages/chaosbringer/src/crawler.ts`, find the synthesised-traceparent branch in `setupNavigationBlocking`. The current code (around line 1187–1199) is:
+
+```ts
+} else {
+  const traceId = randomBytes(16).toString("hex"); // 32 hex chars
+  const spanId = randomBytes(8).toString("hex"); // 16 hex chars
+  const traceparent = `00-${traceId}-${spanId}-01`;
+  outgoingHeaders = { ...reqHeaders, traceparent };
+  traceparentHook?.({
+    url,
+    method,
+    traceparent,
+    traceId,
+    spanId,
+    existing: false,
+  });
+}
+```
+
+Add ONE line — the internal hook fires BEFORE the user-supplied hook so the report state is consistent regardless of what the user does in their callback:
+
+```ts
+} else {
+  const traceId = randomBytes(16).toString("hex"); // 32 hex chars
+  const spanId = randomBytes(8).toString("hex"); // 16 hex chars
+  const traceparent = `00-${traceId}-${spanId}-01`;
+  outgoingHeaders = { ...reqHeaders, traceparent };
+  this.recordTraceId(traceId);
+  traceparentHook?.({
+    url,
+    method,
+    traceparent,
+    traceId,
+    spanId,
+    existing: false,
+  });
+}
+```
+
+Do the SAME for the `existing` traceparent branch (around line 1170–1185). Find:
+
+```ts
+if (existingTp) {
+  // Honour explicit propagation upstream — but still surface it to
+  // the consumer hook so the report can record the correlation id.
+  if (traceparentHook) {
+    const parts = parseTraceparent(existingTp);
+    traceparentHook({
+      url,
+      method,
+      traceparent: existingTp,
+      traceId: parts?.traceId ?? "",
+      spanId: parts?.spanId ?? "",
+      existing: true,
+    });
+  }
+}
+```
+
+Modify so the trace-id from an upstream-supplied traceparent ALSO records to the current action (it's still the action that triggered the request):
+
+```ts
+if (existingTp) {
+  const parts = parseTraceparent(existingTp);
+  if (parts?.traceId) this.recordTraceId(parts.traceId);
+  if (traceparentHook) {
+    traceparentHook({
+      url,
+      method,
+      traceparent: existingTp,
+      traceId: parts?.traceId ?? "",
+      spanId: parts?.spanId ?? "",
+      existing: true,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Verify build is clean**
+
+```bash
+pnpm -F chaosbringer build
+```
+
+Expected: tsc reports zero errors.
+
+- [ ] **Step 5: Verify full chaosbringer suite is green**
+
+```bash
+pnpm -F chaosbringer test
+```
+
+Expected: full suite green. The route handler change is invoked only when `traceparentEnabled`, which existing tests don't toggle.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/chaosbringer/src/crawler.ts packages/chaosbringer/src/server-fault-correlation.test.ts
+git commit -m "feat(chaosbringer): record per-action trace-ids at the traceparent injection site"
+```
+
+---
+
+## Task 4: Compute the per-page and per-action joins in `generateReport`
+
+**Files:**
+- Modify: `packages/chaosbringer/src/crawler.ts` — `generateReport()` method (around line 2280).
+
+This is the only task that produces user-visible behaviour. After it, `report.pages[i].serverFaultEvents` and `report.actions[i].serverFaultEvents` are populated whenever the input data warrants it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/chaosbringer/src/server-fault-correlation.test.ts`:
+
+```ts
+describe("generateReport joins serverFaults onto pages and actions", () => {
+  function callGenerateReport(crawler: ChaosCrawler) {
+    // generateReport is private. We invoke it via the public start() path
+    // is too heavy; instead reach in directly with a cast.
+    return (crawler as unknown as {
+      generateReport: (endTime: number) => import("./types.js").CrawlReport;
+    }).generateReport(Date.now());
+  }
+
+  it("populates PageResult.serverFaultEvents by pageUrl", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    pushPage(crawler, "https://app.test/b");
+    pushFault(crawler, {
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503 },
+    });
+    pushFault(crawler, {
+      pageUrl: "https://app.test/b",
+      observedAt: 110,
+      attrs: { kind: "latency", path: "/api/y", method: "POST", latencyMs: 200 },
+    });
+
+    const report = callGenerateReport(crawler);
+    expect(report.serverFaults).toHaveLength(2);
+
+    const a = report.pages.find((p) => p.url === "https://app.test/a")!;
+    const b = report.pages.find((p) => p.url === "https://app.test/b")!;
+    expect(a.serverFaultEvents?.map((e) => e.attrs.path)).toEqual(["/api/x"]);
+    expect(b.serverFaultEvents?.map((e) => e.attrs.path)).toEqual(["/api/y"]);
+  });
+
+  it("omits serverFaultEvents on pages with no matching events", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    pushPage(crawler, "https://app.test/b");
+    pushFault(crawler, {
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503 },
+    });
+    const report = callGenerateReport(crawler);
+    const b = report.pages.find((p) => p.url === "https://app.test/b")!;
+    expect(b.serverFaultEvents).toBeUndefined();
+  });
+
+  it("populates ActionResult.serverFaultEvents by traceId", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    const action = pushAction(crawler, {
+      type: "click",
+      target: "Buy",
+      success: true,
+      timestamp: 1,
+      traceIds: ["aa".repeat(16), "bb".repeat(16)],
+    });
+    pushFault(crawler, {
+      traceId: "aa".repeat(16),
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: {
+        kind: "5xx",
+        path: "/api/x",
+        method: "POST",
+        targetStatus: 503,
+        traceId: "aa".repeat(16),
+      },
+    });
+    pushFault(crawler, {
+      traceId: "cc".repeat(16),
+      pageUrl: "https://app.test/a",
+      observedAt: 110,
+      attrs: { kind: "5xx", path: "/api/y", method: "GET", targetStatus: 500, traceId: "cc".repeat(16) },
+    });
+
+    const report = callGenerateReport(crawler);
+    expect(action.serverFaultEvents?.map((e) => e.attrs.path)).toEqual(["/api/x"]);
+  });
+
+  it("omits ActionResult.serverFaultEvents when traceIds is empty/absent", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    const noTraceAction = pushAction(crawler, {
+      type: "scroll",
+      target: "scrollY:200",
+      success: true,
+      timestamp: 1,
+    });
+    pushFault(crawler, {
+      traceId: "ee".repeat(16),
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503, traceId: "ee".repeat(16) },
+    });
+    const report = callGenerateReport(crawler);
+    expect(noTraceAction.serverFaultEvents).toBeUndefined();
+  });
+
+  it("references are shared between report.serverFaults and the joined views", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    pushFault(crawler, {
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503 },
+    });
+    const report = callGenerateReport(crawler);
+    const flat = report.serverFaults![0];
+    const onPage = report.pages[0].serverFaultEvents![0];
+    expect(onPage).toBe(flat);
+  });
+});
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+pnpm -F chaosbringer test -- server-fault-correlation.test.ts
+```
+
+Expected: 5 new tests fail (`serverFaultEvents` is `undefined` on every page / action).
+
+- [ ] **Step 3: Implement the joins in `generateReport`**
+
+In `packages/chaosbringer/src/crawler.ts`, locate `private generateReport(endTime: number): CrawlReport { … }` (around line 2263). Find the `serverFaults` field assignment (around line 2313):
+
+```ts
+      // Field is omitted when no faults observed (matches advisor / coverage convention).
+      serverFaults:
+        this.serverFaultCollector && this.serverFaultCollector.size() > 0
+          ? this.serverFaultCollector.drain()
+          : undefined,
+```
+
+Refactor so the drain happens BEFORE the report literal is built — we need the drained array for the per-page / per-action joins as well as for the field itself. Restructure as follows:
+
+a) Above the `return { …report literal… }` (or `const report = { … }`, depending on the existing shape), drain the collector once into a local:
+
+```ts
+    const drainedServerFaults =
+      this.serverFaultCollector && this.serverFaultCollector.size() > 0
+        ? this.serverFaultCollector.drain()
+        : null;
+
+    if (drainedServerFaults) {
+      // Per-page join — same references as the flat list.
+      for (const p of this.results) {
+        const events = drainedServerFaults.filter((e) => e.pageUrl === p.url);
+        if (events.length > 0) p.serverFaultEvents = events;
+      }
+      // Per-action join — only meaningful when traceparent injection is on
+      // (otherwise traceIds is always empty/absent).
+      for (const a of this.actions) {
+        if (!a.traceIds || a.traceIds.length === 0) continue;
+        const set = new Set(a.traceIds);
+        const events = drainedServerFaults.filter((e) => e.traceId !== undefined && set.has(e.traceId));
+        if (events.length > 0) a.serverFaultEvents = events;
+      }
+    }
+```
+
+b) Replace the `serverFaults: …` line in the report literal with:
+
+```ts
+      serverFaults: drainedServerFaults ?? undefined,
+```
+
+The total diff replaces one inline ternary with the local + post-loop block + one cleaner field reference.
+
+- [ ] **Step 4: Run unit tests, observe pass**
+
+```bash
+pnpm -F chaosbringer test -- server-fault-correlation.test.ts
+```
+
+Expected: all 8 tests in the file pass (3 from Task 2, 1 from Task 3, 5 from Task 4).
+
+- [ ] **Step 5: Verify full chaosbringer suite stays green**
+
+```bash
+pnpm -F chaosbringer test
+```
+
+Expected: full suite green.
+
+- [ ] **Step 6: Verify build**
+
+```bash
+pnpm -F chaosbringer build
+```
+
+Expected: tsc reports zero errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/chaosbringer/src/crawler.ts packages/chaosbringer/src/server-fault-correlation.test.ts
+git commit -m "feat(chaosbringer): join serverFaults onto PageResult + ActionResult in generateReport"
+```
+
+---
+
+## Task 5: Update the cf-worker example to demonstrate Phase 2
+
+**Files:**
+- Modify: `examples/cloudflare-worker/chaos/run.ts` — add `traceparent: true`, surface per-page/per-action stats.
+- Modify: `examples/cloudflare-worker/test.mjs` — assert at least one `serverFaultEvents` is attached.
+
+- [ ] **Step 1: Add `traceparent: true` to the example chaos call**
+
+In `examples/cloudflare-worker/chaos/run.ts`, locate the `chaos({ … })` call. Add `traceparent: true` as a top-level option, alongside `server: { mode: "remote" }`:
+
+```ts
+  const { passed, report } = await chaos({
+    baseUrl: BASE_URL,
+    seed: Number(process.env.SEED ?? "42"),
+    maxPages: Number(process.env.MAX_PAGES ?? "20"),
+    strict: false,
+    traceparent: true,
+    faultInjection: [
+      faults.status(500, { urlPattern: /\/api\/todos$/, methods: ["GET"], probability: 0.2 }),
+      faults.delay(2000, { urlPattern: /\/api\/todos/, probability: 0.1 }),
+    ],
+    server: { mode: "remote" },
+    invariants,
+    setup: async ({ page, baseUrl }) => {
+      …
+    },
+  });
+```
+
+- [ ] **Step 2: Surface per-page / per-action stats in the example output**
+
+In the same file, find the post-run `console.log` block (currently prints `pages=` / `errors=` / `server-side fault events: N`). After the existing summary, append:
+
+```ts
+  const pagesWithServerFaults = report.pages.filter((p) => p.serverFaultEvents && p.serverFaultEvents.length > 0);
+  const actionsWithServerFaults = report.actions.filter((a) => a.serverFaultEvents && a.serverFaultEvents.length > 0);
+  console.log(`pages with server faults: ${pagesWithServerFaults.length}`);
+  console.log(`actions with server faults: ${actionsWithServerFaults.length}`);
+```
+
+- [ ] **Step 3: Extend the test to assert at least one action carried a fault**
+
+In `examples/cloudflare-worker/test.mjs`, find the existing assertion block:
+
+```js
+const m = chaosStdout.match(/server-side fault events:\s*(\d+)/);
+if (!m) {
+  throw new Error("could not find 'server-side fault events: N' in chaos output — did the report formatting change?");
+}
+const n = Number(m[1]);
+if (!Number.isFinite(n) || n <= 0) {
+  throw new Error(`expected server-side fault events > 0 with CHAOS_5XX_RATE=0.5, got ${n}`);
+}
+```
+
+After it, add a similar grep for the new line:
+
+```js
+const ma = chaosStdout.match(/actions with server faults:\s*(\d+)/);
+if (!ma) {
+  throw new Error("could not find 'actions with server faults: N' in chaos output — did Phase 2 wiring break?");
+}
+const na = Number(ma[1]);
+if (!Number.isFinite(na) || na <= 0) {
+  throw new Error(`expected at least one action joined to a server fault via traceId, got ${na}`);
+}
+```
+
+Update the success log:
+
+```js
+console.log(`[test] PASS — ${n} fault events / ${na} actions joined via header round-trip`);
+```
+
+- [ ] **Step 4: Run the example test locally**
+
+```bash
+cd /Users/mz/ghq/github.com/mizchi/chaosbringer/examples/cloudflare-worker
+pnpm test
+```
+
+Expected: PASS with both N > 0 and na > 0. The line format printed by `chaos/run.ts` should be:
+
+```
+server-side fault events: 1
+pages with server faults: 1
+actions with server faults: 1
+[test] PASS — 1 fault events / 1 actions joined via header round-trip
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mz/ghq/github.com/mizchi/chaosbringer
+git add examples/cloudflare-worker/chaos/run.ts examples/cloudflare-worker/test.mjs
+git commit -m "test(examples/cloudflare-worker): exercise + assert Phase 2 per-action correlation"
+```
+
+---
+
+## Task 6: Rewrite the recipe to use the new fields
+
+**Files:**
+- Modify: `docs/recipes/server-side-correlation.md` — replace the manual-filter pseudo-code with the new fields and the activation matrix.
+
+The Phase 1 recipe gestured at `action.traceparent` which does not exist. With Phase 2, `report.pages[].serverFaultEvents` and `report.actions[].serverFaultEvents` are directly available.
+
+- [ ] **Step 1: Replace the verification section**
+
+In `docs/recipes/server-side-correlation.md`, locate the section beginning `## Verification`. Replace it with:
+
+```md
+## Verification
+
+After a run with `CHAOS_5XX_RATE=0.3`:
+
+\`\`\`ts
+const fivexx = report.serverFaults?.filter((e) => e.attrs.kind === "5xx") ?? [];
+console.log(`server-side 5xx: ${fivexx.length}`);
+
+// "What server faults fired on the page that broke?"
+const failed = report.pages.filter((p) => p.errors.length > 0);
+for (const p of failed) {
+  const events = p.serverFaultEvents ?? [];
+  if (events.length > 0) {
+    console.log(p.url, events.map((e) => `${e.attrs.kind} ${e.attrs.path}`));
+  }
+}
+
+// "Which click triggered the 503?"
+for (const f of fivexx) {
+  const action = report.actions.find((a) => a.serverFaultEvents?.includes(f));
+  console.log(`5xx on ${f.attrs.path} → triggered by`, action?.target ?? "(no action attribution)");
+}
+\`\`\`
+
+The trace-id join is the load-bearing primitive: same `traceparent` on the wire → same value in
+\`report.actions[i].traceIds\` → same value in \`report.serverFaults[].traceId\` → the report
+pre-computes the per-action match for you. Same value emitted on OTel attributes via
+\`toOtelAttrs(attrs)\` in any downstream observability layer.
+```
+
+- [ ] **Step 2: Add the activation matrix**
+
+Above the verification section (i.e. immediately after the existing "Step 3 — share the chaos seed" subsection), add:
+
+```md
+## Activation matrix
+
+Two chaos options interact to populate the four fault-related fields on the report:
+
+| `chaos({ traceparent })` | `chaos({ server: { mode: "remote" } })` | What's populated |
+|---|---|---|
+| absent | absent | nothing |
+| absent | set | `report.serverFaults`, `pages[].serverFaultEvents`. No per-action attribution (no trace-ids to join on). |
+| set | absent | `actions[].traceIds` (record-only). No fault events anywhere. |
+| set | set | All four. The intended Phase 2 surface — see the example at \`examples/cloudflare-worker/chaos/run.ts\`. |
+
+If the per-action `serverFaultEvents` field is empty when you expected it to be populated, the
+diagnosis is almost always one of:
+- \`traceparent: true\` was not set on \`chaos()\`.
+- The action triggered no requests (scroll, hover) — it carried no trace-ids to join on.
+- The fault fired during a navigation that ended on a different page than the one the action
+  was issued on. The flat \`report.serverFaults[]\` is still the source of truth in those cases.
+```
+
+- [ ] **Step 3: Verify the recipe renders cleanly**
+
+```bash
+# nothing to run — markdown is read by humans + GitHub. Skim the file for
+# obvious rendering issues (broken backticks, unclosed code fences).
+head -200 docs/recipes/server-side-correlation.md
+```
+
+Expected: the file ends without dangling backticks; the activation table renders as a markdown table.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/recipes/server-side-correlation.md
+git commit -m "docs(recipe): rewrite server-side-correlation for Phase 2 (per-page + per-action fields)"
+```
+
+---
+
+## Task 7: Open the PR
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full chaosbringer test suite + build one last time**
+
+```bash
+cd /Users/mz/ghq/github.com/mizchi/chaosbringer
+pnpm -F chaosbringer test
+pnpm -F chaosbringer build
+```
+
+Expected: green + tsc clean.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/chaos-correlation-phase-2
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat(chaosbringer): per-page + per-action server-fault correlation (#56 Phase 2)" --body "$(cat <<'EOF'
+## Summary
+- \`PageResult.serverFaultEvents?: ServerFaultEvent[]\` — server-side faults that fired while a page was active. Pre-computed view of \`report.serverFaults\` filtered by \`pageUrl\`.
+- \`ActionResult.traceIds?: string[]\` — W3C trace-ids of requests issued during an action's window. Captured at the chaosbringer traceparent injection site.
+- \`ActionResult.serverFaultEvents?: ServerFaultEvent[]\` — server-side faults whose \`traceId\` matches one of the action's \`traceIds\`. Pre-computed view of \`report.serverFaults\`.
+
+The flat \`report.serverFaults[]\` from Phase 1 is unchanged — both new fields are derived views over the same array. No data duplication, no breaking change.
+
+Spec: [\`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md\`](https://github.com/mizchi/chaosbringer/blob/feat/chaos-correlation-phase-2/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md)
+
+Closes the remaining work on #56 Phase 2 (per-action + per-page correlation). Same-process direct-handle (Option A in the brainstorm) and auto-seed propagation (Option C) remain explicitly out of scope.
+
+## Activation
+Both options have to be set for the full Phase 2 surface:
+\`\`\`ts
+await chaos({
+  …,
+  traceparent: true,
+  server: { mode: "remote" },
+});
+\`\`\`
+The activation matrix is documented in \`docs/recipes/server-side-correlation.md\`.
+
+## Test plan
+- [x] \`pnpm -F chaosbringer test\` — full suite green (including 9 new tests in \`server-fault-correlation.test.ts\`).
+- [x] \`pnpm -F chaosbringer build\` — tsc clean.
+- [x] \`examples/cloudflare-worker\` test extended to assert at least one action joined to a server fault via traceId.
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** types.ts (Task 1), currentAction tracking + recordTraceId (Tasks 2-3), generateReport joins (Task 4), example demonstration (Task 5), recipe rewrite (Task 6), PR (Task 7). The activation-matrix behaviour from spec §"Activation matrix" lands in Task 6's recipe; the runtime gating is implicit (fields stay absent without the right options) and is exercised by the negative test in Task 4 Step 1.
+- **No placeholders:** every task has concrete code in every code step. Test snippets are full not truncated. The injection-site edit shows the EXACT before/after.
+- **Type consistency:** `serverFaultEvents` is the SAME field name on both `PageResult` and `ActionResult`. `traceIds` is the only new field on `ActionResult`. `recordTraceId` is the only new private method on `ChaosCrawler`. `currentAction` is the only new private field. All match across tasks.
+- **Sequencing risk:** Task 2 leaves `currentAction` populated but unused at the route handler. Task 3 wires it. Each commit independently leaves the suite green because the route-handler change is gated on `traceparentEnabled` (existing tests don't toggle this). If the test runner finds Task 2's commit alone, all existing tests still pass — the new field/method are simply dead until Task 3.

--- a/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md
+++ b/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md
@@ -1,0 +1,220 @@
+# Chaos × server-faults orchestration — Phase 2: per-action and per-page correlation
+
+**Date:** 2026-05-06
+**Issue:** [chaosbringer#56](https://github.com/mizchi/chaosbringer/issues/56)
+**Status:** Approved (awaiting implementation plan)
+**Builds on:** [Phase 1 spec](2026-05-06-chaos-server-orchestration-design.md), shipped in PR #74 + #75.
+
+## Problem
+
+Phase 1 surfaced server-side fault events on `CrawlReport.serverFaults` as a flat array. To answer the natural investigation questions — *"which page was active when the fault fired?"* and *"which user action triggered the fault?"* — consumers must filter manually:
+
+```ts
+// the recipe at docs/recipes/server-side-correlation.md gestures at this
+for (const action of report.actions) {
+  const trace = action.traceparent?.match(/^00-([0-9a-f]{32})/)?.[1]; // ← does not exist
+  if (!trace) continue;
+  const matchingFaults = report.serverFaults?.filter(e => e.traceId === trace) ?? [];
+  …
+}
+```
+
+Two breakages:
+
+1. `ActionResult` does **not** record the traceparent. The recipe is aspirational. Consumers cannot in fact join by trace-id at the action level today.
+2. Even for page-level joins (where `ServerFaultEvent.pageUrl` is already populated), the user has to write the same `report.serverFaults.filter(e => e.pageUrl === page.url)` boilerplate every time.
+
+Phase 2 makes both joins first-class on the report.
+
+## Scope
+
+In scope (Phase 2 ships both as one PR — recipe rewrite is one pass):
+
+- **(γ) Per-page correlation:** `PageResult.serverFaultEvents?: ServerFaultEvent[]`, populated at report finalization by joining `report.serverFaults` on `pageUrl`.
+- **(α) Per-action correlation:** `ActionResult.traceIds?: string[]` and `ActionResult.serverFaultEvents?: ServerFaultEvent[]`, populated by capturing trace-ids during the action's execution window and joining `report.serverFaults` on those ids.
+
+Out of scope (separate Phase 2 sub-issues if needed):
+
+- Same-process integration (`server: ServerFaultHandle` direct passing). Original issue text proposed this, but no demand surfaced; defer.
+- Auto-seed propagation between processes. Requires a server-side control surface; defer.
+
+## Architecture
+
+### Per-page (γ) — pre-computed view
+
+`ServerFaultEvent` already carries `pageUrl: string`. The "join" is a `filter`. Pre-compute it once during `ChaosCrawler.generateReport()`:
+
+```ts
+for (const page of pages) {
+  const events = report.serverFaults?.filter(e => e.pageUrl === page.url);
+  if (events && events.length > 0) page.serverFaultEvents = events;
+}
+```
+
+References are shared between `report.serverFaults[]` and `page.serverFaultEvents[]` — no data duplication, just two views over the same array.
+
+### Per-action (α) — current-action tracking
+
+A click can fire N HTTP requests. Each request gets its own traceparent (PR #72). Action-level correlation needs to capture *all* trace-ids emitted while a given action is "in flight".
+
+Mechanism:
+
+1. `ChaosCrawler` keeps a private `currentAction: ActionResult | null` field.
+2. The action loop sets `this.currentAction = result` immediately before invoking `performActionOnTarget`, and clears it at the start of the next iteration (not at the end of the current action — late-firing requests after `click()` resolves should still attach).
+3. The traceparent injection site in `setupNavigationBlocking` already calls `traceparentHook?.({ traceId, … })`. Add an internal hook *before* that consumer hook that appends `traceId` to `this.currentAction?.traceIds ?? []`.
+4. When `currentAction` is `null` (between actions, during initial page load), trace-ids are still recorded on `report.serverFaults` (via Phase 1 wiring) and surface via `PageResult.serverFaultEvents`. They simply do not get a per-action attribution.
+
+Edge cases:
+
+- **Action triggers no requests** (scroll, hover): `traceIds` stays absent. `serverFaultEvents` stays absent. The empty-array distinction matters less than the absent-field signal.
+- **Action triggers requests *after* it appears to complete** (e.g. a click fires a fetch that resolves 500ms later, still during chaosbringer's `between actions` window): the fetch's trace-id is captured if the next action hasn't started yet; otherwise it attaches to the next action. This is approximate but matches what a human investigator would naturally infer.
+- **Navigation actions** that load a new page: the page-load requests fire under the click action's window. Captured. Subsequent in-page requests fire after the next action starts and attach there.
+
+### Data model changes (types.ts)
+
+```ts
+export interface PageResult {
+  // … existing fields …
+  /**
+   * Server-side fault events that fired while this page was active.
+   * Pre-computed view of `report.serverFaults` filtered by `pageUrl`.
+   * Populated only when `chaos({ server: { mode: "remote" } })` was set
+   * AND faults were observed on this page; absent otherwise.
+   */
+  serverFaultEvents?: ServerFaultEvent[];
+}
+
+export interface ActionResult {
+  // … existing fields …
+  /**
+   * W3C trace-ids of requests triggered while this action was executing.
+   * Populated only when `chaos({ traceparent: true })` is set. Empty for
+   * actions that triggered no requests (scroll, hover).
+   */
+  traceIds?: string[];
+  /**
+   * Server-side fault events whose `traceId` is in `traceIds[]`. Pre-
+   * computed view of `report.serverFaults` per action. Populated only when
+   * `chaos({ traceparent: true, server: { mode: "remote" } })` is both set.
+   */
+  serverFaultEvents?: ServerFaultEvent[];
+}
+```
+
+Both fields are additive. No breaking change to consumers.
+
+### Activation matrix
+
+| `traceparent` set | `server: { mode: "remote" }` set | What's populated |
+|---|---|---|
+| no | no | `report.serverFaults` absent. No correlation. |
+| no | yes | `report.serverFaults`, `PageResult.serverFaultEvents`. No `ActionResult.serverFaultEvents` (no trace-ids to join on). |
+| yes | no | `ActionResult.traceIds`. No fault events anywhere. |
+| yes | yes | All four fields populated. The intended Phase 2 surface. |
+
+The recipe at `docs/recipes/server-side-correlation.md` will be updated to require both options together for full correlation, with the activation matrix documented.
+
+## Component changes
+
+### `packages/chaosbringer/src/crawler.ts`
+
+1. Add `private currentAction: ActionResult | null = null;` to `ChaosCrawler`.
+2. In the per-page action loop (around line 2000), wrap each iteration:
+   ```ts
+   this.currentAction = candidateResult; // set BEFORE performActionOnTarget
+   const result = await this.performActionOnTarget(page, …);
+   // do NOT clear here — late-firing requests still attach
+   ```
+   Clear at the *start* of the next iteration (or at page-end finalisation).
+3. In `setupNavigationBlocking`, in the synthesised-traceparent branch (around line 1187), before the existing `traceparentHook?.(…)` call:
+   ```ts
+   if (this.currentAction) {
+     this.currentAction.traceIds ??= [];
+     this.currentAction.traceIds.push(traceId);
+   }
+   ```
+4. In `generateReport()` (around line 2280), after the existing `serverFaults` field is computed:
+   ```ts
+   if (drainedEvents.length > 0) {
+     // Per-page join
+     for (const p of this.pages) {
+       const events = drainedEvents.filter(e => e.pageUrl === p.url);
+       if (events.length > 0) p.serverFaultEvents = events;
+     }
+     // Per-action join (only when traceparent injection was on)
+     for (const a of this.actions) {
+       if (!a.traceIds || a.traceIds.length === 0) continue;
+       const set = new Set(a.traceIds);
+       const events = drainedEvents.filter(e => e.traceId && set.has(e.traceId));
+       if (events.length > 0) a.serverFaultEvents = events;
+     }
+   }
+   ```
+
+### `packages/chaosbringer/src/types.ts`
+
+Add the two optional fields per the model above with JSDoc explaining the activation requirements.
+
+### `packages/chaosbringer/src/server-fault-collector.ts`
+
+No change. The collector still produces flat events; the join is a generateReport-level concern.
+
+## Recipe updates
+
+`docs/recipes/server-side-correlation.md` is rewritten to:
+
+1. Replace the manual-filter pseudo-code with the new fields.
+2. Document the activation matrix (both options together for full correlation).
+3. Show the canonical investigation pattern:
+   ```ts
+   // "what server faults fired on the page that broke?"
+   const failedPages = report.pages.filter(p => p.errors.length > 0);
+   for (const p of failedPages) {
+     console.log(p.url, p.serverFaultEvents?.map(e => e.attrs.kind));
+   }
+   // "which click triggered the 503?"
+   const fivexx = report.serverFaults?.filter(e => e.attrs.kind === "5xx") ?? [];
+   for (const f of fivexx) {
+     const action = report.actions.find(a => a.serverFaultEvents?.includes(f));
+     console.log(`5xx on ${f.attrs.path} triggered by`, action?.target);
+   }
+   ```
+
+## examples/cloudflare-worker adoption
+
+`examples/cloudflare-worker/chaos/run.ts` adds `traceparent: true` to the `chaos()` options so the demo actually demonstrates Phase 2. The existing `test.mjs` continues to assert `server-side fault events: N > 0`; an additional grep can confirm at least one event is attached to an action (i.e. `report.actions[i].serverFaultEvents` non-empty).
+
+## Testing strategy
+
+### Unit tests (chaosbringer)
+
+- **Per-page join**: feed a fake `generateReport`-input state with synthetic events whose `pageUrl` matches some pages; assert `pages[i].serverFaultEvents` populated correctly. Pages with no events get no field.
+- **Per-action join**: synthetic state with `actions[i].traceIds` populated; assert `actions[i].serverFaultEvents` after join. Actions with no `traceIds` get no field.
+- **Activation matrix**: with traceparent off, assert `actions[i].serverFaultEvents` always absent. With server off, assert no fault-events anywhere.
+
+### Integration
+
+The cloudflare-worker example test (`examples/cloudflare-worker/test.mjs`) already runs the full stack. Extend the assertion: after `server-side fault events: N > 0` matches, also assert that *some* action carried a `serverFaultEvents` field (parse the report file directly). That pins the new wiring end-to-end.
+
+### Non-goals for tests
+
+- Behaviour of N concurrent actions (chaosbringer is single-action serial within a page; concurrency is out of scope).
+- Reconciling drift between Phase 1 collector timestamps and Phase 2 trace-id captures (the trace-id join is exact; timestamp-based fallback is unnecessary).
+
+## Risks and mitigations
+
+- **Action boundary races.** A late-firing request whose trace-id is captured AFTER `currentAction` was already cleared would land on the next action — incorrect attribution. Mitigated by clearing on next-action-start (not current-action-end). True races (request fires between iterations) are inherent to the asynchronous click→fetch model; document the heuristic.
+- **Memory: `traceIds[]` could grow on action-heavy pages.** A page with 50 actions × 5 requests each = 250 strings × 32 chars = ~8KB per page. Negligible.
+- **Backwards compatibility of `ActionResult` shape.** Adding optional fields is additive. Consumers iterating `report.actions[]` see no break.
+- **Same trace-id appearing in multiple actions.** Possible if the user retries an action OR the chaosbringer crawler aborts and reissues. Both fields surface the trace-id under whichever action was current at injection time. The fault event would attach to ALL actions whose `traceIds` contains it — the join uses `.includes`. In practice trace-ids are 32-hex random; collisions across actions are vanishingly unlikely.
+
+## Sequencing
+
+One PR:
+
+1. types.ts: add `PageResult.serverFaultEvents` + `ActionResult.traceIds` + `ActionResult.serverFaultEvents`. Test for shape only (no behaviour).
+2. crawler.ts: `currentAction` tracking, internal trace-id hook, generateReport joins. Unit tests pass.
+3. Recipe rewrite + example update + test extension.
+4. Open PR; merge after CI green.
+
+No upstream `@mizchi/server-faults` changes required. Phase 2 is chaosbringer-internal.

--- a/examples/cloudflare-worker/chaos/run.ts
+++ b/examples/cloudflare-worker/chaos/run.ts
@@ -41,6 +41,7 @@ async function main() {
     seed: Number(process.env.SEED ?? "42"),
     maxPages: Number(process.env.MAX_PAGES ?? "20"),
     strict: false,
+    traceparent: true,
     faultInjection: [
       // Network-layer faults — intercepted by Playwright BEFORE the worker is called.
       // These produce no `x-chaos-fault-*` headers because the worker is never reached.
@@ -80,6 +81,11 @@ async function main() {
   } else {
     console.log("server-side fault events: 0 (set CHAOS_5XX_RATE / CHAOS_LATENCY_RATE on the worker to see some)");
   }
+
+  const pagesWithServerFaults = report.pages.filter((p) => p.serverFaultEvents && p.serverFaultEvents.length > 0);
+  const actionsWithServerFaults = report.actions.filter((a) => a.serverFaultEvents && a.serverFaultEvents.length > 0);
+  console.log(`pages with server faults: ${pagesWithServerFaults.length}`);
+  console.log(`actions with server faults: ${actionsWithServerFaults.length}`);
 
   process.exit(passed ? 0 : 1);
 }

--- a/examples/cloudflare-worker/chaos/run.ts
+++ b/examples/cloudflare-worker/chaos/run.ts
@@ -70,6 +70,10 @@ async function main() {
   console.log(report.reproCommand);
   console.log(`pages=${report.pagesVisited} errors=${report.totalErrors}`);
 
+  // NOTE: the four `console.log` strings below ("server-side fault events: N",
+  // the per-kind breakdown, "pages with server faults: N", "actions with server
+  // faults: N") are asserted by examples/cloudflare-worker/test.mjs via regex.
+  // If you change the wording here, update the regexes there.
   const sf = report.serverFaults ?? [];
   if (sf.length > 0) {
     console.log(`server-side fault events: ${sf.length}`);

--- a/examples/cloudflare-worker/test.mjs
+++ b/examples/cloudflare-worker/test.mjs
@@ -118,7 +118,15 @@ try {
   if (!Number.isFinite(n) || n <= 0) {
     throw new Error(`expected server-side fault events > 0 with CHAOS_5XX_RATE=0.5, got ${n}`);
   }
-  console.log(`[test] PASS — ${n} server-side fault events observed via header round-trip`);
+  const ma = chaosStdout.match(/actions with server faults:\s*(\d+)/);
+  if (!ma) {
+    throw new Error("could not find 'actions with server faults: N' in chaos output — did Phase 2 wiring break?");
+  }
+  const na = Number(ma[1]);
+  if (!Number.isFinite(na) || na <= 0) {
+    throw new Error(`expected at least one action joined to a server fault via traceId, got ${na}`);
+  }
+  console.log(`[test] PASS — ${n} fault events / ${na} actions joined via header round-trip`);
   await teardown(0);
 } catch (err) {
   console.error("[test] FAIL:", err.message ?? err);

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -1995,6 +1995,13 @@ export class ChaosCrawler {
    * Perform actions based on weighted random selection
    */
   private async performWeightedActions(page: Page, url: string): Promise<void> {
+    // Per-page reset: if the previous page's last action left `currentAction`
+    // pointing at it, requests fired during this page's load / navigation /
+    // invariants would otherwise attribute to the previous page's last
+    // action. Clearing here covers both the no-targets early-return below
+    // and the regular-loop entry path.
+    this.currentAction = null;
+
     const targets = await this.getWeightedActionTargets(page);
     this.logger.debug("action_targets", { count: targets.length, url });
     if (targets.length === 0) return;

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -1187,10 +1187,9 @@ export class ChaosCrawler {
         const reqHeaders = await request.allHeaders();
         const existingTp = reqHeaders["traceparent"];
         if (existingTp) {
-          // Honour explicit propagation upstream — but still surface it to
-          // the consumer hook so the report can record the correlation id.
+          const parts = parseTraceparent(existingTp);
+          if (parts?.traceId) this.recordTraceId(parts.traceId);
           if (traceparentHook) {
-            const parts = parseTraceparent(existingTp);
             traceparentHook({
               url,
               method,
@@ -1205,6 +1204,7 @@ export class ChaosCrawler {
           const spanId = randomBytes(8).toString("hex"); // 16 hex chars
           const traceparent = `00-${traceId}-${spanId}-01`;
           outgoingHeaders = { ...reqHeaders, traceparent };
+          this.recordTraceId(traceId);
           traceparentHook?.({
             url,
             method,

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -307,6 +307,13 @@ export class ChaosCrawler {
    * `page.on("response")` listener can be skipped in the common case.
    */
   private readonly serverFaultCollector: ServerFaultCollector | null;
+  /**
+   * Set by the action loop immediately before each `performActionOnTarget`
+   * call; cleared at the start of the next iteration. The traceparent
+   * injection site uses `recordTraceId` to append captured trace-ids onto
+   * this action's `traceIds[]`.
+   */
+  private currentAction: ActionResult | null = null;
 
   constructor(options: CrawlerOptions, events: CrawlerEvents = {}) {
     validateOptions(options);
@@ -1005,6 +1012,17 @@ export class ChaosCrawler {
     if (!this.coverageFeedback) return 1;
     const score = this.targetNovelty.get(targetKey(url, selector)) ?? 0;
     return noveltyMultiplier(score, this.coverageFeedback.boost);
+  }
+
+  /**
+   * Append a trace-id to the currently-executing action, if any. Called
+   * from the per-request traceparent injection in `setupNavigationBlocking`.
+   * No-op when no action is in flight (e.g. during initial page load).
+   */
+  private recordTraceId(traceId: string): void {
+    if (!this.currentAction) return;
+    if (!this.currentAction.traceIds) this.currentAction.traceIds = [];
+    this.currentAction.traceIds.push(traceId);
   }
 
   private async consultAdvisorIfStalled(
@@ -1989,6 +2007,11 @@ export class ChaosCrawler {
     while (actionsPerformed < this.options.maxActionsPerPage && attempts < maxAttempts) {
       attempts++;
 
+      // Clear at the start of each iteration. Late-firing requests from the
+      // previous action attach to the previous action; once we begin the next,
+      // attribution is the current iteration's responsibility.
+      this.currentAction = null;
+
       const advisorPick = await this.consultAdvisorIfStalled(page, url, targets);
       const selectedTarget =
         advisorPick ??
@@ -2001,6 +2024,18 @@ export class ChaosCrawler {
           this.rng,
         );
 
+      // Build a placeholder ActionResult ahead of the call so traceIds captured
+      // during execution land on the right object. We carry the captured ids
+      // onto the real result returned by performActionOnTarget below.
+      const placeholder: ActionResult = {
+        type: "click", // overwritten by performActionOnTarget on success
+        target: selectedTarget.name ?? selectedTarget.selector,
+        selector: selectedTarget.selector,
+        success: false,
+        timestamp: Date.now(),
+      };
+      this.currentAction = placeholder;
+
       const result = await this.performActionOnTarget(page, selectedTarget, url);
 
       // Skip null results (element not visible)
@@ -2008,6 +2043,11 @@ export class ChaosCrawler {
         this.logger.debug("action_skipped", { target: selectedTarget.name || selectedTarget.selector, reason: "not visible" });
         continue;
       }
+
+      // Carry over any traceIds captured against the placeholder onto the
+      // real result. (performActionOnTarget returns a fresh ActionResult.)
+      if (placeholder.traceIds) result.traceIds = placeholder.traceIds;
+      this.currentAction = result;
 
       actionsPerformed++;
       this.actions.push(result);

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -2312,6 +2312,27 @@ export class ChaosCrawler {
   private generateReport(endTime: number): CrawlReport {
     const summary = this.calculateSummary();
 
+    const drainedServerFaults =
+      this.serverFaultCollector && this.serverFaultCollector.size() > 0
+        ? this.serverFaultCollector.drain()
+        : null;
+
+    if (drainedServerFaults) {
+      // Per-page join — same references as the flat list.
+      for (const p of this.results) {
+        const events = drainedServerFaults.filter((e) => e.pageUrl === p.url);
+        if (events.length > 0) p.serverFaultEvents = events;
+      }
+      // Per-action join — only meaningful when traceparent injection is on
+      // (otherwise traceIds is always empty/absent).
+      for (const a of this.actions) {
+        if (!a.traceIds || a.traceIds.length === 0) continue;
+        const set = new Set(a.traceIds);
+        const events = drainedServerFaults.filter((e) => e.traceId !== undefined && set.has(e.traceId));
+        if (events.length > 0) a.serverFaultEvents = events;
+      }
+    }
+
     return {
       baseUrl: this.options.baseUrl,
       seed: this.rng.seed,
@@ -2360,10 +2381,7 @@ export class ChaosCrawler {
       errorClusters: clusterErrors(this.results.flatMap((r) => r.errors)),
       har: this.options.har,
       // Field is omitted when no faults observed (matches advisor / coverage convention).
-      serverFaults:
-        this.serverFaultCollector && this.serverFaultCollector.size() > 0
-          ? this.serverFaultCollector.drain()
-          : undefined,
+      serverFaults: drainedServerFaults ?? undefined,
     };
   }
 

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -1187,6 +1187,8 @@ export class ChaosCrawler {
         const reqHeaders = await request.allHeaders();
         const existingTp = reqHeaders["traceparent"];
         if (existingTp) {
+          // Honour upstream propagation; record the correlation id on the
+          // current action regardless of whether the user supplied a hook.
           const parts = parseTraceparent(existingTp);
           if (parts?.traceId) this.recordTraceId(parts.traceId);
           if (traceparentHook) {

--- a/packages/chaosbringer/src/server-fault-correlation.test.ts
+++ b/packages/chaosbringer/src/server-fault-correlation.test.ts
@@ -132,3 +132,116 @@ describe("traceparent.onInject feeds recordTraceId", () => {
     expect(action.traceIds).toEqual(["aa".repeat(16), "bb".repeat(16)]);
   });
 });
+
+describe("generateReport joins serverFaults onto pages and actions", () => {
+  function callGenerateReport(crawler: ChaosCrawler) {
+    // generateReport is private; reach in directly with a cast.
+    return (crawler as unknown as {
+      generateReport: (endTime: number) => import("./types.js").CrawlReport;
+    }).generateReport(Date.now());
+  }
+
+  it("populates PageResult.serverFaultEvents by pageUrl", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    pushPage(crawler, "https://app.test/b");
+    pushFault(crawler, {
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503 },
+    });
+    pushFault(crawler, {
+      pageUrl: "https://app.test/b",
+      observedAt: 110,
+      attrs: { kind: "latency", path: "/api/y", method: "POST", latencyMs: 200 },
+    });
+
+    const report = callGenerateReport(crawler);
+    expect(report.serverFaults).toHaveLength(2);
+
+    const a = report.pages.find((p) => p.url === "https://app.test/a")!;
+    const b = report.pages.find((p) => p.url === "https://app.test/b")!;
+    expect(a.serverFaultEvents?.map((e) => e.attrs.path)).toEqual(["/api/x"]);
+    expect(b.serverFaultEvents?.map((e) => e.attrs.path)).toEqual(["/api/y"]);
+  });
+
+  it("omits serverFaultEvents on pages with no matching events", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    pushPage(crawler, "https://app.test/b");
+    pushFault(crawler, {
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503 },
+    });
+    const report = callGenerateReport(crawler);
+    const b = report.pages.find((p) => p.url === "https://app.test/b")!;
+    expect(b.serverFaultEvents).toBeUndefined();
+  });
+
+  it("populates ActionResult.serverFaultEvents by traceId", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    const action = pushAction(crawler, {
+      type: "click",
+      target: "Buy",
+      success: true,
+      timestamp: 1,
+      traceIds: ["aa".repeat(16), "bb".repeat(16)],
+    });
+    pushFault(crawler, {
+      traceId: "aa".repeat(16),
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: {
+        kind: "5xx",
+        path: "/api/x",
+        method: "POST",
+        targetStatus: 503,
+        traceId: "aa".repeat(16),
+      },
+    });
+    pushFault(crawler, {
+      traceId: "cc".repeat(16),
+      pageUrl: "https://app.test/a",
+      observedAt: 110,
+      attrs: { kind: "5xx", path: "/api/y", method: "GET", targetStatus: 500, traceId: "cc".repeat(16) },
+    });
+
+    const report = callGenerateReport(crawler);
+    expect(action.serverFaultEvents?.map((e) => e.attrs.path)).toEqual(["/api/x"]);
+  });
+
+  it("omits ActionResult.serverFaultEvents when traceIds is empty/absent", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    const noTraceAction = pushAction(crawler, {
+      type: "scroll",
+      target: "scrollY:200",
+      success: true,
+      timestamp: 1,
+    });
+    pushFault(crawler, {
+      traceId: "ee".repeat(16),
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503, traceId: "ee".repeat(16) },
+    });
+    const report = callGenerateReport(crawler);
+    expect(noTraceAction.serverFaultEvents).toBeUndefined();
+  });
+
+  it("references are shared between report.serverFaults and the joined views", () => {
+    const crawler = freshCrawler();
+    pushPage(crawler, "https://app.test/a");
+    pushFault(crawler, {
+      pageUrl: "https://app.test/a",
+      observedAt: 100,
+      attrs: { kind: "5xx", path: "/api/x", method: "GET", targetStatus: 503 },
+    });
+    const report = callGenerateReport(crawler);
+    const flat = report.serverFaults![0];
+    const onPage = report.pages[0].serverFaultEvents![0];
+    expect(onPage).toBe(flat);
+  });
+});

--- a/packages/chaosbringer/src/server-fault-correlation.test.ts
+++ b/packages/chaosbringer/src/server-fault-correlation.test.ts
@@ -94,11 +94,11 @@ describe("traceIds capture during action execution", () => {
   it("ignores recordTraceId calls when no action is current", () => {
     const crawler = freshCrawler();
     (crawler as unknown as { currentAction: ActionResult | null }).currentAction = null;
-    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
-      "00000000000000000000000000000003",
-    );
-    // No state to assert against; just verify it does not throw.
-    expect(true).toBe(true);
+    expect(() =>
+      (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+        "00000000000000000000000000000003",
+      ),
+    ).not.toThrow();
   });
 
   it("attributes trace-ids to the most recent action when called between actions", () => {

--- a/packages/chaosbringer/src/server-fault-correlation.test.ts
+++ b/packages/chaosbringer/src/server-fault-correlation.test.ts
@@ -117,3 +117,18 @@ describe("traceIds capture during action execution", () => {
     expect(a2.traceIds).toEqual(["a2-trace"]);
   });
 });
+
+describe("traceparent.onInject feeds recordTraceId", () => {
+  it("invokes recordTraceId for each synthesised traceparent", () => {
+    const crawler = freshCrawler();
+    const action: ActionResult = { type: "click", target: "x", success: true, timestamp: 0 };
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = action;
+
+    // Simulate two synthesised injections by calling recordTraceId directly,
+    // mirroring what the in-route handler does.
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("aa".repeat(16));
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("bb".repeat(16));
+
+    expect(action.traceIds).toEqual(["aa".repeat(16), "bb".repeat(16)]);
+  });
+});

--- a/packages/chaosbringer/src/server-fault-correlation.test.ts
+++ b/packages/chaosbringer/src/server-fault-correlation.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Phase 2 — per-action and per-page correlation in `generateReport`.
+ *
+ * These tests exercise the join logic via a thin harness that manipulates
+ * a `ChaosCrawler` instance's internal state (results, actions, collector)
+ * and then triggers report generation. We avoid spinning up Playwright /
+ * the fixture server because the join logic is pure data manipulation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ChaosCrawler } from "./crawler.js";
+import { ServerFaultCollector } from "./server-fault-collector.js";
+import type { PageResult, ActionResult, ServerFaultEvent } from "./types.js";
+
+function freshCrawler(): ChaosCrawler {
+  // baseUrl is the only required option; everything else defaults.
+  return new ChaosCrawler({ baseUrl: "https://app.test" });
+}
+
+function pushPage(crawler: ChaosCrawler, url: string): PageResult {
+  const result: PageResult = {
+    url,
+    status: "success",
+    statusCode: 200,
+    loadTime: 0,
+    errors: [],
+    warnings: [],
+    blockedNavigations: [],
+    discoveredLinks: [],
+    actions: [],
+    metrics: {},
+    hasErrors: false,
+  };
+  // The crawler tracks visited pages in `this.results`. Tests reach in via
+  // the same field name the production code uses.
+  (crawler as unknown as { results: PageResult[] }).results.push(result);
+  return result;
+}
+
+function pushAction(crawler: ChaosCrawler, action: ActionResult): ActionResult {
+  (crawler as unknown as { actions: ActionResult[] }).actions.push(action);
+  return action;
+}
+
+function pushFault(crawler: ChaosCrawler, ev: ServerFaultEvent): void {
+  // The crawler holds a `serverFaultCollector` only when
+  // `server.mode === "remote"`; for the test we install one ourselves.
+  const internal = crawler as unknown as { serverFaultCollector: ServerFaultCollector | null };
+  if (!internal.serverFaultCollector) {
+    internal.serverFaultCollector = new ServerFaultCollector("x-chaos-fault");
+  }
+  // Build matching headers for the collector to parse.
+  const headers = new Headers({
+    "x-chaos-fault-kind": ev.attrs.kind,
+    "x-chaos-fault-path": ev.attrs.path,
+    "x-chaos-fault-method": ev.attrs.method,
+  });
+  if (ev.attrs.targetStatus !== undefined) {
+    headers.set("x-chaos-fault-target-status", String(ev.attrs.targetStatus));
+  }
+  if (ev.attrs.latencyMs !== undefined) {
+    headers.set("x-chaos-fault-latency-ms", String(ev.attrs.latencyMs));
+  }
+  if (ev.traceId) {
+    headers.set("x-chaos-fault-trace-id", ev.traceId);
+  }
+  internal.serverFaultCollector.observe({ headers, pageUrl: ev.pageUrl });
+}
+
+describe("traceIds capture during action execution", () => {
+  it("appends trace-ids to currentAction during the action's window", () => {
+    const crawler = freshCrawler();
+    const action: ActionResult = {
+      type: "click",
+      target: "Save",
+      success: true,
+      timestamp: Date.now(),
+    };
+    // Simulate the action loop: set currentAction before execution.
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = action;
+    // Simulate the injection site calling the internal hook for two requests.
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+      "00000000000000000000000000000001",
+    );
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+      "00000000000000000000000000000002",
+    );
+    expect(action.traceIds).toEqual([
+      "00000000000000000000000000000001",
+      "00000000000000000000000000000002",
+    ]);
+  });
+
+  it("ignores recordTraceId calls when no action is current", () => {
+    const crawler = freshCrawler();
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = null;
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId(
+      "00000000000000000000000000000003",
+    );
+    // No state to assert against; just verify it does not throw.
+    expect(true).toBe(true);
+  });
+
+  it("attributes trace-ids to the most recent action when called between actions", () => {
+    const crawler = freshCrawler();
+    const a1: ActionResult = { type: "click", target: "A", success: true, timestamp: 0 };
+    const a2: ActionResult = { type: "click", target: "B", success: true, timestamp: 1 };
+
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = a1;
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("a1-trace");
+
+    // Next iteration begins — currentAction is reassigned.
+    (crawler as unknown as { currentAction: ActionResult | null }).currentAction = a2;
+    (crawler as unknown as { recordTraceId: (id: string) => void }).recordTraceId("a2-trace");
+
+    expect(a1.traceIds).toEqual(["a1-trace"]);
+    expect(a2.traceIds).toEqual(["a2-trace"]);
+  });
+});

--- a/packages/chaosbringer/src/types.ts
+++ b/packages/chaosbringer/src/types.ts
@@ -462,7 +462,9 @@ export interface PageResult {
    * Populated only when `chaos({ server: { mode: "remote" } })` was set
    * AND faults were observed on this page; absent otherwise.
    *
-   * References are shared with `report.serverFaults[]` — no duplication.
+   * References are shared with `report.serverFaults[]` and with
+   * `ActionResult.serverFaultEvents[]` — no duplication. Treat events as
+   * read-only: mutating one observed here mutates the other views too.
    */
   serverFaultEvents?: ServerFaultEvent[];
 }
@@ -502,6 +504,7 @@ export interface ActionResult {
   timestamp: number;
   /**
    * W3C trace-ids of requests triggered while this action was executing.
+   * Format: 32 lowercase hex chars per id (the traceparent's trace-id segment).
    * Populated only when `chaos({ traceparent: true })` is set. Absent for
    * actions that triggered no requests (scroll, hover) or when traceparent
    * injection is off.
@@ -509,9 +512,19 @@ export interface ActionResult {
   traceIds?: string[];
   /**
    * Server-side fault events whose `traceId` is in `traceIds[]`. Pre-
-   * computed view of `report.serverFaults` per action. Populated only when
-   * `chaos({ traceparent: true, server: { mode: "remote" } })` is BOTH set
-   * AND at least one fault joined to this action.
+   * computed view of `report.serverFaults` per action.
+   *
+   * Populated only when ALL of:
+   *   - `chaos({ traceparent: true })` was set, AND
+   *   - `chaos({ server: { mode: "remote" } })` was set, AND
+   *   - at least one fault's traceId matched a traceId captured by THIS
+   *     specific action.
+   * Otherwise absent — including the case where `report.serverFaults` is
+   * non-empty but no event joined to this action's `traceIds[]`.
+   *
+   * References are shared with `report.serverFaults[]` and with
+   * `PageResult.serverFaultEvents[]` — no duplication. Treat events as
+   * read-only: mutating one observed here mutates the other views too.
    */
   serverFaultEvents?: ServerFaultEvent[];
 }

--- a/packages/chaosbringer/src/types.ts
+++ b/packages/chaosbringer/src/types.ts
@@ -456,6 +456,15 @@ export interface PageResult {
   sourceUrl?: string;
   /** Element that linked to this page */
   sourceElement?: string;
+  /**
+   * Server-side fault events that fired while this page was active.
+   * Pre-computed view of `report.serverFaults` filtered by `pageUrl`.
+   * Populated only when `chaos({ server: { mode: "remote" } })` was set
+   * AND faults were observed on this page; absent otherwise.
+   *
+   * References are shared with `report.serverFaults[]` — no duplication.
+   */
+  serverFaultEvents?: ServerFaultEvent[];
 }
 
 export interface RecoveryInfo {
@@ -491,6 +500,20 @@ export interface ActionResult {
   /** True when the action was skipped because the target URL is owned by another shard. */
   shardSkipped?: boolean;
   timestamp: number;
+  /**
+   * W3C trace-ids of requests triggered while this action was executing.
+   * Populated only when `chaos({ traceparent: true })` is set. Absent for
+   * actions that triggered no requests (scroll, hover) or when traceparent
+   * injection is off.
+   */
+  traceIds?: string[];
+  /**
+   * Server-side fault events whose `traceId` is in `traceIds[]`. Pre-
+   * computed view of `report.serverFaults` per action. Populated only when
+   * `chaos({ traceparent: true, server: { mode: "remote" } })` is BOTH set
+   * AND at least one fault joined to this action.
+   */
+  serverFaultEvents?: ServerFaultEvent[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- `PageResult.serverFaultEvents?: ServerFaultEvent[]` — server-side faults that fired while a page was active. Pre-computed view of `report.serverFaults` filtered by `pageUrl`.
- `ActionResult.traceIds?: string[]` — W3C trace-ids of requests issued during an action's window. Captured at the chaosbringer traceparent injection site via a new internal `recordTraceId` hook.
- `ActionResult.serverFaultEvents?: ServerFaultEvent[]` — server-side faults whose `traceId` matches one of the action's `traceIds`. Pre-computed view of `report.serverFaults`.

The flat `report.serverFaults[]` from Phase 1 is unchanged — both new fields are derived views over the same array (reference identity preserved). No data duplication, no breaking change.

Spec: [`docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md`](https://github.com/mizchi/chaosbringer/blob/feat/chaos-correlation-phase-2/docs/superpowers/specs/2026-05-06-chaos-server-orchestration-phase-2-design.md)

Closes the remaining work on #56 Phase 2 (per-action + per-page correlation). Same-process direct-handle and auto-seed propagation are explicitly out of scope.

## Activation
Both options must be set for the full Phase 2 surface:
\`\`\`ts
await chaos({
  …,
  traceparent: true,
  server: { mode: "remote" },
});
\`\`\`
The activation matrix (4 quadrants) is documented in [`docs/recipes/server-side-correlation.md`](https://github.com/mizchi/chaosbringer/blob/feat/chaos-correlation-phase-2/docs/recipes/server-side-correlation.md#activation-matrix).

## End-to-end demonstration
[`examples/cloudflare-worker`](https://github.com/mizchi/chaosbringer/tree/feat/chaos-correlation-phase-2/examples/cloudflare-worker) is updated to use both options. Its CI test asserts at least one action joined to a server fault via traceId — the round-trip verification.

Sample output:
\`\`\`
server-side fault events: 1
  5xx: 1
pages with server faults: 1
actions with server faults: 1
[test] PASS — 1 fault events / 1 actions joined via header round-trip
\`\`\`

## Test plan
- [x] \`pnpm -F chaosbringer test\` — 429/429 green (9 new tests in \`server-fault-correlation.test.ts\`).
- [x] \`pnpm -F chaosbringer build\` — tsc clean.
- [x] \`pnpm -F @mizchi/chaosbringer-example-cloudflare-worker test\` — end-to-end PASS with the new \`actions with server faults: N > 0\` assertion.