### PR TITLE
chore(release): track all 5 workspace packages in release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,7 @@
 {
-  "packages/chaosbringer": "0.8.1"
+  "packages/chaosbringer": "0.8.1",
+  "packages/server-faults": "0.1.0",
+  "packages/playwright-faults": "0.1.0",
+  "packages/playwright-v8-coverage": "0.1.0",
+  "packages/cf-faults": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,30 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-v-in-tag": true,
+  "separate-pull-requests": true,
   "packages": {
     "packages/chaosbringer": {
       "package-name": "chaosbringer",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/server-faults": {
+      "package-name": "@mizchi/server-faults",
+      "component": "server-faults",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/playwright-faults": {
+      "package-name": "@mizchi/playwright-faults",
+      "component": "playwright-faults",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/playwright-v8-coverage": {
+      "package-name": "@mizchi/playwright-v8-coverage",
+      "component": "playwright-v8-coverage",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/cf-faults": {
+      "package-name": "@mizchi/cf-faults",
+      "component": "cf-faults",
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## Summary
\`release-please-config.json\` originally tracked only \`packages/chaosbringer\`. The 4 sibling packages (\`@mizchi/server-faults\`, \`@mizchi/playwright-faults\`, \`@mizchi/playwright-v8-coverage\`, \`@mizchi/cf-faults\`) had to be published manually because release-please never opened Release PRs for them.

With Trusted Publishing now configured on npmjs for all 5 packages, this PR adds the missing 4 to the manifest:

- \`feat(server-faults): …\` → release-please opens a Release PR for \`@mizchi/server-faults\`
- Tag format per package: \`server-faults-v0.x.y\`, \`playwright-faults-v0.x.y\`, etc. (set via explicit \`component\`)
- The existing publish.yml regex \`^([a-z0-9-]+)-v[0-9]\` already routes those tags to the right \`packages/\${component}\` dir — no workflow change needed
- \`separate-pull-requests: true\` keeps multi-package changes from collapsing into one giant Release PR

## Verification path (post-merge)
1. Merging this PR alone won't open Release PRs immediately — release-please needs new conventional commits since each package's last release.
2. Next \`feat(server-faults):\` etc. commit opens that package's first Release PR.
3. Merging the Release PR → release-please tags + Release → publish.yml fires → \`pnpm publish\` (now correct from #85) succeeds via OIDC.

## Out of scope
- Cross-package version coordination (e.g. \`chaosbringer\` always lags \`server-faults\`). Handled at PR-review time, not config.
- Backfilling CHANGELOGs for past versions of the 4 sibling packages. release-please writes them forward only.