### PR TITLE
fix(publish): use pnpm publish to rewrite workspace:^ deps + 0.8.1 hotfix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,4 +59,11 @@ jobs:
 
       - name: Publish to npm (OIDC Trusted Publishing)
         working-directory: ${{ steps.pkg.outputs.dir }}
-        run: npm publish --access public --provenance
+        # pnpm publish (NOT npm publish): rewrites `workspace:^` / `workspace:*`
+        # refs in dependencies to actual workspace package versions before
+        # packing. `npm publish` leaves them as literal strings, which break
+        # installs at consume time. (chaosbringer@0.8.0 shipped to npm with
+        # `@mizchi/playwright-faults: workspace:^` because of this.)
+        # `--no-git-checks` is required because the workflow runs on a release
+        # tag (detached HEAD) which pnpm publish would otherwise refuse.
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/chaosbringer": "0.8.0"
+  "packages/chaosbringer": "0.8.1"
 }

--- a/packages/chaosbringer/CHANGELOG.md
+++ b/packages/chaosbringer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.1](https://github.com/mizchi/chaosbringer/compare/chaosbringer-v0.8.0...chaosbringer-v0.8.1) (2026-05-06)
+
+
+### Bug Fixes
+
+* **publish:** rewrite `workspace:^` refs in the published `package.json` (use `pnpm publish`, not `npm publish`). 0.8.0 shipped with `@mizchi/playwright-faults: workspace:^` literally, which breaks installs at consume time. Use 0.8.1 instead.
+
 ## [0.8.0](https://github.com/mizchi/chaosbringer/compare/chaosbringer-v0.7.0...chaosbringer-v0.8.0) (2026-05-06)
 
 

--- a/packages/chaosbringer/package.json
+++ b/packages/chaosbringer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaosbringer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Playwright-based chaos testing tool for web applications",
   "license": "MIT",
   "author": "mizchi",


### PR DESCRIPTION
## Summary
\`chaosbringer@0.8.0\` shipped to npm with \`@mizchi/playwright-faults: workspace:^\` as a literal dependency string. \`npm install chaosbringer@0.8.0\` therefore fails at consume time:

\`\`\`
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
"@mizchi/playwright-faults@workspace:^" is in the dependencies but no
package named "@mizchi/playwright-faults" is present in the workspace
\`\`\`

(Verified by switching otel-chaos-lab from \`link:\` to \`^0.8.0\`.)

## Root cause
The publish workflow used \`npm publish\` instead of \`pnpm publish\`. \`npm publish\` does not understand pnpm's \`workspace:\` protocol — it includes the package.json verbatim. \`pnpm publish\` rewrites \`workspace:^\` to the actual workspace package version at pack time.

## Fix
- \`.github/workflows/publish.yml\`: \`npm publish --access public --provenance\` → \`pnpm publish --access public --provenance --no-git-checks\` (the last flag is required because the workflow runs on a release tag = detached HEAD).
- Bump chaosbringer to 0.8.1 with this fix.

## Action items for the maintainer (after merge + republish)
\`\`\`bash
# Mark 0.8.0 as broken so users of \`==0.8.0\` pins see the warning:
npm deprecate chaosbringer@0.8.0 "Broken: workspace:^ refs leaked into published deps. Use 0.8.1+."
\`\`\`

(\`^0.8.0\` SemVer pins will resolve to 0.8.1 automatically once 0.8.1 is published.)

## Test plan
- [x] Workflow change verified by reading pnpm docs (\`pnpm publish\` rewrites \`workspace:\` refs; \`--provenance\` is supported in pnpm 9+).
- [ ] Will be verified end-to-end by the post-merge \`gh release create chaosbringer-v0.8.1\` (or release-please re-run) — the published 0.8.1 tarball must NOT contain \`workspace:\` strings in its dependencies.