### PR TITLE
Close out remaining open issues (#80–83, #87, #88) + test coverage

### DIFF
--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -42,7 +42,7 @@ Playwright-based chaos testing for web apps. Crawls the pages you point it at, p
 - **Parallel sharding** — split a crawl across N processes with `--shard i/N`, then merge via the `shard` subcommand.
 - **GitHub Actions annotations** — emit `::error` / `::warning` lines so failures show up on the run summary.
 - **Playwright Test integration** for when you'd rather run chaos inside an existing test file.
-- **CLI** for running from a shell or CI, with `minimize` / `flake` / `shard` subcommands.
+- **CLI** for running from a shell or CI, with `minimize` / `flake` / `shard` / `diff` / `parity` / `cluster-artifacts` / `recipes` / `load` subcommands.
 
 ## Install
 
@@ -963,6 +963,49 @@ chaosbringer --url ... --shard 1/4 --output shard-1.json
 import { mergeReports } from "chaosbringer";
 const merged = mergeReports([r0, r1, r2, r3]);
 ```
+
+### `diff`
+
+Compare two independent crawl reports. Surfaces clusters that fire only on the left, only on the right, and on both (likely third-party noise). Designed for the dual-runtime regression workflow where the same site data is served by two runtimes and crawled with the same seed.
+
+```bash
+chaosbringer --url http://127.0.0.1:3000 --seed 1 --output left.json
+chaosbringer --url http://127.0.0.1:3001 --seed 1 --output right.json
+chaosbringer diff left.json right.json
+```
+
+Flags: `--json` (machine output), `--shared-only` / `--left-only` / `--right-only` (filtered views for piping into wrapper scripts). Distinct from the `--baseline` flag, which assumes a directional baseline-vs-current comparison.
+
+### `parity`
+
+Non-random side-by-side HTTP probe. For each path in a file, GETs the same path against two base URLs and surfaces status mismatches, redirect-target mismatches, and one-side-only fetch failures. Use this when random crawls produce too much third-party noise to isolate route divergence.
+
+```bash
+chaosbringer parity \
+  --left http://127.0.0.1:3000 \
+  --right http://127.0.0.1:3001 \
+  --paths paths.txt \
+  --output parity.json
+```
+
+Default mode is manual redirects (compare 3xx + Location directly — the most sensitive mode for routing-bug detection). `--follow-redirects` falls back to final-status comparison. Fetch-based only — JS exceptions / body predicates would need a Playwright session per probe and are out of scope. Exits non-zero on any mismatch so it slots into CI as a gate.
+
+### `cluster-artifacts`
+
+Walks a report's `errorClusters` and emits one representative artifact bundle per cluster — copying `page.html` / `trace.jsonl` / `repro.sh` / screenshot from the matching per-page failure bundle and writing a filtered `errors.json` (only the cluster's own errors, not the whole page's). Triage-friendly: a cluster with 30 pages produces one directory the reviewer skims.
+
+```bash
+# Post-hoc: against an already-written failure-artifacts directory.
+chaosbringer cluster-artifacts chaos-report.json --bundle-dir ./artifacts
+
+# Inline: hook the main crawl so cluster bundles are emitted at the end.
+chaosbringer --url http://localhost:3000 \
+  --failure-artifacts ./artifacts \
+  --cluster-artifacts \
+  --cluster-min-count 5
+```
+
+`--min-count` (or `--cluster-min-count` inline) filters low-frequency noise. The inline form requires `--failure-artifacts` since it copies from the per-page bundles.
 
 ## CLI reference
 

--- a/packages/chaosbringer/src/cli.ts
+++ b/packages/chaosbringer/src/cli.ts
@@ -156,6 +156,8 @@ const { values, positionals } = parseArgs({
     "visual-diff-dir": { type: "string" },
     "visual-update": { type: "boolean", default: false },
     "failure-artifacts": { type: "string" },
+    "cluster-artifacts": { type: "boolean", default: false },
+    "cluster-min-count": { type: "string" },
     "failure-max": { type: "string" },
     "trace-out": { type: "string" },
     "trace-replay": { type: "string" },
@@ -221,6 +223,8 @@ OPTIONS:
   --visual-update       Overwrite baselines with current screenshots (for intentional UI updates)
   --failure-artifacts <dir>  Write a bundle (screenshot + html + errors + trace + repro.sh) per failing page
   --failure-max <n>     Cap the number of failure bundles per run (default: unlimited)
+  --cluster-artifacts   After the crawl, emit one representative bundle per error cluster in <failure-artifacts>/clusters/
+  --cluster-min-count <n>  Skip clusters with count below n when --cluster-artifacts is set
   --trace-out <path>    Write a JSONL trace of visits + actions for replay / minimize
   --trace-replay <path> Replay a previously recorded trace instead of random actions
   --device <name>       Emulate a Playwright device descriptor (e.g. "iPhone 14", "Pixel 7")
@@ -525,6 +529,27 @@ async function main() {
       if (heatmapOut) {
         writeFileSync(heatmapOut, JSON.stringify(entries, null, 2));
         if (!isQuiet) console.log(`\nHeatmap saved to: ${heatmapOut}`);
+      }
+    }
+
+    if (values["cluster-artifacts"]) {
+      const failureDir = values["failure-artifacts"];
+      if (!failureDir) {
+        console.error(
+          "--cluster-artifacts requires --failure-artifacts <dir> (it copies from the per-page bundles)",
+        );
+        process.exit(1);
+      }
+      const { writeClusterArtifacts } = await import("./cluster-artifacts.js");
+      const minCount = values["cluster-min-count"]
+        ? parseInt(values["cluster-min-count"], 10)
+        : undefined;
+      const results = writeClusterArtifacts(report, {
+        bundleDir: failureDir,
+        minCount,
+      });
+      if (!isQuiet) {
+        console.log(`\nWrote ${results.length} cluster bundle(s) to ${failureDir}/clusters/`);
       }
     }
 

--- a/packages/chaosbringer/src/cli.ts
+++ b/packages/chaosbringer/src/cli.ts
@@ -38,85 +38,35 @@ import { visualRegression } from "./visual.js";
 
 // Subcommand dispatch. Intercept before parseArgs runs so subcommand-specific
 // flags (e.g. --match for `minimize`) don't trip the main options map.
+//
+// Each entry lazy-imports its handler so a `chaosbringer --help` invocation
+// doesn't pay the cost of compiling every subcommand. The handler is
+// expected to set `process.exitCode` on a non-fatal failure; thrown errors
+// are surfaced with the subcommand name and an exit code of 1. Legacy
+// handlers (minimize / flake / shard) call `process.exit` directly inside
+// themselves and never return, so the final `process.exit` here is only
+// reached by the newer handlers that opt into exitCode-based signalling.
+const SUBCOMMANDS: Record<string, () => Promise<(argv: string[]) => Promise<void>>> = {
+  minimize: () => import("./minimize.js").then((m) => m.runMinimizeCli),
+  flake: () => import("./flake.js").then((m) => m.runFlakeCli),
+  shard: () => import("./shard.js").then((m) => m.runShardCli),
+  recipes: () => import("./recipes/cli.js").then((m) => m.runRecipesCli),
+  load: () => import("./recipes/load-cli.js").then((m) => m.runLoadCli),
+  diff: () => import("./diff-cli.js").then((m) => m.runDiffCli),
+  "cluster-artifacts": () =>
+    import("./cluster-artifacts-cli.js").then((m) => m.runClusterArtifactsCli),
+  parity: () => import("./parity-cli.js").then((m) => m.runParityCli),
+};
+
 const rawSub = process.argv[2];
 const subcommand = rawSub && !rawSub.startsWith("-") ? rawSub : null;
-if (subcommand === "minimize") {
-  const { runMinimizeCli } = await import("./minimize.js");
+if (subcommand && Object.hasOwn(SUBCOMMANDS, subcommand)) {
   try {
-    await runMinimizeCli(process.argv.slice(3));
-    process.exit(0);
-  } catch (err) {
-    console.error("minimize failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "flake") {
-  const { runFlakeCli } = await import("./flake.js");
-  try {
-    await runFlakeCli(process.argv.slice(3));
-    process.exit(0);
-  } catch (err) {
-    console.error("flake failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "shard") {
-  const { runShardCli } = await import("./shard.js");
-  try {
-    await runShardCli(process.argv.slice(3));
-    process.exit(0);
-  } catch (err) {
-    console.error("shard failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "recipes") {
-  const { runRecipesCli } = await import("./recipes/cli.js");
-  try {
-    await runRecipesCli(process.argv.slice(3));
+    const run = await SUBCOMMANDS[subcommand]();
+    await run(process.argv.slice(3));
     process.exit(process.exitCode ?? 0);
   } catch (err) {
-    console.error("recipes failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "load") {
-  const { runLoadCli } = await import("./recipes/load-cli.js");
-  try {
-    await runLoadCli(process.argv.slice(3));
-    process.exit(process.exitCode ?? 0);
-  } catch (err) {
-    console.error("load failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "diff") {
-  const { runDiffCli } = await import("./diff-cli.js");
-  try {
-    await runDiffCli(process.argv.slice(3));
-    process.exit(process.exitCode ?? 0);
-  } catch (err) {
-    console.error("diff failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "cluster-artifacts") {
-  const { runClusterArtifactsCli } = await import("./cluster-artifacts-cli.js");
-  try {
-    await runClusterArtifactsCli(process.argv.slice(3));
-    process.exit(process.exitCode ?? 0);
-  } catch (err) {
-    console.error("cluster-artifacts failed:", err instanceof Error ? err.message : err);
-    process.exit(1);
-  }
-}
-if (subcommand === "parity") {
-  const { runParityCli } = await import("./parity-cli.js");
-  try {
-    await runParityCli(process.argv.slice(3));
-    process.exit(process.exitCode ?? 0);
-  } catch (err) {
-    console.error("parity failed:", err instanceof Error ? err.message : err);
+    console.error(`${subcommand} failed:`, err instanceof Error ? err.message : err);
     process.exit(1);
   }
 }

--- a/packages/chaosbringer/src/cli.ts
+++ b/packages/chaosbringer/src/cli.ts
@@ -24,7 +24,7 @@
  */
 
 import { parseArgs } from "node:util";
-import { ChaosCrawler, COMMON_IGNORE_PATTERNS } from "./crawler.js";
+import { ChaosCrawler, COMMON_IGNORE_PATTERNS, IGNORE_PRESETS, resolveIgnorePresets } from "./crawler.js";
 import { diffReports, loadBaseline } from "./diff.js";
 import { printGithubAnnotations } from "./github.js";
 import { axe } from "./invariants.js";
@@ -90,6 +90,16 @@ if (subcommand === "load") {
     process.exit(1);
   }
 }
+if (subcommand === "diff") {
+  const { runDiffCli } = await import("./diff-cli.js");
+  try {
+    await runDiffCli(process.argv.slice(3));
+    process.exit(process.exitCode ?? 0);
+  } catch (err) {
+    console.error("diff failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
 
 const { values, positionals } = parseArgs({
   options: {
@@ -107,6 +117,7 @@ const { values, positionals } = parseArgs({
     exclude: { type: "string", multiple: true },
     "ignore-error": { type: "string", multiple: true },
     "ignore-analytics": { type: "boolean", default: false },
+    "ignore-preset": { type: "string", multiple: true },
     spa: { type: "string", multiple: true },
     "log-file": { type: "string" },
     "log-level": { type: "string" },
@@ -169,6 +180,8 @@ OPTIONS:
   --ignore-analytics    Ignore common analytics script errors (googletagmanager,
                         google-analytics, hotjar, clarity, segment, amplitude,
                         cloudflareinsights, facebook.net, and net::ERR_FAILED)
+  --ignore-preset <p>   Apply a named ignore-error preset (can be repeated; comma-separated).
+                        Known: analytics, maps, media-embeds, pdf-orb, iframe-sandbox
   --spa <pattern>       Mark URLs as SPA (errors shown separately, can be repeated)
   --log-file <path>     Write execution log to file (JSON format)
   --log-level <level>   Log level: debug, info, warn, error (default: info)
@@ -241,6 +254,15 @@ if (!baseUrl) {
 const ignoreErrorPatterns: string[] = [...(values["ignore-error"] || [])];
 if (values["ignore-analytics"]) {
   ignoreErrorPatterns.push(...COMMON_IGNORE_PATTERNS);
+}
+for (const presetSpec of values["ignore-preset"] ?? []) {
+  try {
+    ignoreErrorPatterns.push(...resolveIgnorePresets(presetSpec));
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : err}`);
+    console.error(`Tip: --ignore-preset accepts comma-separated names. Known: ${Object.keys(IGNORE_PRESETS).join(", ")}`);
+    process.exit(1);
+  }
 }
 
 // Validate log level

--- a/packages/chaosbringer/src/cli.ts
+++ b/packages/chaosbringer/src/cli.ts
@@ -100,6 +100,26 @@ if (subcommand === "diff") {
     process.exit(1);
   }
 }
+if (subcommand === "cluster-artifacts") {
+  const { runClusterArtifactsCli } = await import("./cluster-artifacts-cli.js");
+  try {
+    await runClusterArtifactsCli(process.argv.slice(3));
+    process.exit(process.exitCode ?? 0);
+  } catch (err) {
+    console.error("cluster-artifacts failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+if (subcommand === "parity") {
+  const { runParityCli } = await import("./parity-cli.js");
+  try {
+    await runParityCli(process.argv.slice(3));
+    process.exit(process.exitCode ?? 0);
+  } catch (err) {
+    console.error("parity failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
 
 const { values, positionals } = parseArgs({
   options: {

--- a/packages/chaosbringer/src/cluster-artifacts-cli.test.ts
+++ b/packages/chaosbringer/src/cluster-artifacts-cli.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { runClusterArtifactsCli } from "./cluster-artifacts-cli.js";
+import type { CrawlReport, CrawlSummary, PageError, PageResult } from "./types.js";
+
+function err(o: Partial<PageError> & { type: PageError["type"]; message: string }): PageError {
+  return { timestamp: 0, ...o };
+}
+
+function cluster(o: Partial<ErrorCluster> & { key: string; fingerprint: string; sample: PageError }): ErrorCluster {
+  return {
+    key: o.key,
+    type: o.type ?? "console",
+    fingerprint: o.fingerprint,
+    sample: o.sample,
+    count: o.count ?? 1,
+    urls: o.urls ?? [],
+    invariantNames: o.invariantNames,
+  };
+}
+
+function makeSummary(): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    pagesWithErrors: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    invariantViolations: 0,
+    avgLoadTime: 0,
+  };
+}
+
+function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://localhost:3000",
+    seed: 1,
+    reproCommand: "chaosbringer",
+    startTime: 0,
+    endTime: 0,
+    duration: 0,
+    pagesVisited: 0,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: makeSummary(),
+    errorClusters: [],
+    ...overrides,
+  };
+}
+
+function page(o: Partial<PageResult> & { url: string; errors: PageError[] }): PageResult {
+  return {
+    url: o.url,
+    status: o.status ?? "success",
+    loadTime: 0,
+    errors: o.errors,
+    hasErrors: o.errors.length > 0,
+    warnings: [],
+    links: [],
+    ...o,
+  };
+}
+
+describe("runClusterArtifactsCli", () => {
+  let dir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "chaos-ca-cli-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.exitCode = 0;
+  });
+
+  function logged(): string {
+    return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  }
+
+  function writeReportFile(name: string, report: CrawlReport): string {
+    const p = join(dir, name);
+    writeFileSync(p, JSON.stringify(report));
+    return p;
+  }
+
+  function makeBundle(name: string, info: { url: string }, files: Record<string, string>): string {
+    const p = join(dir, name);
+    mkdirSync(p, { recursive: true });
+    writeFileSync(join(p, "info.json"), JSON.stringify(info));
+    for (const [n, c] of Object.entries(files)) writeFileSync(join(p, n), c);
+    return p;
+  }
+
+  it("emits a bundle and reports it to stdout", async () => {
+    makeBundle("0000__page", { url: "http://app/x" }, {
+      "page.html": "<x/>",
+      "trace.jsonl": "{}",
+      "repro.sh": "#!/bin/sh",
+    });
+    const sample = err({ type: "console", message: "boom", url: "http://app/x" });
+    const reportPath = writeReportFile(
+      "report.json",
+      makeReport({
+        pages: [page({ url: "http://app/x", errors: [sample] })],
+        errorClusters: [
+          cluster({ key: "console|boom", fingerprint: "boom", sample, urls: ["http://app/x"] }),
+        ],
+      }),
+    );
+    await runClusterArtifactsCli([reportPath, "--bundle-dir", dir]);
+    const out = logged();
+    expect(out).toContain("Wrote 1 cluster bundle(s).");
+    expect(out).toContain("console|boom");
+    // `process.exitCode` is undefined by default; either undefined or 0 is success.
+    expect(process.exitCode === undefined || process.exitCode === 0).toBe(true);
+  });
+
+  it("emits JSON when --json is set", async () => {
+    const sample = err({ type: "console", message: "x", url: "http://app/x" });
+    const reportPath = writeReportFile(
+      "report.json",
+      makeReport({
+        errorClusters: [cluster({ key: "console|x", fingerprint: "x", sample })],
+      }),
+    );
+    await runClusterArtifactsCli([reportPath, "--bundle-dir", dir, "--json"]);
+    const parsed = JSON.parse(logged());
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].clusterKey).toBe("console|x");
+  });
+
+  it("forwards --min-count to the underlying writer", async () => {
+    const sample = err({ type: "console", message: "x", url: "http://app/x" });
+    const reportPath = writeReportFile(
+      "report.json",
+      makeReport({
+        errorClusters: [
+          cluster({ key: "console|low", fingerprint: "low", sample, count: 1 }),
+          cluster({ key: "console|hi", fingerprint: "hi", sample, count: 10 }),
+        ],
+      }),
+    );
+    await runClusterArtifactsCli([reportPath, "--bundle-dir", dir, "--min-count", "5", "--json"]);
+    const parsed = JSON.parse(logged());
+    expect(parsed.results.map((r: { clusterKey: string }) => r.clusterKey)).toEqual(["console|hi"]);
+  });
+
+  it("exits 1 when --bundle-dir is missing", async () => {
+    const reportPath = writeReportFile("report.json", makeReport());
+    await runClusterArtifactsCli([reportPath]);
+    expect(process.exitCode).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("exits 1 when no positional report is given", async () => {
+    await runClusterArtifactsCli(["--bundle-dir", dir]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("--help prints usage", async () => {
+    await runClusterArtifactsCli(["--help"]);
+    expect(logged()).toContain("Usage: chaosbringer cluster-artifacts");
+  });
+
+  it("throws on a non-report JSON file", async () => {
+    const bad = join(dir, "bad.json");
+    writeFileSync(bad, JSON.stringify({ totally: "wrong" }));
+    await expect(
+      runClusterArtifactsCli([bad, "--bundle-dir", dir]),
+    ).rejects.toThrow(/not a chaos report/);
+  });
+
+  it("honours --output-dir for the bundle destination", async () => {
+    const sample = err({ type: "console", message: "x", url: "http://app/x" });
+    const reportPath = writeReportFile(
+      "report.json",
+      makeReport({
+        errorClusters: [cluster({ key: "console|x", fingerprint: "x", sample })],
+      }),
+    );
+    const customOut = join(dir, "elsewhere");
+    await runClusterArtifactsCli([
+      reportPath,
+      "--bundle-dir",
+      dir,
+      "--output-dir",
+      customOut,
+      "--json",
+    ]);
+    const parsed = JSON.parse(logged());
+    expect(parsed.results[0].bundlePath.startsWith(customOut)).toBe(true);
+    // Ensure info.json actually exists in the custom location.
+    expect(readFileSync(join(parsed.results[0].bundlePath, "info.json"), "utf-8")).toContain(
+      "clusterKey",
+    );
+  });
+});

--- a/packages/chaosbringer/src/cluster-artifacts-cli.ts
+++ b/packages/chaosbringer/src/cluster-artifacts-cli.ts
@@ -1,0 +1,98 @@
+/**
+ * `chaosbringer cluster-artifacts <report.json> --bundle-dir <dir>` —
+ * post-hoc cluster bundle generator. See `cluster-artifacts.ts` for
+ * design notes.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { writeClusterArtifacts } from "./cluster-artifacts.js";
+import type { CrawlReport } from "./types.js";
+
+const HELP = `Usage: chaosbringer cluster-artifacts <report.json> --bundle-dir <dir> [options]
+
+Generate one representative artifact bundle per error cluster, drawing
+from an existing failure-artifacts directory. Outputs to
+<bundle-dir>/clusters/<sanitised-key>/ by default.
+
+Each cluster bundle contains:
+  - errors.json   filtered to just this cluster's errors
+  - info.json     cluster metadata + which page bundle it copied from
+  - page.html, trace.jsonl, repro.sh, screenshot.png   (if available
+                  in the representative page's bundle)
+
+Options:
+  --bundle-dir <dir>   Directory of per-page failure bundles (required)
+  --output-dir <dir>   Where to write cluster bundles (default <bundle-dir>/clusters)
+  --max-clusters <n>   Cap on number of cluster bundles emitted
+  --min-count <n>      Skip clusters whose count is below n (default 1)
+  --json               Print a JSON summary instead of a human-readable one
+  --help               Show this help
+
+Examples:
+  chaosbringer cluster-artifacts chaos-report.json --bundle-dir ./artifacts
+  chaosbringer cluster-artifacts report.json --bundle-dir ./artifacts --min-count 5
+`;
+
+export async function runClusterArtifactsCli(argv: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      "bundle-dir": { type: "string" },
+      "output-dir": { type: "string" },
+      "max-clusters": { type: "string" },
+      "min-count": { type: "string" },
+      json: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+  });
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (positionals.length !== 1) {
+    console.error("cluster-artifacts: expected exactly one report path");
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+  if (!values["bundle-dir"]) {
+    console.error("cluster-artifacts: --bundle-dir is required");
+    process.exitCode = 1;
+    return;
+  }
+
+  const reportPath = positionals[0];
+  let report: CrawlReport;
+  try {
+    report = JSON.parse(readFileSync(reportPath, "utf-8")) as CrawlReport;
+  } catch (err) {
+    throw new Error(`failed to read report ${reportPath}: ${err instanceof Error ? err.message : err}`);
+  }
+  if (!Array.isArray(report.errorClusters)) {
+    throw new Error(`${reportPath} is not a chaos report (no errorClusters array)`);
+  }
+
+  const results = writeClusterArtifacts(report, {
+    bundleDir: values["bundle-dir"],
+    outputDir: values["output-dir"],
+    maxClusters: values["max-clusters"] ? parseInt(values["max-clusters"], 10) : undefined,
+    minCount: values["min-count"] ? parseInt(values["min-count"], 10) : undefined,
+  });
+
+  if (values.json) {
+    console.log(JSON.stringify({ results }, null, 2));
+    return;
+  }
+
+  console.log(`Wrote ${results.length} cluster bundle(s).`);
+  for (const r of results) {
+    const note = r.representativeBundleFound
+      ? `copied [${r.copiedFiles.join(", ")}]`
+      : "no per-page bundle found — wrote errors.json + info.json only";
+    console.log(`  ${r.clusterKey}`);
+    console.log(`    → ${r.bundlePath}`);
+    console.log(`    representative: ${r.representativeUrl ?? "(none)"}  ${note}`);
+  }
+}

--- a/packages/chaosbringer/src/cluster-artifacts.test.ts
+++ b/packages/chaosbringer/src/cluster-artifacts.test.ts
@@ -218,4 +218,59 @@ describe("writeClusterArtifacts", () => {
     const [result] = writeClusterArtifacts(report, { bundleDir: dir });
     expect(result.representativeBundleFound).toBe(true);
   });
+
+  it("returns an empty result list for a report with no error clusters", () => {
+    const results = writeClusterArtifacts(makeReport(), { bundleDir: dir });
+    expect(results).toEqual([]);
+  });
+
+  it("tolerates a non-existent bundleDir (no representative bundle, errors.json still written)", () => {
+    const sample = err({ type: "console", message: "x", url: "http://app/x" });
+    const report = makeReport({
+      pages: [page({ url: "http://app/x", errors: [sample] })],
+      errorClusters: [cluster({ key: "console|x", fingerprint: "x", sample, urls: ["http://app/x"] })],
+    });
+    const ghostDir = join(dir, "does-not-exist");
+    const outputDir = join(dir, "out");
+    const [result] = writeClusterArtifacts(report, { bundleDir: ghostDir, outputDir });
+    expect(result.representativeBundleFound).toBe(false);
+    expect(result.copiedFiles).toEqual([]);
+    expect(readFileSync(join(result.bundlePath, "errors.json"), "utf-8")).toContain("x");
+  });
+
+  it("picks the earliest sequence-prefixed bundle when multiple bundles exist for one URL", () => {
+    // Two bundles for the same URL (e.g. crawled twice across recovery). The
+    // index should prefer the lexicographically earliest dirname so triagers
+    // see the first failure occurrence.
+    makeBundle("0002__later", { url: "http://app/x" }, { "page.html": "later" });
+    makeBundle("0001__earlier", { url: "http://app/x" }, { "page.html": "earlier" });
+    const sample = err({ type: "console", message: "x", url: "http://app/x" });
+    const report = makeReport({
+      pages: [page({ url: "http://app/x", errors: [sample] })],
+      errorClusters: [cluster({ key: "console|x", fingerprint: "x", sample, urls: ["http://app/x"] })],
+    });
+    const [result] = writeClusterArtifacts(report, { bundleDir: dir });
+    expect(readFileSync(join(result.bundlePath, "page.html"), "utf-8")).toBe("earlier");
+  });
+
+  it("sanitises cluster keys with special characters into safe directory names", () => {
+    // Real fingerprints can contain "/", spaces, quotes, etc. The output
+    // dirname must not contain path separators or shell metacharacters.
+    const sample = err({ type: "console", message: "a/b 'c'", url: "http://app/x" });
+    const report = makeReport({
+      errorClusters: [
+        cluster({
+          key: 'console|a/b "c" foo<bar>',
+          fingerprint: 'a/b "c" foo<bar>',
+          sample,
+        }),
+      ],
+    });
+    const [result] = writeClusterArtifacts(report, { bundleDir: dir });
+    const dirName = result.bundlePath.split("/").pop()!;
+    expect(dirName).not.toMatch(/[\\/"<>'`\s]/);
+    // The original key is preserved in info.json for downstream tools.
+    const info = JSON.parse(readFileSync(join(result.bundlePath, "info.json"), "utf-8"));
+    expect(info.clusterKey).toBe('console|a/b "c" foo<bar>');
+  });
 });

--- a/packages/chaosbringer/src/cluster-artifacts.test.ts
+++ b/packages/chaosbringer/src/cluster-artifacts.test.ts
@@ -1,0 +1,221 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { writeClusterArtifacts } from "./cluster-artifacts.js";
+import type { CrawlReport, CrawlSummary, PageError, PageResult } from "./types.js";
+
+function err(o: Partial<PageError> & { type: PageError["type"]; message: string }): PageError {
+  return {
+    timestamp: 0,
+    ...o,
+  };
+}
+
+function cluster(o: Partial<ErrorCluster> & { key: string; fingerprint: string; sample: PageError }): ErrorCluster {
+  return {
+    key: o.key,
+    type: o.type ?? "console",
+    fingerprint: o.fingerprint,
+    sample: o.sample,
+    count: o.count ?? 1,
+    urls: o.urls ?? [],
+    invariantNames: o.invariantNames,
+  };
+}
+
+function makeSummary(): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    pagesWithErrors: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    invariantViolations: 0,
+    avgLoadTime: 0,
+  };
+}
+
+function page(o: Partial<PageResult> & { url: string; errors: PageError[] }): PageResult {
+  return {
+    url: o.url,
+    status: o.status ?? "success",
+    loadTime: 0,
+    errors: o.errors,
+    hasErrors: o.errors.length > 0,
+    warnings: [],
+    links: [],
+    ...o,
+  };
+}
+
+function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://localhost:3000",
+    seed: 1,
+    reproCommand: "chaosbringer",
+    startTime: 0,
+    endTime: 0,
+    duration: 0,
+    pagesVisited: 0,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: makeSummary(),
+    errorClusters: [],
+    ...overrides,
+  };
+}
+
+describe("writeClusterArtifacts", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "chaos-cluster-artifacts-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeBundle(name: string, info: { url: string }, files: Record<string, string>): string {
+    const bundlePath = join(dir, name);
+    mkdirSync(bundlePath, { recursive: true });
+    writeFileSync(join(bundlePath, "info.json"), JSON.stringify(info));
+    for (const [filename, content] of Object.entries(files)) {
+      writeFileSync(join(bundlePath, filename), content);
+    }
+    return bundlePath;
+  }
+
+  it("emits one cluster bundle per cluster with copied files + filtered errors", () => {
+    makeBundle("0000__app_x__abcdef01", { url: "http://app/x" }, {
+      "page.html": "<html>x</html>",
+      "trace.jsonl": '{"event":"visit"}',
+      "repro.sh": "#!/bin/sh\necho x",
+    });
+    const errA = err({ type: "console", message: "boom 123", url: "http://app/x" });
+    const errB = err({ type: "console", message: "boom 456", url: "http://app/x" });
+    const errOther = err({ type: "network", message: "other", url: "http://app/x" });
+    const report = makeReport({
+      pages: [page({ url: "http://app/x", errors: [errA, errB, errOther] })],
+      errorClusters: [
+        cluster({
+          key: "console|boom <n>",
+          type: "console",
+          fingerprint: "boom <n>",
+          sample: errA,
+          count: 2,
+          urls: ["http://app/x"],
+        }),
+      ],
+    });
+
+    const results = writeClusterArtifacts(report, { bundleDir: dir });
+    expect(results).toHaveLength(1);
+    const out = results[0];
+    expect(out.representativeBundleFound).toBe(true);
+    expect(out.copiedFiles).toEqual(expect.arrayContaining(["page.html", "trace.jsonl", "repro.sh"]));
+
+    // Copied files exist in cluster bundle.
+    expect(readFileSync(join(out.bundlePath, "page.html"), "utf-8")).toBe("<html>x</html>");
+    expect(readFileSync(join(out.bundlePath, "trace.jsonl"), "utf-8")).toBe('{"event":"visit"}');
+
+    // errors.json filtered to ONLY the two console "boom" errors (not the network one).
+    const errors = JSON.parse(readFileSync(join(out.bundlePath, "errors.json"), "utf-8"));
+    expect(errors).toHaveLength(2);
+    expect(errors.every((e: PageError) => e.type === "console")).toBe(true);
+
+    // info.json carries cluster metadata + the original key.
+    const info = JSON.parse(readFileSync(join(out.bundlePath, "info.json"), "utf-8"));
+    expect(info.clusterKey).toBe("console|boom <n>");
+    expect(info.count).toBe(2);
+    expect(info.representative.url).toBe("http://app/x");
+  });
+
+  it("writes errors.json + info.json even when no per-page bundle is found", () => {
+    // Cluster's representative URL has no failure bundle on disk.
+    const sample = err({ type: "console", message: "no bundle", url: "http://app/y" });
+    const report = makeReport({
+      pages: [page({ url: "http://app/y", errors: [sample] })],
+      errorClusters: [
+        cluster({
+          key: "console|no bundle",
+          fingerprint: "no bundle",
+          sample,
+          count: 1,
+          urls: ["http://app/y"],
+        }),
+      ],
+    });
+
+    const [result] = writeClusterArtifacts(report, { bundleDir: dir });
+    expect(result.representativeBundleFound).toBe(false);
+    expect(result.copiedFiles).toEqual([]);
+    expect(existsSync(join(result.bundlePath, "errors.json"))).toBe(true);
+    expect(existsSync(join(result.bundlePath, "info.json"))).toBe(true);
+    expect(existsSync(join(result.bundlePath, "page.html"))).toBe(false);
+  });
+
+  it("honours minCount to filter low-frequency clusters", () => {
+    const sample = err({ type: "console", message: "rare", url: "http://app/z" });
+    const report = makeReport({
+      pages: [page({ url: "http://app/z", errors: [sample] })],
+      errorClusters: [
+        cluster({ key: "console|rare", fingerprint: "rare", sample, count: 1, urls: ["http://app/z"] }),
+        cluster({ key: "console|frequent", fingerprint: "frequent", sample, count: 10, urls: ["http://app/z"] }),
+      ],
+    });
+    const results = writeClusterArtifacts(report, { bundleDir: dir, minCount: 5 });
+    expect(results).toHaveLength(1);
+    expect(results[0].clusterKey).toBe("console|frequent");
+  });
+
+  it("honours maxClusters", () => {
+    const sample = err({ type: "console", message: "x", url: "http://app/a" });
+    const report = makeReport({
+      errorClusters: [
+        cluster({ key: "console|a", fingerprint: "a", sample, count: 3 }),
+        cluster({ key: "console|b", fingerprint: "b", sample, count: 2 }),
+        cluster({ key: "console|c", fingerprint: "c", sample, count: 1 }),
+      ],
+    });
+    const results = writeClusterArtifacts(report, { bundleDir: dir, maxClusters: 2 });
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.clusterKey)).toEqual(["console|a", "console|b"]);
+  });
+
+  it("respects custom outputDir", () => {
+    const sample = err({ type: "console", message: "x", url: "http://app/a" });
+    const report = makeReport({
+      errorClusters: [cluster({ key: "console|x", fingerprint: "x", sample })],
+    });
+    const customOut = join(dir, "elsewhere");
+    const [result] = writeClusterArtifacts(report, { bundleDir: dir, outputDir: customOut });
+    expect(result.bundlePath.startsWith(customOut)).toBe(true);
+  });
+
+  it("ignores existing 'clusters' subdirectory when indexing bundles", () => {
+    // Simulate a previous run: the per-page bundle dir already contains a
+    // `clusters/` subdir. It must not be misread as a page bundle.
+    mkdirSync(join(dir, "clusters", "left-over"), { recursive: true });
+    writeFileSync(join(dir, "clusters", "left-over", "info.json"), JSON.stringify({ url: "http://noise" }));
+    makeBundle("0000__app_x__deadbeef", { url: "http://app/x" }, { "page.html": "x" });
+
+    const sample = err({ type: "console", message: "x", url: "http://app/x" });
+    const report = makeReport({
+      pages: [page({ url: "http://app/x", errors: [sample] })],
+      errorClusters: [cluster({ key: "console|x", fingerprint: "x", sample, urls: ["http://app/x"] })],
+    });
+    const [result] = writeClusterArtifacts(report, { bundleDir: dir });
+    expect(result.representativeBundleFound).toBe(true);
+  });
+});

--- a/packages/chaosbringer/src/cluster-artifacts.ts
+++ b/packages/chaosbringer/src/cluster-artifacts.ts
@@ -1,0 +1,203 @@
+/**
+ * Per-cluster representative artifact bundles.
+ *
+ * `failure-artifacts.ts` writes one bundle per failing page, which is the
+ * right granularity for reproducing a specific failure but the wrong one
+ * for issue-writing: a cluster with 30 pages produces 30 directories the
+ * triager has to skim. The cluster bundle picks ONE representative page
+ * per cluster and copies its evidence (HTML, trace, repro.sh) into
+ * `<dir>/clusters/<clusterKey>/`, alongside a `errors.json` filtered to
+ * the cluster's own errors and an `info.json` with cluster metadata.
+ *
+ * Designed to run post-hoc against an already-written failure-artifacts
+ * directory: takes the final report + the directory and produces the
+ * cluster bundles without needing the crawler in the loop. That makes
+ * the operation re-runnable and re-targetable (different output dirs,
+ * different filtering) from a saved report.
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+import type { ErrorCluster } from "./clusters.js";
+import { fingerprintError } from "./clusters.js";
+import type { CrawlReport, PageError } from "./types.js";
+
+/** Files copied verbatim from the representative page bundle. */
+const COPYABLE_FILES = ["page.html", "trace.jsonl", "repro.sh", "screenshot.png"] as const;
+type CopyableFile = (typeof COPYABLE_FILES)[number];
+
+export interface WriteClusterArtifactsOptions {
+  /** Directory where per-page failure bundles live (i.e. failureArtifacts.dir). */
+  bundleDir: string;
+  /**
+   * Output directory for cluster bundles. Defaults to `<bundleDir>/clusters`.
+   * Keeping the default under bundleDir means the existing artefact upload
+   * step in CI picks up both per-page and per-cluster bundles for free.
+   */
+  outputDir?: string;
+  /** Maximum cluster bundles to emit. Defaults to all clusters. */
+  maxClusters?: number;
+  /**
+   * Skip clusters whose count is below this threshold. Defaults to 1
+   * (no filtering). Useful when triaging a noisy run — `--min-count 5`
+   * surfaces only the recurring failures.
+   */
+  minCount?: number;
+}
+
+export interface ClusterArtifactResult {
+  clusterKey: string;
+  /** Directory written, relative to outputDir. */
+  bundlePath: string;
+  /** Page URL chosen as representative (cluster.urls[0]). */
+  representativeUrl: string | null;
+  /** True when an existing per-page bundle was found and copied from. */
+  representativeBundleFound: boolean;
+  /** Files actually copied (subset of COPYABLE_FILES). */
+  copiedFiles: CopyableFile[];
+}
+
+interface BundleInfoJson {
+  url: string;
+}
+
+/**
+ * Build a map from page URL → bundle directory by reading each
+ * `info.json` under `bundleDir`. Done once up front because per-page
+ * bundle directory names are URL-derived but not URL-encoded — round-
+ * tripping URL → dirname would re-implement `failureBundleKey` here and
+ * silently break if that function evolves.
+ */
+function buildUrlIndex(bundleDir: string): Map<string, string> {
+  const idx = new Map<string, string>();
+  if (!existsSync(bundleDir)) return idx;
+  for (const entry of readdirSync(bundleDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === "clusters") continue;
+    const infoPath = join(bundleDir, entry.name, "info.json");
+    if (!existsSync(infoPath)) continue;
+    try {
+      const info = JSON.parse(readFileSync(infoPath, "utf-8")) as BundleInfoJson;
+      if (typeof info.url === "string") {
+        // Prefer the earliest bundle for a given URL — the lexicographically
+        // first directory name has the smallest sequence prefix.
+        if (!idx.has(info.url)) idx.set(info.url, join(bundleDir, entry.name));
+      }
+    } catch {
+      // Skip unreadable / non-JSON info files — they're not the bundles we want.
+    }
+  }
+  return idx;
+}
+
+/**
+ * Sanitise a cluster key into a filesystem-safe directory name. Cluster
+ * keys are `<type>|<fingerprint>` where the fingerprint can contain
+ * arbitrary characters — slashes, quotes, control chars — so we strip
+ * them aggressively. The original key is preserved in the bundle's
+ * `info.json`, so downstream tools that need the exact key still have
+ * it.
+ */
+function sanitizeClusterKey(key: string): string {
+  return (
+    key
+      .replace(/[^A-Za-z0-9._|-]+/g, "_")
+      .replace(/_+/g, "_")
+      .replace(/^_|_$/g, "")
+      .slice(0, 80) || "cluster"
+  );
+}
+
+/**
+ * Filter a report's page errors down to those that belong to a
+ * specific cluster. Re-runs the fingerprint hash since `errorClusters`
+ * carries counts but not the individual underlying errors.
+ */
+function errorsForCluster(report: CrawlReport, cluster: ErrorCluster): PageError[] {
+  const matches: PageError[] = [];
+  for (const page of report.pages) {
+    for (const err of page.errors) {
+      if (err.type !== cluster.type) continue;
+      if (fingerprintError(err) !== cluster.fingerprint) continue;
+      matches.push(err);
+    }
+  }
+  return matches;
+}
+
+/**
+ * Write one cluster bundle per cluster in the report. Returns metadata
+ * about each emitted bundle so the caller can log / surface counts.
+ */
+export function writeClusterArtifacts(
+  report: CrawlReport,
+  options: WriteClusterArtifactsOptions,
+): ClusterArtifactResult[] {
+  const outputDir = options.outputDir ?? join(options.bundleDir, "clusters");
+  const minCount = options.minCount ?? 1;
+  const max = options.maxClusters ?? Number.POSITIVE_INFINITY;
+
+  mkdirSync(outputDir, { recursive: true });
+  const urlIndex = buildUrlIndex(options.bundleDir);
+
+  const results: ClusterArtifactResult[] = [];
+  let emitted = 0;
+  for (const cluster of report.errorClusters) {
+    if (emitted >= max) break;
+    if (cluster.count < minCount) continue;
+
+    const dirName = sanitizeClusterKey(cluster.key);
+    const bundlePath = join(outputDir, dirName);
+    mkdirSync(bundlePath, { recursive: true });
+
+    const repUrl = cluster.urls[0] ?? null;
+    const sourceBundle = repUrl ? urlIndex.get(repUrl) ?? null : null;
+
+    const copied: CopyableFile[] = [];
+    if (sourceBundle) {
+      for (const name of COPYABLE_FILES) {
+        const src = join(sourceBundle, name);
+        if (!existsSync(src)) continue;
+        copyFileSync(src, join(bundlePath, name));
+        copied.push(name);
+      }
+    }
+
+    const errors = errorsForCluster(report, cluster);
+    writeFileSync(join(bundlePath, "errors.json"), JSON.stringify(errors, null, 2));
+
+    const info = {
+      clusterKey: cluster.key,
+      type: cluster.type,
+      fingerprint: cluster.fingerprint,
+      count: cluster.count,
+      urls: cluster.urls,
+      invariantNames: cluster.invariantNames,
+      representative: {
+        url: repUrl,
+        bundleDir: sourceBundle ? basename(sourceBundle) : null,
+      },
+      copiedFiles: copied,
+      baseUrl: report.baseUrl,
+      seed: report.seed,
+    };
+    writeFileSync(join(bundlePath, "info.json"), JSON.stringify(info, null, 2));
+
+    results.push({
+      clusterKey: cluster.key,
+      bundlePath,
+      representativeUrl: repUrl,
+      representativeBundleFound: !!sourceBundle,
+      copiedFiles: copied,
+    });
+    emitted++;
+  }
+  return results;
+}

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -182,6 +182,91 @@ export const COMMON_IGNORE_PATTERNS = [
 ];
 
 /**
+ * Named bundles of regex patterns for `--exclude` / `excludePatterns`.
+ *
+ * Real-world crawls hit the same families of third-party noise (analytics
+ * pixels, embedded map tiles, video players) again and again. Each preset
+ * names one such family so wrapper scripts can write `--ignore-preset
+ * analytics,maps` instead of pasting 8 regexes. Presets compose with
+ * `--exclude` — both are unioned before the pattern test runs.
+ *
+ * Keys are intentionally short and stable. Adding a new pattern to an
+ * existing preset is backward-compatible; renaming a preset is not.
+ */
+export const IGNORE_PRESETS: Record<string, readonly string[]> = {
+  // Analytics / tag managers / ad-conversion endpoints. Overlaps with
+  // COMMON_IGNORE_PATTERNS but explicit so the preset is self-contained.
+  analytics: [
+    "cloudflareinsights\\.com",
+    "googletagmanager\\.com",
+    "google-analytics\\.com",
+    "analytics\\.google\\.com",
+    "googleadservices\\.com",
+    "doubleclick\\.net",
+    "facebook\\.net",
+    "connect\\.facebook\\.net",
+    "hotjar\\.com",
+    "clarity\\.ms",
+    "segment\\.io",
+    "amplitude\\.com",
+    "mixpanel\\.com",
+  ],
+  // Embedded map iframes + map script/tile requests.
+  maps: [
+    "maps\\.googleapis\\.com",
+    "maps\\.google\\.com",
+    "mapbox\\.com",
+    "openstreetmap\\.org",
+    "tile\\.openstreetmap\\.org",
+  ],
+  // Video / audio player embeds.
+  "media-embeds": [
+    "youtube\\.com/embed",
+    "youtube-nocookie\\.com",
+    "player\\.vimeo\\.com",
+    "vimeocdn\\.com",
+    "soundcloud\\.com/player",
+    "spotify\\.com/embed",
+  ],
+  // Chrome's Opaque Response Blocking (ORB) failures for PDFs / cross-origin
+  // documents — generic enough to drown out real failures otherwise.
+  "pdf-orb": [
+    "ERR_BLOCKED_BY_ORB",
+    "net::ERR_BLOCKED_BY_ORB",
+    "\\.pdf$",
+  ],
+  // Blocked sandboxed iframe sub-requests — common in embedded widgets.
+  "iframe-sandbox": [
+    "sandbox attribute",
+    "Blocked a frame with origin",
+    "Refused to display .* in a frame",
+  ],
+};
+
+/**
+ * Resolve a comma-separated preset spec into a flat list of regex
+ * strings. Unknown preset names throw with the available keys listed —
+ * silent fall-through would let typos drop the user's noise filter and
+ * spam the report.
+ */
+export function resolveIgnorePresets(spec: string): string[] {
+  const out: string[] = [];
+  const known = Object.keys(IGNORE_PRESETS);
+  for (const raw of spec.split(",")) {
+    const name = raw.trim();
+    if (!name) continue;
+    const preset = IGNORE_PRESETS[name];
+    if (!preset) {
+      throw new Error(
+        `unknown ignore preset "${name}". Available: ${known.join(", ")}`,
+      );
+    }
+    out.push(...preset);
+  }
+  return out;
+}
+
+/**
  * Parse a W3C traceparent header. Returns `null` if the value is malformed.
  * Used by the route handler when honouring an incoming traceparent so we
  * can still pass `traceId` / `spanId` to the consumer hook.

--- a/packages/chaosbringer/src/diff-cli.test.ts
+++ b/packages/chaosbringer/src/diff-cli.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ErrorCluster } from "./clusters.js";
+import { runDiffCli } from "./diff-cli.js";
+import type { CrawlReport, CrawlSummary, PageError } from "./types.js";
+
+function cluster(o: Partial<ErrorCluster> & { key: string; fingerprint: string }): ErrorCluster {
+  const sample: PageError = { type: "console", message: o.fingerprint, timestamp: 0 };
+  return {
+    key: o.key,
+    type: o.type ?? "console",
+    fingerprint: o.fingerprint,
+    sample,
+    count: o.count ?? 1,
+    urls: o.urls ?? [],
+    invariantNames: o.invariantNames,
+  };
+}
+
+function makeSummary(): CrawlSummary {
+  return {
+    successPages: 0,
+    errorPages: 0,
+    timeoutPages: 0,
+    recoveredPages: 0,
+    pagesWithErrors: 0,
+    consoleErrors: 0,
+    networkErrors: 0,
+    jsExceptions: 0,
+    unhandledRejections: 0,
+    invariantViolations: 0,
+    avgLoadTime: 0,
+  };
+}
+
+function makeReport(overrides: Partial<CrawlReport> = {}): CrawlReport {
+  return {
+    baseUrl: "http://localhost:3000",
+    seed: 1,
+    reproCommand: "chaosbringer",
+    startTime: 0,
+    endTime: 0,
+    duration: 0,
+    pagesVisited: 0,
+    totalErrors: 0,
+    totalWarnings: 0,
+    blockedExternalNavigations: 0,
+    recoveryCount: 0,
+    pages: [],
+    actions: [],
+    summary: makeSummary(),
+    errorClusters: [],
+    ...overrides,
+  };
+}
+
+describe("runDiffCli", () => {
+  let dir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "chaos-diff-cli-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.exitCode = 0;
+  });
+
+  function writeReport(name: string, report: CrawlReport): string {
+    const p = join(dir, name);
+    writeFileSync(p, JSON.stringify(report));
+    return p;
+  }
+
+  function output(): string {
+    return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  }
+
+  it("classifies clusters into left-only, right-only, and shared", async () => {
+    const leftPath = writeReport(
+      "left.json",
+      makeReport({
+        errorClusters: [
+          cluster({ key: "console|only-left", fingerprint: "only-left", count: 2 }),
+          cluster({ key: "console|shared", fingerprint: "shared", count: 5 }),
+        ],
+      }),
+    );
+    const rightPath = writeReport(
+      "right.json",
+      makeReport({
+        errorClusters: [
+          cluster({ key: "console|only-right", fingerprint: "only-right", count: 1 }),
+          cluster({ key: "console|shared", fingerprint: "shared", count: 4 }),
+        ],
+      }),
+    );
+    await runDiffCli([leftPath, rightPath, "--json"]);
+    const out = JSON.parse(output());
+    expect(out.leftOnlyClusters.map((c: { key: string }) => c.key)).toEqual([
+      "console|only-left",
+    ]);
+    expect(out.rightOnlyClusters.map((c: { key: string }) => c.key)).toEqual([
+      "console|only-right",
+    ]);
+    expect(out.sharedClusters.map((c: { key: string }) => c.key)).toEqual(["console|shared"]);
+  });
+
+  it("--right-only filters to clusters present only on the right", async () => {
+    const leftPath = writeReport(
+      "left.json",
+      makeReport({ errorClusters: [cluster({ key: "console|shared", fingerprint: "shared" })] }),
+    );
+    const rightPath = writeReport(
+      "right.json",
+      makeReport({
+        errorClusters: [
+          cluster({ key: "console|shared", fingerprint: "shared" }),
+          cluster({ key: "console|only-right", fingerprint: "only-right", count: 3 }),
+        ],
+      }),
+    );
+    await runDiffCli([leftPath, rightPath, "--right-only"]);
+    const out = output();
+    expect(out).toContain("console|only-right");
+    expect(out).not.toContain("console|shared");
+  });
+
+  it("exits with code 1 and prints help when positionals are missing", async () => {
+    await runDiffCli(["only-one.json"]);
+    expect(process.exitCode).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("throws a clear error for a non-report JSON file", async () => {
+    const bad = join(dir, "bad.json");
+    writeFileSync(bad, JSON.stringify({ totally: "wrong" }));
+    const other = writeReport("right.json", makeReport());
+    await expect(runDiffCli([bad, other])).rejects.toThrow(/not a chaos report/);
+  });
+
+  it("--help prints usage and exits cleanly", async () => {
+    await runDiffCli(["--help"]);
+    const out = output();
+    expect(out).toMatch(/Usage: chaosbringer diff/);
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/packages/chaosbringer/src/diff-cli.ts
+++ b/packages/chaosbringer/src/diff-cli.ts
@@ -1,0 +1,215 @@
+/**
+ * `chaosbringer diff <left.json> <right.json>` — compare two independent
+ * crawl reports and surface cluster / page differences.
+ *
+ * Distinct from `--baseline`, which assumes the left is "yesterday's
+ * good run" and the right is "today's run". The standalone subcommand
+ * is symmetric: it shows left-only, right-only, and shared clusters
+ * without claiming a direction. Designed for the dual-runtime
+ * regression workflow described in #88 — same site data, two runtimes,
+ * separate which clusters are unique to each side from third-party
+ * noise that appears in both.
+ *
+ * The heavy lifting (cluster matching, page state computation) lives
+ * in `diffReports` so behaviour stays consistent with `--baseline`.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { diffReports } from "./diff.js";
+import type { CrawlReport } from "./types.js";
+
+function loadReport(path: string): CrawlReport {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new Error(`failed to read ${path}: ${err instanceof Error ? err.message : err}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`failed to parse ${path}: ${err instanceof Error ? err.message : err}`);
+  }
+  const report = parsed as CrawlReport;
+  if (!report || typeof report !== "object" || !Array.isArray(report.errorClusters)) {
+    throw new Error(`${path} is not a chaos report (no errorClusters array)`);
+  }
+  return report;
+}
+
+interface DiffSummary {
+  left: string;
+  right: string;
+  leftOnlyClusters: Array<{ key: string; type: string; count: number }>;
+  rightOnlyClusters: Array<{ key: string; type: string; count: number }>;
+  sharedClusters: Array<{ key: string; type: string; leftCount: number; rightCount: number }>;
+  leftOnlyFailedPages: Array<{ url: string; errors: number }>;
+  rightOnlyFailedPages: Array<{ url: string; errors: number }>;
+}
+
+/**
+ * Reframe `diffReports` from the symmetric two-runtime perspective.
+ *
+ * `diffReports(baseline, current)` calls things `new` / `resolved`
+ * relative to the baseline. For two-runtime diffing we don't have a
+ * baseline — we want "only on left", "only on right", "on both". The
+ * mapping:
+ *
+ *   - newClusters       — in right, not in left   → rightOnly
+ *   - resolvedClusters  — in left,  not in right  → leftOnly
+ *   - unchangedClusters — in both                 → shared
+ *
+ * Same logic applies to failed pages.
+ */
+function buildSummary(leftPath: string, rightPath: string): DiffSummary {
+  const left = loadReport(leftPath);
+  const right = loadReport(rightPath);
+  const d = diffReports(left, right);
+  return {
+    left: leftPath,
+    right: rightPath,
+    leftOnlyClusters: d.resolvedClusters.map((c) => ({
+      key: c.key,
+      type: c.type,
+      count: c.before,
+    })),
+    rightOnlyClusters: d.newClusters.map((c) => ({
+      key: c.key,
+      type: c.type,
+      count: c.after,
+    })),
+    sharedClusters: d.unchangedClusters.map((c) => ({
+      key: c.key,
+      type: c.type,
+      leftCount: c.before,
+      rightCount: c.after,
+    })),
+    leftOnlyFailedPages: d.resolvedFailedPages
+      .filter((p) => p.before !== null)
+      .map((p) => ({ url: p.url, errors: p.before!.errors })),
+    rightOnlyFailedPages: d.newFailedPages.map((p) => ({
+      url: p.url,
+      errors: p.after?.errors ?? 0,
+    })),
+  };
+}
+
+function formatHuman(s: DiffSummary): string {
+  const out: string[] = [];
+  out.push(`Comparing:`);
+  out.push(`  left  = ${s.left}`);
+  out.push(`  right = ${s.right}`);
+  out.push("");
+  out.push(`Clusters: ${s.leftOnlyClusters.length} left-only, ${s.rightOnlyClusters.length} right-only, ${s.sharedClusters.length} shared`);
+  out.push(`Pages:    ${s.leftOnlyFailedPages.length} failed only on left, ${s.rightOnlyFailedPages.length} only on right`);
+  out.push("");
+  if (s.leftOnlyClusters.length > 0) {
+    out.push("Left-only clusters:");
+    for (const c of s.leftOnlyClusters) {
+      out.push(`  [${c.type}] ${c.key} (${c.count})`);
+    }
+    out.push("");
+  }
+  if (s.rightOnlyClusters.length > 0) {
+    out.push("Right-only clusters:");
+    for (const c of s.rightOnlyClusters) {
+      out.push(`  [${c.type}] ${c.key} (${c.count})`);
+    }
+    out.push("");
+  }
+  if (s.sharedClusters.length > 0) {
+    out.push("Shared clusters (likely third-party noise):");
+    for (const c of s.sharedClusters) {
+      out.push(`  [${c.type}] ${c.key} (left=${c.leftCount}, right=${c.rightCount})`);
+    }
+    out.push("");
+  }
+  if (s.leftOnlyFailedPages.length > 0) {
+    out.push("Pages failing only on left:");
+    for (const p of s.leftOnlyFailedPages) {
+      out.push(`  ${p.url} (${p.errors} errors)`);
+    }
+    out.push("");
+  }
+  if (s.rightOnlyFailedPages.length > 0) {
+    out.push("Pages failing only on right:");
+    for (const p of s.rightOnlyFailedPages) {
+      out.push(`  ${p.url} (${p.errors} errors)`);
+    }
+    out.push("");
+  }
+  return out.join("\n");
+}
+
+const HELP = `Usage: chaosbringer diff <left.json> <right.json> [options]
+
+Compare two independent crawl reports. Shows clusters that appear only
+on the left, only on the right, and in both (likely third-party noise).
+
+Options:
+  --json                Output JSON instead of a human-readable summary
+  --shared-only         Print only the shared clusters
+  --left-only           Print only the left-only clusters/pages
+  --right-only          Print only the right-only clusters/pages
+  --help                Show this help
+
+Examples:
+  chaosbringer diff old.json new.json
+  chaosbringer diff runtime-a.json runtime-b.json --json > diff.json
+  chaosbringer diff a.json b.json --right-only  # show what's broken only on the right
+`;
+
+export async function runDiffCli(argv: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      json: { type: "boolean", default: false },
+      "shared-only": { type: "boolean", default: false },
+      "left-only": { type: "boolean", default: false },
+      "right-only": { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+  });
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (positionals.length !== 2) {
+    console.error("diff: expected exactly two report paths");
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+  const [leftPath, rightPath] = positionals;
+  const summary = buildSummary(leftPath, rightPath);
+
+  if (values.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  // Filtered views — useful for piping into wrapper scripts that only
+  // care about one side. Filters are exclusive: enabling one suppresses
+  // the others.
+  if (values["shared-only"]) {
+    for (const c of summary.sharedClusters) {
+      console.log(`[${c.type}] ${c.key} (left=${c.leftCount}, right=${c.rightCount})`);
+    }
+    return;
+  }
+  if (values["left-only"]) {
+    for (const c of summary.leftOnlyClusters) console.log(`[${c.type}] ${c.key} (${c.count})`);
+    for (const p of summary.leftOnlyFailedPages) console.log(`PAGE ${p.url} (${p.errors} errors)`);
+    return;
+  }
+  if (values["right-only"]) {
+    for (const c of summary.rightOnlyClusters) console.log(`[${c.type}] ${c.key} (${c.count})`);
+    for (const p of summary.rightOnlyFailedPages) console.log(`PAGE ${p.url} (${p.errors} errors)`);
+    return;
+  }
+
+  console.log(formatHuman(summary));
+}

--- a/packages/chaosbringer/src/ignore-presets.test.ts
+++ b/packages/chaosbringer/src/ignore-presets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { IGNORE_PRESETS, resolveIgnorePresets } from "./crawler.js";
+
+describe("resolveIgnorePresets", () => {
+  it("resolves a single preset to its bundled patterns", () => {
+    const out = resolveIgnorePresets("maps");
+    expect(out).toEqual([...IGNORE_PRESETS.maps]);
+  });
+
+  it("unions comma-separated presets in declaration order", () => {
+    const out = resolveIgnorePresets("maps,analytics");
+    expect(out).toEqual([...IGNORE_PRESETS.maps, ...IGNORE_PRESETS.analytics]);
+  });
+
+  it("trims whitespace and ignores empty tokens", () => {
+    const out = resolveIgnorePresets("  maps  , , analytics ");
+    expect(out).toEqual([...IGNORE_PRESETS.maps, ...IGNORE_PRESETS.analytics]);
+  });
+
+  it("throws on unknown preset with the available list", () => {
+    expect(() => resolveIgnorePresets("not-real")).toThrow(/unknown ignore preset "not-real"/);
+    expect(() => resolveIgnorePresets("not-real")).toThrow(/Available:/);
+  });
+
+  it("ships the four documented presets", () => {
+    for (const key of ["analytics", "maps", "media-embeds", "pdf-orb", "iframe-sandbox"]) {
+      expect(IGNORE_PRESETS).toHaveProperty(key);
+      expect(IGNORE_PRESETS[key].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/chaosbringer/src/ignore-presets.test.ts
+++ b/packages/chaosbringer/src/ignore-presets.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from "vitest";
 import { IGNORE_PRESETS, resolveIgnorePresets } from "./crawler.js";
+import { matchesAnyPattern } from "./filters.js";
+
+/**
+ * The presets are regex strings consumed by `matchesAnyPattern`. If a
+ * pattern is mis-escaped (forgotten backslash on a dot, wrong anchor)
+ * it silently fails to match the third-party noise it's meant to
+ * filter. These tests pin each preset to a realistic example string
+ * so a regex typo on edit fails loudly.
+ */
+const REPRESENTATIVE_NOISE: Record<string, string[]> = {
+  analytics: [
+    "https://www.googletagmanager.com/gtm.js",
+    "Failed to load https://connect.facebook.net/en_US/fbevents.js",
+    "Mixpanel error from cdn.mixpanel.com",
+  ],
+  maps: [
+    "GET https://maps.googleapis.com/maps/api/js failed",
+    "https://tile.openstreetmap.org/1/0/0.png",
+  ],
+  "media-embeds": [
+    "https://www.youtube.com/embed/abc",
+    "https://player.vimeo.com/video/123",
+  ],
+  "pdf-orb": [
+    "net::ERR_BLOCKED_BY_ORB",
+    "Refused to load /docs/sample.pdf",
+  ],
+  "iframe-sandbox": [
+    "Blocked a frame with origin \"null\" from accessing a cross-origin frame.",
+  ],
+};
 
 describe("resolveIgnorePresets", () => {
   it("resolves a single preset to its bundled patterns", () => {
@@ -27,5 +58,30 @@ describe("resolveIgnorePresets", () => {
       expect(IGNORE_PRESETS).toHaveProperty(key);
       expect(IGNORE_PRESETS[key].length).toBeGreaterThan(0);
     }
+  });
+
+  describe("preset patterns match representative noise (regression guard)", () => {
+    for (const [preset, samples] of Object.entries(REPRESENTATIVE_NOISE)) {
+      it(`'${preset}' matches all of its targeted noise strings`, () => {
+        const patterns = IGNORE_PRESETS[preset];
+        for (const sample of samples) {
+          expect(
+            matchesAnyPattern(sample, patterns, "i"),
+            `preset='${preset}' should match: ${sample}`,
+          ).toBe(true);
+        }
+      });
+    }
+
+    it("presets do not match unrelated error strings (no over-broad regex)", () => {
+      // A real application error must not be silently dropped by ANY preset.
+      const realError = "TypeError: Cannot read properties of undefined";
+      for (const [name, patterns] of Object.entries(IGNORE_PRESETS)) {
+        expect(
+          matchesAnyPattern(realError, patterns, "i"),
+          `preset='${name}' incorrectly matched a real app error`,
+        ).toBe(false);
+      }
+    });
   });
 });

--- a/packages/chaosbringer/src/index.test.ts
+++ b/packages/chaosbringer/src/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Smoke test for the public package entry. If `index.ts` accidentally
+ * stops re-exporting a name (or a name gets renamed in its source
+ * module), this test catches it at import time rather than waiting for
+ * a downstream consumer to surface the regression.
+ *
+ * Only checks the symbols this branch added; older exports are covered
+ * by their respective unit tests.
+ */
+import * as api from "./index.js";
+
+describe("public package exports (this branch's additions)", () => {
+  it("re-exports ignore-preset helpers", () => {
+    expect(typeof api.resolveIgnorePresets).toBe("function");
+    expect(api.IGNORE_PRESETS).toBeDefined();
+    expect(api.IGNORE_PRESETS.analytics).toBeDefined();
+  });
+
+  it("re-exports cluster-artifacts surface", () => {
+    expect(typeof api.writeClusterArtifacts).toBe("function");
+  });
+
+  it("re-exports parity surface", () => {
+    expect(typeof api.runParity).toBe("function");
+  });
+});

--- a/packages/chaosbringer/src/index.ts
+++ b/packages/chaosbringer/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Core
-export { ChaosCrawler, COMMON_IGNORE_PATTERNS, validateOptions } from "./crawler.js";
+export { ChaosCrawler, COMMON_IGNORE_PATTERNS, IGNORE_PRESETS, resolveIgnorePresets, validateOptions } from "./crawler.js";
 export { formatReport, formatCompactReport, saveReport, printReport, getExitCode, type ExitCodeOptions } from "./reporter.js";
 export { Logger, createNullLogger, type LogEntry, type LogLevel, type LoggerOptions } from "./logger.js";
 export { chaos, type ChaosResult, type ChaosRunOptions } from "./chaos.js";
@@ -39,6 +39,20 @@ export {
 } from "./lifecycle-faults.js";
 export { clusterErrors, fingerprintError, type ErrorCluster } from "./clusters.js";
 export { diffReports, loadBaseline, hasRegressions } from "./diff.js";
+export {
+  writeClusterArtifacts,
+  type WriteClusterArtifactsOptions,
+  type ClusterArtifactResult,
+} from "./cluster-artifacts.js";
+export {
+  runParity,
+  type MismatchKind,
+  type ParityMismatch,
+  type ParityProbe,
+  type ParityReport,
+  type RunParityOptions,
+  type SideResult,
+} from "./parity.js";
 export { checkPerformanceBudget } from "./budget.js";
 export { invariants, axe, buildAxeRunPayload, formatAxeViolations, type AxeInvariantOptions } from "./invariants.js";
 export {

--- a/packages/chaosbringer/src/parity-cli.test.ts
+++ b/packages/chaosbringer/src/parity-cli.test.ts
@@ -1,0 +1,128 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runParityCli } from "./parity-cli.js";
+
+/**
+ * The CLI calls the global `fetch`. We stub it per-test so unit tests
+ * don't go over the wire. parity.ts itself is tested with a direct
+ * fetcher injection; here we exercise the CLI surface (path-file parse,
+ * exit code, JSON output, missing-args handling).
+ */
+
+describe("runParityCli", () => {
+  let dir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "chaos-parity-cli-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+    process.exitCode = 0;
+  });
+
+  function logged(): string {
+    return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  }
+
+  function writePaths(name: string, paths: string[]): string {
+    const p = join(dir, name);
+    writeFileSync(p, paths.join("\n"));
+    return p;
+  }
+
+  function stubFetch(handlers: Record<string, () => Response | Promise<Response>>) {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const handler = handlers[url];
+      if (!handler) throw new Error(`unexpected fetch: ${url}`);
+      return handler();
+    }) as typeof fetch;
+  }
+
+  it("exits 0 when both sides agree on every path", async () => {
+    stubFetch({
+      "http://l/foo": () => new Response("", { status: 200 }),
+      "http://r/foo": () => new Response("", { status: 200 }),
+    });
+    const pathsFile = writePaths("paths.txt", ["/foo"]);
+    await runParityCli(["--left", "http://l", "--right", "http://r", "--paths", pathsFile]);
+    // `process.exitCode` stays at its default (undefined) when the CLI
+    // never sets it. Either undefined or 0 is success.
+    expect(process.exitCode === undefined || process.exitCode === 0).toBe(true);
+    expect(logged()).toContain("0 mismatch");
+  });
+
+  it("exits 1 and prints the mismatch when sides disagree", async () => {
+    stubFetch({
+      "http://l/foo": () => new Response("", { status: 200 }),
+      "http://r/foo": () => new Response("", { status: 500 }),
+    });
+    const pathsFile = writePaths("paths.txt", ["/foo"]);
+    await runParityCli(["--left", "http://l", "--right", "http://r", "--paths", pathsFile]);
+    expect(process.exitCode).toBe(1);
+    expect(logged()).toContain("STATUS");
+    expect(logged()).toContain("/foo");
+  });
+
+  it("writes the JSON report to --output, creating parent directories", async () => {
+    stubFetch({
+      "http://l/foo": () => new Response("", { status: 200 }),
+      "http://r/foo": () => new Response("", { status: 200 }),
+    });
+    const pathsFile = writePaths("paths.txt", ["/foo"]);
+    const outPath = join(dir, "nested", "deep", "parity.json");
+    await runParityCli([
+      "--left",
+      "http://l",
+      "--right",
+      "http://r",
+      "--paths",
+      pathsFile,
+      "--output",
+      outPath,
+    ]);
+    expect(existsSync(outPath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(outPath, "utf-8"));
+    expect(parsed.pathsChecked).toBe(1);
+    expect(parsed.matches).toHaveLength(1);
+  });
+
+  it("skips blank lines and #-prefixed comments in the paths file", async () => {
+    stubFetch({
+      "http://l/foo": () => new Response("", { status: 200 }),
+      "http://r/foo": () => new Response("", { status: 200 }),
+    });
+    const pathsFile = writePaths("paths.txt", ["# comment", "", "/foo", "  ", "# another"]);
+    await runParityCli(["--left", "http://l", "--right", "http://r", "--paths", pathsFile]);
+    expect(logged()).toContain("Checked 1 path(s)");
+  });
+
+  it("exits 1 with a helpful error when required flags are missing", async () => {
+    await runParityCli(["--left", "http://l"]);
+    expect(process.exitCode).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("exits 1 when the paths file has no usable entries", async () => {
+    const pathsFile = writePaths("paths.txt", ["# only comments"]);
+    await runParityCli(["--left", "http://l", "--right", "http://r", "--paths", pathsFile]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("--help prints usage", async () => {
+    await runParityCli(["--help"]);
+    expect(logged()).toContain("Usage: chaosbringer parity");
+  });
+});

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -1,0 +1,111 @@
+/**
+ * `chaosbringer parity --left URL --right URL --paths file [--output file]`.
+ * See `parity.ts` for design notes.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { parseArgs } from "node:util";
+import { runParity } from "./parity.js";
+
+const HELP = `Usage: chaosbringer parity --left <url> --right <url> --paths <file> [options]
+
+Probe the same paths against two base URLs and report routing-bug
+mismatches: status code differences, redirect target differences, and
+one-side-only fetch failures. Designed for the dual-runtime regression
+workflow where random crawls cannot isolate route divergence from
+third-party noise.
+
+Required:
+  --left <url>       First base URL
+  --right <url>      Second base URL
+  --paths <file>     File with one path per line (blank lines and lines
+                     starting with '#' are skipped)
+
+Options:
+  --output <file>    Write the full report (JSON) to this path
+  --follow-redirects Follow redirects on both sides and compare the
+                     final status. Default is manual (compare the 3xx
+                     status + Location directly, the more sensitive
+                     mode for routing-bug detection).
+  --timeout <ms>     Per-request timeout. Default 10000.
+  --help             Show this help
+
+Exit code is 1 when any mismatch is found, 0 when both sides agree on
+every path. Useful as a CI gate: \`chaosbringer parity ... || exit 1\`.
+
+Examples:
+  chaosbringer parity --left http://localhost:3000 --right http://localhost:3001 \\
+    --paths paths.txt --output parity.json
+  echo "/" | chaosbringer parity --left http://a --right http://b --paths /dev/stdin
+`;
+
+function readPaths(file: string): string[] {
+  const text = readFileSync(file, "utf-8");
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+export async function runParityCli(argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      left: { type: "string" },
+      right: { type: "string" },
+      paths: { type: "string" },
+      output: { type: "string" },
+      "follow-redirects": { type: "boolean", default: false },
+      timeout: { type: "string" },
+      help: { type: "boolean", default: false },
+    },
+  });
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (!values.left || !values.right || !values.paths) {
+    console.error("parity: --left, --right, and --paths are all required");
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+  const timeoutMs = values.timeout ? parseInt(values.timeout, 10) : undefined;
+  const paths = readPaths(values.paths);
+  if (paths.length === 0) {
+    console.error("parity: no paths found in", values.paths);
+    process.exitCode = 1;
+    return;
+  }
+
+  const report = await runParity({
+    left: values.left,
+    right: values.right,
+    paths,
+    followRedirects: values["follow-redirects"],
+    timeoutMs,
+  });
+
+  if (values.output) {
+    mkdirSync(dirname(values.output), { recursive: true });
+    writeFileSync(values.output, JSON.stringify(report, null, 2));
+  }
+
+  console.log(`Checked ${report.pathsChecked} path(s): ${report.matches.length} match, ${report.mismatches.length} mismatch.`);
+  for (const m of report.mismatches) {
+    if (m.kind === "status") {
+      console.log(`  STATUS ${m.path}  left=${m.left.status}  right=${m.right.status}`);
+    } else if (m.kind === "redirect") {
+      console.log(`  REDIR  ${m.path}  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`);
+    } else {
+      const leftMsg = m.left.error ?? `status ${m.left.status}`;
+      const rightMsg = m.right.error ?? `status ${m.right.status}`;
+      console.log(`  FAIL   ${m.path}  left=${leftMsg}  right=${rightMsg}`);
+    }
+  }
+
+  // Non-zero exit on any mismatch — makes the subcommand usable as a CI gate
+  // without an extra `jq` step on the output.
+  if (report.mismatches.length > 0) process.exitCode = 1;
+}

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { runParity } from "./parity.js";
+
+function makeFetcher(handlers: Record<string, () => Response | Promise<Response> | Promise<never>>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const handler = handlers[url];
+    if (!handler) throw new Error(`unexpected fetch: ${url}`);
+    return handler();
+  }) as typeof fetch;
+}
+
+describe("runParity", () => {
+  it("classifies matching paths as match (no mismatch)", async () => {
+    const fetcher = makeFetcher({
+      "http://left/foo": () => new Response("", { status: 200 }),
+      "http://right/foo": () => new Response("", { status: 200 }),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["foo"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.matches).toHaveLength(1);
+  });
+
+  it("flags a status mismatch when status codes differ", async () => {
+    const fetcher = makeFetcher({
+      "http://left/api": () => new Response("", { status: 200 }),
+      "http://right/api": () => new Response("", { status: 500 }),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["api"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].kind).toBe("status");
+    expect(report.mismatches[0].left.status).toBe(200);
+    expect(report.mismatches[0].right.status).toBe(500);
+  });
+
+  it("flags a redirect mismatch when 3xx Location differs", async () => {
+    const fetcher = makeFetcher({
+      "http://left/old": () =>
+        new Response("", { status: 301, headers: { location: "/new" } }),
+      "http://right/old": () =>
+        new Response("", { status: 301, headers: { location: "/elsewhere" } }),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["old"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].kind).toBe("redirect");
+    expect(report.mismatches[0].left.location).toBe("/new");
+    expect(report.mismatches[0].right.location).toBe("/elsewhere");
+  });
+
+  it("does not flag redirect on 3xx when Location matches", async () => {
+    const fetcher = makeFetcher({
+      "http://left/r": () =>
+        new Response("", { status: 302, headers: { location: "/dest" } }),
+      "http://right/r": () =>
+        new Response("", { status: 302, headers: { location: "/dest" } }),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["r"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(0);
+  });
+
+  it("flags a failure mismatch when one side throws and the other succeeds", async () => {
+    const fetcher = makeFetcher({
+      "http://left/x": () => Promise.reject(new Error("ECONNREFUSED")),
+      "http://right/x": () => new Response("", { status: 200 }),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["x"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].kind).toBe("failure");
+    expect(report.mismatches[0].left.error).toContain("ECONNREFUSED");
+    expect(report.mismatches[0].right.status).toBe(200);
+  });
+
+  it("treats both-sides-failed as a match (per spec: only one-side failures count)", async () => {
+    const fetcher = makeFetcher({
+      "http://left/y": () => Promise.reject(new Error("down")),
+      "http://right/y": () => Promise.reject(new Error("down")),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["y"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.matches).toHaveLength(1);
+  });
+
+  it("joins base URL + path without double-slashing", async () => {
+    const seen: string[] = [];
+    const fetcher = (async (input: RequestInfo | URL) => {
+      const u = typeof input === "string" ? input : input.toString();
+      seen.push(u);
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    await runParity({
+      left: "http://left",
+      right: "http://right/",
+      paths: ["/foo", "bar"],
+      fetcher,
+    });
+    expect(seen).toEqual([
+      "http://left/foo",
+      "http://right/foo",
+      "http://left/bar",
+      "http://right/bar",
+    ]);
+  });
+});

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -131,4 +131,72 @@ describe("runParity", () => {
       "http://right/bar",
     ]);
   });
+
+  it("passes redirect: 'manual' by default, 'follow' when followRedirects=true", async () => {
+    const seenInit: Array<RequestInit | undefined> = [];
+    const fetcher = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenInit.push(init);
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    await runParity({
+      left: "http://l",
+      right: "http://r",
+      paths: ["/x"],
+      fetcher,
+    });
+    expect(seenInit[0]?.redirect).toBe("manual");
+
+    seenInit.length = 0;
+    await runParity({
+      left: "http://l",
+      right: "http://r",
+      paths: ["/x"],
+      followRedirects: true,
+      fetcher,
+    });
+    expect(seenInit[0]?.redirect).toBe("follow");
+  });
+
+  it("aborts a slow request after timeoutMs and records the error", async () => {
+    const fetcher = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      // Honour the abort signal so the timeout actually fires.
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new Error("aborted by timeout"));
+        });
+      });
+    }) as typeof fetch;
+
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["slow"],
+      timeoutMs: 5,
+      fetcher,
+    });
+    // Both sides hit the same timeout, so they "match" per the both-failed rule.
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.matches).toHaveLength(1);
+    expect(report.matches[0].left.error).toBeDefined();
+    expect(report.matches[0].right.error).toBeDefined();
+  });
+
+  it("flags 3xx → 200 status mismatch (not redirect mismatch)", async () => {
+    // Same status family check guards against false-positive redirects:
+    // 301 vs 200 should be reported as a status mismatch, not a redirect mismatch.
+    const fetcher = makeFetcher({
+      "http://left/x": () =>
+        new Response("", { status: 301, headers: { location: "/dest" } }),
+      "http://right/x": () => new Response("", { status: 200 }),
+    });
+    const report = await runParity({
+      left: "http://left",
+      right: "http://right",
+      paths: ["x"],
+      fetcher,
+    });
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].kind).toBe("status");
+  });
 });

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -1,0 +1,162 @@
+/**
+ * Non-random parity probe. For each path in a list, fetch the same path
+ * against two base URLs and surface differences in status, redirect
+ * target, and request failure. This is the routing-bug detection mode
+ * — when random crawls find too much third-party noise, a deterministic
+ * same-path probe across two runtimes pinpoints where the routes
+ * actually disagree.
+ *
+ * Scope: HTTP request-level only (status codes, redirect locations,
+ * fetch failures). JavaScript exceptions and body predicates from the
+ * original feature request would need a Playwright session per probe
+ * and are deferred — the fetch-based subset covers the three top-listed
+ * comparisons (status mismatch / redirect mismatch / failed request
+ * mismatch) without paying the browser-launch tax.
+ */
+
+export type MismatchKind =
+  /** HTTP status codes differ. */
+  | "status"
+  /** One side redirected to a different Location than the other. */
+  | "redirect"
+  /** fetch() threw on one side and succeeded on the other. */
+  | "failure";
+
+export interface SideResult {
+  /** Final status. `null` when the fetch threw before getting a response. */
+  status: number | null;
+  /** Redirect target for 3xx responses, when present. */
+  location?: string | null;
+  /** Captured fetch error message when the request threw. */
+  error?: string;
+}
+
+export interface ParityProbe {
+  path: string;
+  left: SideResult;
+  right: SideResult;
+}
+
+export interface ParityMismatch extends ParityProbe {
+  /** Mismatch kinds detected for this probe. A single probe can carry
+   *  multiple kinds (e.g. left fails + right returns 200 → both
+   *  "failure" and "status" depending on the consumer's view; we record
+   *  the strongest one). */
+  kind: MismatchKind;
+}
+
+export interface ParityReport {
+  left: string;
+  right: string;
+  pathsChecked: number;
+  mismatches: ParityMismatch[];
+  /** Paths that agreed on every comparison. Carried so consumers can
+   *  prove which routes are stable without re-running. */
+  matches: ParityProbe[];
+}
+
+export interface RunParityOptions {
+  left: string;
+  right: string;
+  paths: string[];
+  /**
+   * When `true`, fetch follows redirects and the comparison uses the
+   * final status. When `false` (the default), `redirect: "manual"`
+   * is used so 3xx and the Location header are compared directly —
+   * the more sensitive mode for routing-bug detection.
+   */
+  followRedirects?: boolean;
+  /**
+   * Per-request timeout in ms. Defaults to 10s. Applied to each side
+   * independently; one slow side does not stall the other.
+   */
+  timeoutMs?: number;
+  /** Override fetch for testing. */
+  fetcher?: typeof fetch;
+}
+
+function joinBase(base: string, path: string): string {
+  // Both `<base>/foo` and `<base>foo` are common in path files. Normalise
+  // so we never double-slash or miss-slash. URL parses both cleanly.
+  return new URL(path, base.endsWith("/") ? base : `${base}/`).toString();
+}
+
+async function probeSide(
+  base: string,
+  path: string,
+  opts: { followRedirects: boolean; timeoutMs: number; fetcher: typeof fetch },
+): Promise<SideResult> {
+  const url = joinBase(base, path);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  try {
+    const resp = await opts.fetcher(url, {
+      redirect: opts.followRedirects ? "follow" : "manual",
+      signal: controller.signal,
+    });
+    return {
+      status: resp.status,
+      location: resp.headers.get("location"),
+    };
+  } catch (err) {
+    return {
+      status: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function classify(left: SideResult, right: SideResult): MismatchKind | null {
+  const leftFailed = left.status === null;
+  const rightFailed = right.status === null;
+  if (leftFailed !== rightFailed) return "failure";
+  if (leftFailed && rightFailed) {
+    // Both failed — not a parity mismatch per the feature request
+    // ("only one side fails"), so treat as a match. The caller can
+    // still see both error strings via the probe data if needed.
+    return null;
+  }
+  if (left.status !== right.status) return "status";
+  // Status matched. For 3xx, also check the redirect target.
+  if (
+    typeof left.status === "number" &&
+    left.status >= 300 &&
+    left.status < 400 &&
+    left.location !== right.location
+  ) {
+    return "redirect";
+  }
+  return null;
+}
+
+export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
+  const followRedirects = opts.followRedirects ?? false;
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const fetcher = opts.fetcher ?? fetch;
+
+  const mismatches: ParityMismatch[] = [];
+  const matches: ParityProbe[] = [];
+
+  for (const path of opts.paths) {
+    // Probe both sides in parallel — they're independent and the report
+    // is symmetric, so there's no reason to serialise.
+    const [left, right] = await Promise.all([
+      probeSide(opts.left, path, { followRedirects, timeoutMs, fetcher }),
+      probeSide(opts.right, path, { followRedirects, timeoutMs, fetcher }),
+    ]);
+    const probe: ParityProbe = { path, left, right };
+    const kind = classify(left, right);
+    if (kind) mismatches.push({ ...probe, kind });
+    else matches.push(probe);
+  }
+
+  return {
+    left: opts.left,
+    right: opts.right,
+    pathsChecked: opts.paths.length,
+    mismatches,
+    matches,
+  };
+}

--- a/packages/chaosbringer/src/reporter.test.ts
+++ b/packages/chaosbringer/src/reporter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readFileSync, existsSync, unlinkSync } from "node:fs";
+import { readFileSync, existsSync, unlinkSync, rmSync } from "node:fs";
 import { formatCompactReport, formatReport, getExitCode, saveReport } from "./reporter.js";
 import type { CrawlReport, CrawlSummary } from "./types.js";
 
@@ -241,6 +241,20 @@ describe("saveReport", () => {
       expect(parsed.baseUrl).toBe("http://localhost:3000");
     } finally {
       if (existsSync(path)) unlinkSync(path);
+    }
+  });
+
+  it("creates missing parent directories before writing", () => {
+    const rootDir = join(tmpdir(), `chaos-test-mkdir-${Date.now()}`);
+    const path = join(rootDir, "nested", "deep", "report.json");
+    try {
+      const report = makeReport({ pagesVisited: 3 });
+      saveReport(report, path);
+      expect(existsSync(path)).toBe(true);
+      const parsed = JSON.parse(readFileSync(path, "utf-8"));
+      expect(parsed.pagesVisited).toBe(3);
+    } finally {
+      if (existsSync(rootDir)) rmSync(rootDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/chaosbringer/src/reporter.ts
+++ b/packages/chaosbringer/src/reporter.ts
@@ -2,7 +2,8 @@
  * Report generation and formatting utilities
  */
 
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type { CrawlReport, PageResult } from "./types.js";
 
 export function formatReport(report: CrawlReport): string {
@@ -291,6 +292,7 @@ export function formatCompactReport(report: CrawlReport, strict: boolean | ExitC
 }
 
 export function saveReport(report: CrawlReport, path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(report, null, 2));
 }
 

--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -1,6 +1,6 @@
 # @mizchi/server-faults
 
-Framework-agnostic server-side fault injection (5xx + latency + abort + partial response + slow streaming) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
+Framework-agnostic server-side fault injection (5xx + latency + abort + partial response + slow streaming + status flapping) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
 
 ## Install
 
@@ -79,6 +79,7 @@ if (response) {
 |---|---|---|---|
 | `status5xxRate` | `number` (0..1) | `0` | Probability of synthetic 5xx response |
 | `status5xxCode` | `500 \| 502 \| 503 \| 504` | `503` | Status to return when the 5xx raffle wins |
+| `statusFlapping` | `{ code?, windowMs, badMs, phaseOffsetMs? }` | none | Windowed 5xx: the first `badMs` of each `windowMs` period returns 5xx. Composes with `status5xxRate` via OR. Time-based, so **not seed-reproducible** |
 | `latencyRate` | `number` (0..1) | `0` | Probability of injected latency |
 | `latencyMs` | `number \| {minMs, maxMs}` | — | Sleep duration. Number = constant; range = uniform pick |
 | `abortRate` | `number` (0..1) | `0` | Probability of tearing down the connection without sending a response. Rolled before 5xx / latency — wins short-circuit both |
@@ -103,7 +104,7 @@ if (response) {
 ## Semantics
 
 - `null` = no fault, continue normally; `Response` = synthetic response, skip the handler.
-- All fault kinds are **mutually exclusive in the same request**. Roll order is `abort → 5xx → partial → slowStream → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
+- All fault kinds are **mutually exclusive in the same request**. Roll order is `abort → statusFlapping → 5xx → partial → slowStream → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
 - `seed` drives **fault selection** (which raffles win), not exact ms values inside a `latencyMs` range — the inner range pick uses `Math.random()` so config tweaks don't shift the RNG sequence.
 - **abort caveat**: the connection is torn down before any bytes can be sent, so `metadataHeader` cannot round-trip on the abort path. `observer.onFault` is the only observability channel. Express / Fastify / Koa call `socket.end()` (hangup) or `socket.destroy(err)` (reset) on the underlying Node socket. Hono throws `ServerFaultsAbortError` — runtimes propagate it as a connection error; Node-hosts can install an `onError` handler that translates it to a TCP-level teardown.
 

--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -1,6 +1,6 @@
 # @mizchi/server-faults
 
-Framework-agnostic server-side fault injection (5xx + latency + abort + partial response) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
+Framework-agnostic server-side fault injection (5xx + latency + abort + partial response + slow streaming) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
 
 ## Install
 
@@ -85,6 +85,9 @@ if (response) {
 | `abortStyle` | `"hangup" \| "reset"` | `"hangup"` | `hangup` = clean half-close (EOF). `reset` = forced reset (ECONNRESET) |
 | `partialResponseRate` | `number` (0..1) | `0` | Probability of truncating the response body after `partialResponseAfterBytes`. **Hono adapter only** — Express / Koa / Fastify throw at construction if set |
 | `partialResponseAfterBytes` | `number` | `0` | Bytes of the real response body to emit before EOF |
+| `slowStreaming.rate` | `number` (0..1) | `0` | Probability of slow-streaming the response body. **Hono adapter only** |
+| `slowStreaming.chunkDelayMs` | `number` | — | Milliseconds to sleep before each emitted chunk |
+| `slowStreaming.chunkSize` | `number` | — | Optional: rechunk the body to fixed-size pieces before delaying. Omit to preserve source chunking |
 | `pathPattern` | `RegExp \| string` | none | Only matching paths are considered for fault injection |
 | `exemptPathPattern` | `RegExp \| string` | none | Paths that match are passed through unconditionally — useful for health checks or seed endpoints. Wins over `pathPattern`. |
 | `bypassHeader` | `string` | none | Header name (case-insensitive). Any request that carries it is passed through unconditionally — useful for warm-up / fixture traffic in tests. |
@@ -100,7 +103,7 @@ if (response) {
 ## Semantics
 
 - `null` = no fault, continue normally; `Response` = synthetic response, skip the handler.
-- All fault kinds are **mutually exclusive in the same request**. Roll order is `abort → 5xx → partial → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
+- All fault kinds are **mutually exclusive in the same request**. Roll order is `abort → 5xx → partial → slowStream → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
 - `seed` drives **fault selection** (which raffles win), not exact ms values inside a `latencyMs` range — the inner range pick uses `Math.random()` so config tweaks don't shift the RNG sequence.
 - **abort caveat**: the connection is torn down before any bytes can be sent, so `metadataHeader` cannot round-trip on the abort path. `observer.onFault` is the only observability channel. Express / Fastify / Koa call `socket.end()` (hangup) or `socket.destroy(err)` (reset) on the underlying Node socket. Hono throws `ServerFaultsAbortError` — runtimes propagate it as a connection error; Node-hosts can install an `onError` handler that translates it to a TCP-level teardown.
 
@@ -136,13 +139,15 @@ const fault = serverFaults({
 
 | Attribute | Type | Required | Notes |
 |---|---|---|---|
-| `fault.kind` | `"5xx" \| "latency" \| "abort" \| "partial"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
+| `fault.kind` | `"5xx" \| "latency" \| "abort" \| "partial" \| "slowStream"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
 | `fault.path` | `string` | always | URL pathname (no host, no query) |
 | `fault.method` | `string` | always | HTTP method, uppercased |
 | `fault.target_status` | `number` | when `kind === "5xx"` | the synthetic HTTP status returned |
 | `fault.latency_ms` | `number` | when `kind === "latency"` | milliseconds actually slept |
 | `fault.abort_style` | `"hangup" \| "reset"` | when `kind === "abort"` | how the connection was torn down |
 | `fault.after_bytes` | `number` | when `kind === "partial"` | bytes of the real body emitted before truncation |
+| `fault.chunk_delay_ms` | `number` | when `kind === "slowStream"` | milliseconds slept between chunks |
+| `fault.chunk_size` | `number` | when `kind === "slowStream"` and configured | rechunked output size |
 
 The shape is part of the public contract: additions are backward-compatible, renames are not. This is why we shipped a stable schema before any consumer pinned to ad-hoc keys.
 

--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -1,6 +1,6 @@
 # @mizchi/server-faults
 
-Framework-agnostic server-side fault injection (5xx + latency) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
+Framework-agnostic server-side fault injection (5xx + latency + abort) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
 
 ## Install
 
@@ -81,6 +81,8 @@ if (response) {
 | `status5xxCode` | `500 \| 502 \| 503 \| 504` | `503` | Status to return when the 5xx raffle wins |
 | `latencyRate` | `number` (0..1) | `0` | Probability of injected latency |
 | `latencyMs` | `number \| {minMs, maxMs}` | — | Sleep duration. Number = constant; range = uniform pick |
+| `abortRate` | `number` (0..1) | `0` | Probability of tearing down the connection without sending a response. Rolled before 5xx / latency — wins short-circuit both |
+| `abortStyle` | `"hangup" \| "reset"` | `"hangup"` | `hangup` = clean half-close (EOF). `reset` = forced reset (ECONNRESET) |
 | `pathPattern` | `RegExp \| string` | none | Only matching paths are considered for fault injection |
 | `exemptPathPattern` | `RegExp \| string` | none | Paths that match are passed through unconditionally — useful for health checks or seed endpoints. Wins over `pathPattern`. |
 | `bypassHeader` | `string` | none | Header name (case-insensitive). Any request that carries it is passed through unconditionally — useful for warm-up / fixture traffic in tests. |
@@ -96,8 +98,9 @@ if (response) {
 ## Semantics
 
 - `null` = no fault, continue normally; `Response` = synthetic response, skip the handler.
-- 5xx and latency are **mutually exclusive in the same request**. If the 5xx raffle wins, the function returns immediately and the latency raffle is never rolled. Single-fault-per-request keeps observability data clean.
+- 5xx, latency, and abort are **mutually exclusive in the same request**. Roll order is `abort → 5xx → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
 - `seed` drives **fault selection** (which raffles win), not exact ms values inside a `latencyMs` range — the inner range pick uses `Math.random()` so config tweaks don't shift the RNG sequence.
+- **abort caveat**: the connection is torn down before any bytes can be sent, so `metadataHeader` cannot round-trip on the abort path. `observer.onFault` is the only observability channel. Express / Fastify / Koa call `socket.end()` (hangup) or `socket.destroy(err)` (reset) on the underlying Node socket. Hono throws `ServerFaultsAbortError` — runtimes propagate it as a connection error; Node-hosts can install an `onError` handler that translates it to a TCP-level teardown.
 
 ## Comparison with related layers
 
@@ -131,11 +134,12 @@ const fault = serverFaults({
 
 | Attribute | Type | Required | Notes |
 |---|---|---|---|
-| `fault.kind` | `"5xx" \| "latency"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
+| `fault.kind` | `"5xx" \| "latency" \| "abort"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
 | `fault.path` | `string` | always | URL pathname (no host, no query) |
 | `fault.method` | `string` | always | HTTP method, uppercased |
 | `fault.target_status` | `number` | when `kind === "5xx"` | the synthetic HTTP status returned |
 | `fault.latency_ms` | `number` | when `kind === "latency"` | milliseconds actually slept |
+| `fault.abort_style` | `"hangup" \| "reset"` | when `kind === "abort"` | how the connection was torn down |
 
 The shape is part of the public contract: additions are backward-compatible, renames are not. This is why we shipped a stable schema before any consumer pinned to ad-hoc keys.
 

--- a/packages/server-faults/README.md
+++ b/packages/server-faults/README.md
@@ -1,6 +1,6 @@
 # @mizchi/server-faults
 
-Framework-agnostic server-side fault injection (5xx + latency + abort) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
+Framework-agnostic server-side fault injection (5xx + latency + abort + partial response) for Web Standard `Request` / `Response`. Sits between network-side fault interception (outside the server) and any client-side mocking. Independent of any HTTP framework — wire it as a 1-2 line middleware.
 
 ## Install
 
@@ -83,6 +83,8 @@ if (response) {
 | `latencyMs` | `number \| {minMs, maxMs}` | — | Sleep duration. Number = constant; range = uniform pick |
 | `abortRate` | `number` (0..1) | `0` | Probability of tearing down the connection without sending a response. Rolled before 5xx / latency — wins short-circuit both |
 | `abortStyle` | `"hangup" \| "reset"` | `"hangup"` | `hangup` = clean half-close (EOF). `reset` = forced reset (ECONNRESET) |
+| `partialResponseRate` | `number` (0..1) | `0` | Probability of truncating the response body after `partialResponseAfterBytes`. **Hono adapter only** — Express / Koa / Fastify throw at construction if set |
+| `partialResponseAfterBytes` | `number` | `0` | Bytes of the real response body to emit before EOF |
 | `pathPattern` | `RegExp \| string` | none | Only matching paths are considered for fault injection |
 | `exemptPathPattern` | `RegExp \| string` | none | Paths that match are passed through unconditionally — useful for health checks or seed endpoints. Wins over `pathPattern`. |
 | `bypassHeader` | `string` | none | Header name (case-insensitive). Any request that carries it is passed through unconditionally — useful for warm-up / fixture traffic in tests. |
@@ -98,7 +100,7 @@ if (response) {
 ## Semantics
 
 - `null` = no fault, continue normally; `Response` = synthetic response, skip the handler.
-- 5xx, latency, and abort are **mutually exclusive in the same request**. Roll order is `abort → 5xx → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
+- All fault kinds are **mutually exclusive in the same request**. Roll order is `abort → 5xx → partial → latency`; the first one that wins short-circuits the rest. Single-fault-per-request keeps observability data clean.
 - `seed` drives **fault selection** (which raffles win), not exact ms values inside a `latencyMs` range — the inner range pick uses `Math.random()` so config tweaks don't shift the RNG sequence.
 - **abort caveat**: the connection is torn down before any bytes can be sent, so `metadataHeader` cannot round-trip on the abort path. `observer.onFault` is the only observability channel. Express / Fastify / Koa call `socket.end()` (hangup) or `socket.destroy(err)` (reset) on the underlying Node socket. Hono throws `ServerFaultsAbortError` — runtimes propagate it as a connection error; Node-hosts can install an `onError` handler that translates it to a TCP-level teardown.
 
@@ -134,12 +136,13 @@ const fault = serverFaults({
 
 | Attribute | Type | Required | Notes |
 |---|---|---|---|
-| `fault.kind` | `"5xx" \| "latency" \| "abort"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
+| `fault.kind` | `"5xx" \| "latency" \| "abort" \| "partial"` | always | mirrors the `kind` arg, so the attrs object is self-describing |
 | `fault.path` | `string` | always | URL pathname (no host, no query) |
 | `fault.method` | `string` | always | HTTP method, uppercased |
 | `fault.target_status` | `number` | when `kind === "5xx"` | the synthetic HTTP status returned |
 | `fault.latency_ms` | `number` | when `kind === "latency"` | milliseconds actually slept |
 | `fault.abort_style` | `"hangup" \| "reset"` | when `kind === "abort"` | how the connection was torn down |
+| `fault.after_bytes` | `number` | when `kind === "partial"` | bytes of the real body emitted before truncation |
 
 The shape is part of the public contract: additions are backward-compatible, renames are not. This is why we shipped a stable schema before any consumer pinned to ad-hoc keys.
 

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -97,6 +97,31 @@ describe("honoMiddleware", () => {
     expect(text).toBe("hello");
   });
 
+  it("wraps response body in slowStream when slowStreaming raffle wins (full body delivered)", async () => {
+    const mw = honoMiddleware({
+      slowStreaming: { rate: 1, chunkDelayMs: 0 },
+      metadataHeader: true,
+    });
+    const body = "abcdefghij";
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/plain", "content-length": String(body.length) },
+      }),
+    };
+    const next = vi.fn(async () => undefined);
+    await mw(c, next);
+    const finalRes = c.res as Response;
+    expect(finalRes.status).toBe(200);
+    // chunkSize unset => total bytes unchanged, Content-Length preserved.
+    expect(finalRes.headers.get("content-length")).toBe(String(body.length));
+    expect(finalRes.headers.get("x-chaos-fault-kind")).toBe("slowStream");
+    expect(finalRes.headers.get("x-chaos-fault-chunk-delay-ms")).toBe("0");
+    const text = await finalRes.text();
+    expect(text).toBe(body);
+  });
+
   it("preserves status + null-body for partial verdict when handler returns null body", async () => {
     const mw = honoMiddleware({ partialResponseRate: 1, partialResponseAfterBytes: 0 });
     const c: HonoLikeContext = {
@@ -275,6 +300,12 @@ describe("expressMiddleware", () => {
   it("rejects partialResponseRate at construction time (unsupported on this adapter)", () => {
     expect(() => expressMiddleware({ partialResponseRate: 0.1 })).toThrow(/express adapter/);
     expect(() => expressMiddleware({ partialResponseRate: 0.1 })).toThrow(/partialResponseRate/);
+  });
+
+  it("rejects slowStreaming at construction time", () => {
+    expect(() => expressMiddleware({ slowStreaming: { rate: 0.1, chunkDelayMs: 100 } })).toThrow(
+      /slowStreaming/,
+    );
   });
 
   it("allows partialResponseRate=0 (no opt-in, no rejection)", () => {
@@ -465,6 +496,12 @@ describe("fastifyPlugin", () => {
   it("rejects partialResponseRate at construction time", () => {
     expect(() => fastifyPlugin({ partialResponseRate: 0.1 })).toThrow(/fastify adapter/);
   });
+
+  it("rejects slowStreaming at construction time", () => {
+    expect(() => fastifyPlugin({ slowStreaming: { rate: 0.1, chunkDelayMs: 100 } })).toThrow(
+      /slowStreaming/,
+    );
+  });
 });
 
 describe("koaMiddleware", () => {
@@ -552,6 +589,12 @@ describe("koaMiddleware", () => {
 
   it("rejects partialResponseRate at construction time", () => {
     expect(() => koaMiddleware({ partialResponseRate: 0.1 })).toThrow(/koa adapter/);
+  });
+
+  it("rejects slowStreaming at construction time", () => {
+    expect(() => koaMiddleware({ slowStreaming: { rate: 0.1, chunkDelayMs: 100 } })).toThrow(
+      /slowStreaming/,
+    );
   });
 
   it("tears down ctx.req.socket on abort and skips next()", async () => {

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { honoMiddleware, type HonoLikeContext } from "./hono.js";
+import { honoMiddleware, ServerFaultsAbortError, type HonoLikeContext } from "./hono.js";
 import { expressMiddleware } from "./express.js";
 import { fastifyPlugin } from "./fastify.js";
 import { koaMiddleware } from "./koa.js";
@@ -66,6 +66,19 @@ describe("honoMiddleware", () => {
     // Stronger than checking just one header: the entire Headers object stays
     // empty so no other fault.* key sneaks through.
     expect([...headers.entries()]).toHaveLength(0);
+  });
+
+  it("throws ServerFaultsAbortError carrying abortStyle when abort wins", async () => {
+    const mw = honoMiddleware({ abortRate: 1, abortStyle: "reset" });
+    const next = vi.fn();
+    const c = { req: { raw: new Request("https://test.local/api/x") } };
+    await expect(mw(c, next)).rejects.toBeInstanceOf(ServerFaultsAbortError);
+    expect(next).not.toHaveBeenCalled();
+    try {
+      await mw(c, next);
+    } catch (err) {
+      expect((err as ServerFaultsAbortError).abortStyle).toBe("reset");
+    }
   });
 });
 
@@ -159,6 +172,61 @@ describe("expressMiddleware", () => {
     await mw(req, res, next);
     expect(res.statusCode).toBe(503);
     expect(res.headers["x-chaos-fault-kind"]).toBe("5xx");
+  });
+
+  it("calls socket.end() for hangup abort and skips next()", async () => {
+    const mw = expressMiddleware({ abortRate: 1, abortStyle: "hangup" });
+    const next = vi.fn();
+    const end = vi.fn();
+    const destroy = vi.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/api/x",
+      headers: { host: "test.local" },
+      socket: { destroy, end },
+    };
+    const res = makeRes();
+    await mw(req, res, next);
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(0);
+  });
+
+  it("calls socket.destroy(err) for reset abort", async () => {
+    const mw = expressMiddleware({ abortRate: 1, abortStyle: "reset" });
+    const next = vi.fn();
+    const end = vi.fn();
+    const destroy = vi.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/api/x",
+      headers: { host: "test.local" },
+      socket: { destroy, end },
+    };
+    const res = makeRes();
+    await mw(req, res, next);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(end).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("falls back to socket.destroy() when end() is unavailable on hangup", async () => {
+    const mw = expressMiddleware({ abortRate: 1, abortStyle: "hangup" });
+    const next = vi.fn();
+    const destroy = vi.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/api/x",
+      headers: { host: "test.local" },
+      socket: { destroy },
+    };
+    const res = makeRes();
+    await mw(req, res, next);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy.mock.calls[0][0]).toBeUndefined();
+    expect(next).not.toHaveBeenCalled();
   });
 });
 
@@ -290,6 +358,57 @@ describe("fastifyPlugin", () => {
     expect(reply._code).toBe(503);
     expect(reply._headers["x-chaos-fault-kind"]).toBe("5xx");
   });
+
+  it("tears down req.raw.socket on abort and never touches reply", async () => {
+    const plugin = fastifyPlugin({ abortRate: 1, abortStyle: "reset" });
+    let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+    const fastify = {
+      addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+        registered = h;
+      },
+    };
+    await plugin(fastify);
+    const destroy = vi.fn();
+    const end = vi.fn();
+    const req = {
+      method: "GET",
+      url: "/api/x",
+      headers: { host: "test.local" },
+      raw: { socket: { destroy, end } },
+    };
+    const code = vi.fn(() => reply);
+    const send = vi.fn();
+    const header = vi.fn(() => reply);
+    const reply = { code, send, header };
+    await registered!(req, reply);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(send).not.toHaveBeenCalled();
+    expect(code).not.toHaveBeenCalled();
+  });
+
+  it("falls back to req.socket when req.raw is absent", async () => {
+    const plugin = fastifyPlugin({ abortRate: 1, abortStyle: "hangup" });
+    let registered: ((req: unknown, reply: unknown) => Promise<void>) | null = null;
+    const fastify = {
+      addHook(_: "onRequest", h: (req: unknown, reply: unknown) => Promise<void>) {
+        registered = h;
+      },
+    };
+    await plugin(fastify);
+    const end = vi.fn();
+    const destroy = vi.fn();
+    const req = {
+      method: "GET",
+      url: "/api/x",
+      headers: { host: "test.local" },
+      socket: { destroy, end },
+    };
+    const reply = { code: vi.fn(), header: vi.fn(), send: vi.fn() };
+    await registered!(req, reply);
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
+  });
 });
 
 describe("koaMiddleware", () => {
@@ -373,5 +492,29 @@ describe("koaMiddleware", () => {
     await mw(ctx, next);
     expect(ctx.status).toBe(503);
     expect(ctx._headers["x-chaos-fault-kind"]).toBe("5xx");
+  });
+
+  it("tears down ctx.req.socket on abort and skips next()", async () => {
+    const mw = koaMiddleware({ abortRate: 1, abortStyle: "reset" });
+    const next = vi.fn();
+    const end = vi.fn();
+    const destroy = vi.fn();
+    const ctx = {
+      req: {
+        method: "GET",
+        url: "/api/x",
+        headers: { host: "test.local" },
+        socket: { destroy, end },
+      },
+      status: 0,
+      body: undefined as unknown,
+      set: vi.fn(),
+    };
+    await mw(ctx, next);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(end).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(ctx.status).toBe(0);
   });
 });

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -148,6 +148,69 @@ describe("honoMiddleware", () => {
       expect((err as ServerFaultsAbortError).abortStyle).toBe("reset");
     }
   });
+
+  it("partial verdict with afterBytes > body length delivers the full body", async () => {
+    // Truncation that is larger than the body should be a no-op for the
+    // content but still stamp headers + strip Content-Length so the wire
+    // shape is consistent with shorter truncations.
+    const mw = honoMiddleware({
+      partialResponseRate: 1,
+      partialResponseAfterBytes: 9999,
+      metadataHeader: true,
+    });
+    const body = "short body";
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response(body, { status: 200 }),
+    };
+    const next = vi.fn(async () => undefined);
+    await mw(c, next);
+    const final = c.res as Response;
+    expect(await final.text()).toBe(body);
+    expect(final.headers.get("x-chaos-fault-kind")).toBe("partial");
+  });
+
+  it("partial verdict without metadataHeader stamps no fault headers", async () => {
+    const mw = honoMiddleware({ partialResponseRate: 1, partialResponseAfterBytes: 3 });
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response("abcdefg", { status: 200 }),
+    };
+    await mw(c, vi.fn(async () => undefined));
+    const final = c.res as Response;
+    expect(await final.text()).toBe("abc");
+    expect(final.headers.get("x-chaos-fault-kind")).toBeNull();
+  });
+
+  it("slowStream with chunkSize rechunks the body (full content preserved)", async () => {
+    const mw = honoMiddleware({
+      slowStreaming: { rate: 1, chunkDelayMs: 0, chunkSize: 4 },
+    });
+    const body = "abcdefghij";
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response(body, { status: 200 }),
+    };
+    await mw(c, vi.fn(async () => undefined));
+    const final = c.res as Response;
+    expect(await final.text()).toBe(body);
+  });
+
+  it("slowStream short-circuits cleanly on null-body responses (204)", async () => {
+    const mw = honoMiddleware({
+      slowStreaming: { rate: 1, chunkDelayMs: 0 },
+      metadataHeader: true,
+    });
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response(null, { status: 204 }),
+    };
+    await mw(c, vi.fn(async () => undefined));
+    const final = c.res as Response;
+    expect(final.status).toBe(204);
+    // Metadata still gets stamped on the null-body short-circuit.
+    expect(final.headers.get("x-chaos-fault-kind")).toBe("slowStream");
+  });
 });
 
 describe("expressMiddleware", () => {

--- a/packages/server-faults/src/adapters/adapters.test.ts
+++ b/packages/server-faults/src/adapters/adapters.test.ts
@@ -68,6 +68,49 @@ describe("honoMiddleware", () => {
     expect([...headers.entries()]).toHaveLength(0);
   });
 
+  it("truncates response body to afterBytes on partial verdict and strips Content-Length", async () => {
+    const mw = honoMiddleware({
+      partialResponseRate: 1,
+      partialResponseAfterBytes: 5,
+      metadataHeader: true,
+    });
+    const body = "hello world, this is a longer body";
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/plain", "content-length": String(body.length) },
+      }),
+    };
+    const next = vi.fn(async () => undefined);
+    await mw(c, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const finalRes = c.res as Response;
+    expect(finalRes.status).toBe(200);
+    expect(finalRes.headers.get("content-type")).toBe("text/plain");
+    // Content-Length stripped — declared length no longer matches truncated body.
+    expect(finalRes.headers.get("content-length")).toBeNull();
+    // Metadata headers stamped through on the partial path.
+    expect(finalRes.headers.get("x-chaos-fault-kind")).toBe("partial");
+    expect(finalRes.headers.get("x-chaos-fault-after-bytes")).toBe("5");
+    const text = await finalRes.text();
+    expect(text).toBe("hello");
+  });
+
+  it("preserves status + null-body for partial verdict when handler returns null body", async () => {
+    const mw = honoMiddleware({ partialResponseRate: 1, partialResponseAfterBytes: 0 });
+    const c: HonoLikeContext = {
+      req: { raw: new Request("https://test.local/api/x") },
+      res: new Response(null, { status: 204 }),
+    };
+    const next = vi.fn(async () => undefined);
+    await mw(c, next);
+    const finalRes = c.res as Response;
+    expect(finalRes.status).toBe(204);
+    const text = await finalRes.text();
+    expect(text).toBe("");
+  });
+
   it("throws ServerFaultsAbortError carrying abortStyle when abort wins", async () => {
     const mw = honoMiddleware({ abortRate: 1, abortStyle: "reset" });
     const next = vi.fn();
@@ -227,6 +270,15 @@ describe("expressMiddleware", () => {
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(destroy.mock.calls[0][0]).toBeUndefined();
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects partialResponseRate at construction time (unsupported on this adapter)", () => {
+    expect(() => expressMiddleware({ partialResponseRate: 0.1 })).toThrow(/express adapter/);
+    expect(() => expressMiddleware({ partialResponseRate: 0.1 })).toThrow(/partialResponseRate/);
+  });
+
+  it("allows partialResponseRate=0 (no opt-in, no rejection)", () => {
+    expect(() => expressMiddleware({ partialResponseRate: 0 })).not.toThrow();
   });
 });
 
@@ -409,6 +461,10 @@ describe("fastifyPlugin", () => {
     expect(end).toHaveBeenCalledTimes(1);
     expect(destroy).not.toHaveBeenCalled();
   });
+
+  it("rejects partialResponseRate at construction time", () => {
+    expect(() => fastifyPlugin({ partialResponseRate: 0.1 })).toThrow(/fastify adapter/);
+  });
 });
 
 describe("koaMiddleware", () => {
@@ -492,6 +548,10 @@ describe("koaMiddleware", () => {
     await mw(ctx, next);
     expect(ctx.status).toBe(503);
     expect(ctx._headers["x-chaos-fault-kind"]).toBe("5xx");
+  });
+
+  it("rejects partialResponseRate at construction time", () => {
+    expect(() => koaMiddleware({ partialResponseRate: 0.1 })).toThrow(/koa adapter/);
   });
 
   it("tears down ctx.req.socket on abort and skips next()", async () => {

--- a/packages/server-faults/src/adapters/express.ts
+++ b/packages/server-faults/src/adapters/express.ts
@@ -16,11 +16,18 @@ import {
 } from "../server-faults.js";
 
 // Loosely-typed Express surface to keep server-faults zero-dep.
+interface ExpressLikeSocket {
+  /** Forced reset (TCP RST → ECONNRESET on the client). */
+  destroy(err?: Error): void;
+  /** Clean half-close (FIN → EOF on the client). */
+  end?: () => void;
+}
 interface ExpressLikeRequest {
   method: string;
   originalUrl?: string;
   url?: string;
   headers: Record<string, string | string[] | undefined>;
+  socket?: ExpressLikeSocket;
 }
 interface ExpressLikeResponse {
   status(code: number): ExpressLikeResponse;
@@ -66,6 +73,22 @@ export function expressMiddleware(
           res.setHeader(key, value);
         });
         res.json(await verdict.response.json());
+        return;
+      }
+      if (verdict.kind === "abort") {
+        // Tear down the TCP connection. `reset` calls socket.destroy(err) so
+        // the client sees ECONNRESET; `hangup` half-closes via socket.end()
+        // for a clean EOF. Fall back to destroy() if end() is unavailable.
+        // Metadata headers cannot be delivered — observer is the only channel.
+        const socket = req.socket;
+        if (verdict.abortStyle === "reset") {
+          socket?.destroy(new Error("server-faults: synthetic abort"));
+        } else if (socket?.end) {
+          socket.end();
+        } else {
+          socket?.destroy();
+        }
+        // Do NOT call next() — the request is over.
         return;
       }
       if (verdict.kind === "annotate") {

--- a/packages/server-faults/src/adapters/express.ts
+++ b/packages/server-faults/src/adapters/express.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  assertAdapterSupportsConfig,
   attrsToHeaderEntries,
   resolveMetadataPrefix,
   serverFaults,
@@ -57,6 +58,7 @@ function toWebRequest(req: ExpressLikeRequest): Request {
 export function expressMiddleware(
   cfg: ServerFaultConfig,
 ): (req: ExpressLikeRequest, res: ExpressLikeResponse, next: ExpressLikeNext) => Promise<void> {
+  assertAdapterSupportsConfig(cfg, "express");
   const fault = serverFaults(cfg);
   const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async (req, res, next) => {
@@ -90,6 +92,12 @@ export function expressMiddleware(
         }
         // Do NOT call next() — the request is over.
         return;
+      }
+      if (verdict.kind === "partial") {
+        // Unreachable: assertAdapterSupportsConfig() refuses construction
+        // when partialResponseRate > 0. Kept so exhaustive narrowing
+        // catches any future verdict additions at compile time.
+        throw new Error("server-faults: unexpected partial verdict on express adapter");
       }
       if (verdict.kind === "annotate") {
         // Stamp headers BEFORE calling next() — Express buffers headers on the

--- a/packages/server-faults/src/adapters/express.ts
+++ b/packages/server-faults/src/adapters/express.ts
@@ -93,11 +93,11 @@ export function expressMiddleware(
         // Do NOT call next() — the request is over.
         return;
       }
-      if (verdict.kind === "partial") {
+      if (verdict.kind === "partial" || verdict.kind === "slowStream") {
         // Unreachable: assertAdapterSupportsConfig() refuses construction
-        // when partialResponseRate > 0. Kept so exhaustive narrowing
-        // catches any future verdict additions at compile time.
-        throw new Error("server-faults: unexpected partial verdict on express adapter");
+        // when these are enabled. Kept so exhaustive narrowing catches
+        // any future verdict additions at compile time.
+        throw new Error(`server-faults: unexpected ${verdict.kind} verdict on express adapter`);
       }
       if (verdict.kind === "annotate") {
         // Stamp headers BEFORE calling next() — Express buffers headers on the

--- a/packages/server-faults/src/adapters/fastify.ts
+++ b/packages/server-faults/src/adapters/fastify.ts
@@ -13,11 +13,18 @@ import {
   type ServerFaultConfig,
 } from "../server-faults.js";
 
+interface FastifyLikeSocket {
+  destroy(err?: Error): void;
+  end?: () => void;
+}
 interface FastifyLikeRequest {
   method: string;
   url: string;
   hostname?: string;
   headers: Record<string, string | string[] | undefined>;
+  /** Underlying Node IncomingMessage; carries `.socket` for teardown. */
+  raw?: { socket?: FastifyLikeSocket };
+  socket?: FastifyLikeSocket;
 }
 interface FastifyLikeReply {
   code(statusCode: number): FastifyLikeReply;
@@ -61,6 +68,21 @@ export function fastifyPlugin(cfg: ServerFaultConfig) {
           reply.header(key, value);
         });
         await reply.send(await verdict.response.json());
+        return;
+      }
+      if (verdict.kind === "abort") {
+        // Prefer req.raw.socket (the canonical Fastify accessor for the
+        // underlying Node socket); fall back to req.socket which newer
+        // Fastify versions also expose. Reset uses destroy(err); hangup
+        // half-closes via end() and falls back to destroy() if absent.
+        const socket = req.raw?.socket ?? req.socket;
+        if (verdict.abortStyle === "reset") {
+          socket?.destroy(new Error("server-faults: synthetic abort"));
+        } else if (socket?.end) {
+          socket.end();
+        } else {
+          socket?.destroy();
+        }
         return;
       }
       if (verdict.kind === "annotate") {

--- a/packages/server-faults/src/adapters/fastify.ts
+++ b/packages/server-faults/src/adapters/fastify.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  assertAdapterSupportsConfig,
   attrsToHeaderEntries,
   resolveMetadataPrefix,
   serverFaults,
@@ -56,6 +57,7 @@ function toWebRequest(req: FastifyLikeRequest): Request {
 }
 
 export function fastifyPlugin(cfg: ServerFaultConfig) {
+  assertAdapterSupportsConfig(cfg, "fastify");
   const fault = serverFaults(cfg);
   const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async function plugin(fastify: FastifyLikeInstance) {
@@ -84,6 +86,12 @@ export function fastifyPlugin(cfg: ServerFaultConfig) {
           socket?.destroy();
         }
         return;
+      }
+      if (verdict.kind === "partial") {
+        // Unreachable: assertAdapterSupportsConfig() refuses construction
+        // when partialResponseRate > 0. Kept so exhaustive narrowing
+        // catches any future verdict additions at compile time.
+        throw new Error("server-faults: unexpected partial verdict on fastify adapter");
       }
       if (verdict.kind === "annotate") {
         // Stamp headers; the real route runs after this hook returns. If a

--- a/packages/server-faults/src/adapters/fastify.ts
+++ b/packages/server-faults/src/adapters/fastify.ts
@@ -87,11 +87,11 @@ export function fastifyPlugin(cfg: ServerFaultConfig) {
         }
         return;
       }
-      if (verdict.kind === "partial") {
+      if (verdict.kind === "partial" || verdict.kind === "slowStream") {
         // Unreachable: assertAdapterSupportsConfig() refuses construction
-        // when partialResponseRate > 0. Kept so exhaustive narrowing
-        // catches any future verdict additions at compile time.
-        throw new Error("server-faults: unexpected partial verdict on fastify adapter");
+        // when these are enabled. Kept so exhaustive narrowing catches
+        // any future verdict additions at compile time.
+        throw new Error(`server-faults: unexpected ${verdict.kind} verdict on fastify adapter`);
       }
       if (verdict.kind === "annotate") {
         // Stamp headers; the real route runs after this hook returns. If a

--- a/packages/server-faults/src/adapters/hono.ts
+++ b/packages/server-faults/src/adapters/hono.ts
@@ -14,8 +14,28 @@ import {
   attrsToHeaderEntries,
   resolveMetadataPrefix,
   serverFaults,
+  type AbortStyle,
   type ServerFaultConfig,
 } from "../server-faults.js";
+
+/**
+ * Error thrown by `honoMiddleware` when an abort fault wins.
+ *
+ * Hono targets Node, Bun, Workers, Deno, etc. — there is no portable
+ * "destroy the socket" call we can make from the middleware. Throwing a
+ * tagged error is the only adapter-agnostic option: Workers' `fetch()`
+ * propagates the throw as a connection error, while Node-based Hono users
+ * can install an `app.onError` handler that recognises this error and
+ * calls `c.env.incoming.socket.destroy()` for a real TCP teardown.
+ */
+export class ServerFaultsAbortError extends Error {
+  readonly abortStyle: AbortStyle;
+  constructor(abortStyle: AbortStyle) {
+    super("server-faults: synthetic abort");
+    this.name = "ServerFaultsAbortError";
+    this.abortStyle = abortStyle;
+  }
+}
 
 export interface HonoLikeContext {
   req: { raw: Request };
@@ -39,6 +59,14 @@ export function honoMiddleware(cfg: ServerFaultConfig): HonoLikeMiddleware {
       return;
     }
     if (verdict.kind === "synthetic") return verdict.response;
+    if (verdict.kind === "abort") {
+      // No portable socket teardown across Hono's runtime targets — throw a
+      // tagged error and let either the runtime (Workers / Bun) treat it as
+      // a connection error, or a Node-host's onError handler call
+      // `c.env.incoming.socket.destroy()` if a real TCP-level abort is
+      // required. Metadata headers cannot be delivered on this path.
+      throw new ServerFaultsAbortError(verdict.abortStyle);
+    }
     if (verdict.kind === "annotate") {
       // Real handler runs, then stamp headers. Mutating `c.res.headers` after
       // the handler returns relies on Hono's live `Headers` object — if a

--- a/packages/server-faults/src/adapters/hono.ts
+++ b/packages/server-faults/src/adapters/hono.ts
@@ -17,6 +17,7 @@ import {
   type AbortStyle,
   type ServerFaultConfig,
 } from "../server-faults.js";
+import { truncateStream } from "../stream-transforms.js";
 
 /**
  * Error thrown by `honoMiddleware` when an abort fault wins.
@@ -39,10 +40,12 @@ export class ServerFaultsAbortError extends Error {
 
 export interface HonoLikeContext {
   req: { raw: Request };
-  // c.res is always populated in real Hono (lazy getter that synthesizes a
-  // Response if none was set). The optional marker here is for structurally-
-  // typed test mocks that omit it on the no-fault path.
-  res?: { headers: Headers };
+  // In real Hono `c.res` is a getter/setter backed by a lazily-synthesized
+  // Response. The optional marker is for structurally-typed test mocks that
+  // omit it on the no-fault path; the union form accepts both a full
+  // `Response` (real Hono / the `partial` verdict needs to set a new one)
+  // and a minimal `{ headers }` stand-in (existing annotate tests).
+  res?: Response | { headers: Headers };
 }
 interface HonoLikeNext {
   (): Promise<unknown>;
@@ -80,7 +83,51 @@ export function honoMiddleware(cfg: ServerFaultConfig): HonoLikeMiddleware {
       }
       return;
     }
+    if (verdict.kind === "partial") {
+      // Real handler runs, then we wrap its response body in a truncating
+      // stream. The bytes-after-N truncation matches real upstream cuts
+      // (OOM, pod evict). `Content-Length` is stripped because the
+      // declared length no longer matches the bytes actually delivered —
+      // leaving it intact would make standards-compliant clients hang
+      // waiting for the missing bytes, masking the failure mode we want
+      // to expose.
+      await next();
+      const current = c.res;
+      if (!isFullResponse(current)) return;
+      if (current.body === null) {
+        // Null-body statuses (204 / 205 / 304) have nothing to truncate.
+        // The Response constructor also forbids passing a body for them,
+        // so attempting to wrap would throw. Stamp metadata headers on
+        // the existing Response (if enabled) and leave the body alone.
+        if (metadataPrefix) {
+          for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+            current.headers.set(name, value);
+          }
+        }
+        return;
+      }
+      const truncated = truncateStream(current.body, verdict.afterBytes);
+      const headers = new Headers(current.headers);
+      headers.delete("content-length");
+      if (metadataPrefix) {
+        for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+          headers.set(name, value);
+        }
+      }
+      c.res = new Response(truncated, {
+        status: current.status,
+        statusText: current.statusText,
+        headers,
+      });
+      return;
+    }
     const _exhaustive: never = verdict;
     void _exhaustive;
   };
+}
+
+function isFullResponse(r: Response | { headers: Headers } | undefined): r is Response {
+  // Discriminate via the `body` property: real Response always has it
+  // (possibly null), the `{ headers }` test-mock shape does not.
+  return !!r && "body" in r;
 }

--- a/packages/server-faults/src/adapters/hono.ts
+++ b/packages/server-faults/src/adapters/hono.ts
@@ -17,7 +17,7 @@ import {
   type AbortStyle,
   type ServerFaultConfig,
 } from "../server-faults.js";
-import { truncateStream } from "../stream-transforms.js";
+import { slowStream, truncateStream } from "../stream-transforms.js";
 
 /**
  * Error thrown by `honoMiddleware` when an abort fault wins.
@@ -115,6 +115,43 @@ export function honoMiddleware(cfg: ServerFaultConfig): HonoLikeMiddleware {
         }
       }
       c.res = new Response(truncated, {
+        status: current.status,
+        statusText: current.statusText,
+        headers,
+      });
+      return;
+    }
+    if (verdict.kind === "slowStream") {
+      // Real handler runs; we then wrap its body in a per-chunk delay
+      // stream. Headers leave immediately (matching the real-world
+      // "fast start, slow body" pattern), so `metadataHeader` round-
+      // trips fine.
+      await next();
+      const current = c.res;
+      if (!isFullResponse(current)) return;
+      if (current.body === null) {
+        if (metadataPrefix) {
+          for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+            current.headers.set(name, value);
+          }
+        }
+        return;
+      }
+      const slowed = slowStream(current.body, {
+        chunkDelayMs: verdict.chunkDelayMs,
+        chunkSize: verdict.chunkSize,
+      });
+      const headers = new Headers(current.headers);
+      // When chunkSize is set the consumer sees fixed-size chunks, but the
+      // total length is unchanged, so Content-Length stays valid. When
+      // chunkSize is omitted, source chunking is preserved end-to-end.
+      // Either way we do not need to strip Content-Length.
+      if (metadataPrefix) {
+        for (const [name, value] of attrsToHeaderEntries(verdict.attrs, metadataPrefix)) {
+          headers.set(name, value);
+        }
+      }
+      c.res = new Response(slowed, {
         status: current.status,
         statusText: current.statusText,
         headers,

--- a/packages/server-faults/src/adapters/koa.ts
+++ b/packages/server-faults/src/adapters/koa.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  assertAdapterSupportsConfig,
   attrsToHeaderEntries,
   resolveMetadataPrefix,
   serverFaults,
@@ -51,6 +52,7 @@ function toWebRequest(req: KoaLikeRequest): Request {
 export function koaMiddleware(
   cfg: ServerFaultConfig,
 ): (ctx: KoaLikeContext, next: KoaLikeNext) => Promise<void> {
+  assertAdapterSupportsConfig(cfg, "koa");
   const fault = serverFaults(cfg);
   const metadataPrefix = resolveMetadataPrefix(cfg.metadataHeader);
   return async (ctx, next) => {
@@ -80,6 +82,12 @@ export function koaMiddleware(
         socket?.destroy();
       }
       return;
+    }
+    if (verdict.kind === "partial") {
+      // Unreachable: assertAdapterSupportsConfig() refuses construction
+      // when partialResponseRate > 0. Kept so exhaustive narrowing
+      // catches any future verdict additions at compile time.
+      throw new Error("server-faults: unexpected partial verdict on koa adapter");
     }
     if (verdict.kind === "annotate") {
       // Stamp BEFORE next() — Koa's ctx.set just wraps res.setHeader, which

--- a/packages/server-faults/src/adapters/koa.ts
+++ b/packages/server-faults/src/adapters/koa.ts
@@ -13,10 +13,15 @@ import {
   type ServerFaultConfig,
 } from "../server-faults.js";
 
+interface KoaLikeSocket {
+  destroy(err?: Error): void;
+  end?: () => void;
+}
 interface KoaLikeRequest {
   method?: string;
   url?: string;
   headers: Record<string, string | string[] | undefined>;
+  socket?: KoaLikeSocket;
 }
 interface KoaLikeContext {
   req: KoaLikeRequest;
@@ -60,6 +65,20 @@ export function koaMiddleware(
         ctx.set(key, value);
       });
       ctx.body = await verdict.response.json();
+      return;
+    }
+    if (verdict.kind === "abort") {
+      // See express adapter — same socket-level teardown contract. Koa's
+      // ctx.req is the raw Node IncomingMessage, so `req.socket` is the same
+      // object as in the Express case.
+      const socket = ctx.req.socket;
+      if (verdict.abortStyle === "reset") {
+        socket?.destroy(new Error("server-faults: synthetic abort"));
+      } else if (socket?.end) {
+        socket.end();
+      } else {
+        socket?.destroy();
+      }
       return;
     }
     if (verdict.kind === "annotate") {

--- a/packages/server-faults/src/adapters/koa.ts
+++ b/packages/server-faults/src/adapters/koa.ts
@@ -83,11 +83,11 @@ export function koaMiddleware(
       }
       return;
     }
-    if (verdict.kind === "partial") {
+    if (verdict.kind === "partial" || verdict.kind === "slowStream") {
       // Unreachable: assertAdapterSupportsConfig() refuses construction
-      // when partialResponseRate > 0. Kept so exhaustive narrowing
-      // catches any future verdict additions at compile time.
-      throw new Error("server-faults: unexpected partial verdict on koa adapter");
+      // when these are enabled. Kept so exhaustive narrowing catches
+      // any future verdict additions at compile time.
+      throw new Error(`server-faults: unexpected ${verdict.kind} verdict on koa adapter`);
     }
     if (verdict.kind === "annotate") {
       // Stamp BEFORE next() — Koa's ctx.set just wraps res.setHeader, which

--- a/packages/server-faults/src/index.ts
+++ b/packages/server-faults/src/index.ts
@@ -1,8 +1,10 @@
 export {
   serverFaults,
   toOtelAttrs,
+  type AbortStyle,
   type FaultAttrs,
   type FaultKind,
+  type FaultVerdict,
   type ServerFaultConfig,
   type ServerFaultHandle,
   type ServerFaultObserver,

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -273,6 +273,80 @@ describe("serverFaults", () => {
     });
   });
 
+  describe("abort", () => {
+    it("returns null when abortRate is 0", async () => {
+      const fault = serverFaults({ abortRate: 0 });
+      for (let i = 0; i < 50; i += 1) {
+        expect(await fault.maybeInject(req(`/api/${i}`))).toBeNull();
+      }
+    });
+
+    it("always returns an abort verdict when abortRate=1", async () => {
+      const fault = serverFaults({ abortRate: 1 });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("abort");
+      const abort = v as { kind: "abort"; abortStyle: "hangup" | "reset"; attrs: FaultAttrs };
+      expect(abort.abortStyle).toBe("hangup");
+      expect(abort.attrs).toEqual({
+        kind: "abort",
+        path: "/api/x",
+        method: "GET",
+        abortStyle: "hangup",
+      });
+    });
+
+    it("honours abortStyle=reset", async () => {
+      const fault = serverFaults({ abortRate: 1, abortStyle: "reset" });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect((v as { abortStyle: string }).abortStyle).toBe("reset");
+      expect((v as { attrs: FaultAttrs }).attrs.abortStyle).toBe("reset");
+    });
+
+    it("invokes observer.onFault for abort faults", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        abortRate: 1,
+        abortStyle: "reset",
+        observer: { onFault },
+      });
+      await fault.maybeInject(req("/api/x"));
+      expect(onFault).toHaveBeenCalledWith("abort", {
+        kind: "abort",
+        path: "/api/x",
+        method: "GET",
+        abortStyle: "reset",
+      });
+    });
+
+    it("populates traceId on abort events too", async () => {
+      const TP = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+      const onFault = vi.fn();
+      const fault = serverFaults({ abortRate: 1, observer: { onFault } });
+      await fault.maybeInject(
+        new Request("https://test.local/api/x", { headers: { traceparent: TP } }),
+      );
+      expect(onFault).toHaveBeenCalledWith(
+        "abort",
+        expect.objectContaining({ traceId: "0af7651916cd43dd8448eb211c80319c" }),
+      );
+    });
+
+    it("short-circuits 5xx and latency rolls when abort wins", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        abortRate: 1,
+        status5xxRate: 1,
+        latencyRate: 1,
+        latencyMs: 1,
+        observer: { onFault },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("abort");
+      expect(onFault).toHaveBeenCalledTimes(1);
+      expect(onFault).toHaveBeenCalledWith("abort", expect.anything());
+    });
+  });
+
   it("does not roll latency raffle when 5xx already won", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({
@@ -360,6 +434,21 @@ describe("serverFaults", () => {
       });
       expect("fault.target_status" in out).toBe(false);
       expect("fault.trace_id" in out).toBe(false);
+    });
+
+    it("maps abortStyle for abort verdicts", () => {
+      const out = toOtelAttrs({
+        kind: "abort",
+        path: "/api/x",
+        method: "GET",
+        abortStyle: "reset",
+      });
+      expect(out).toEqual({
+        "fault.kind": "abort",
+        "fault.path": "/api/x",
+        "fault.method": "GET",
+        "fault.abort_style": "reset",
+      });
     });
   });
 

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -410,6 +410,71 @@ describe("serverFaults", () => {
     });
   });
 
+  describe("slowStreaming", () => {
+    it("returns a slowStream verdict when raffle wins", async () => {
+      const fault = serverFaults({
+        slowStreaming: { rate: 1, chunkDelayMs: 250 },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("slowStream");
+      expect((v as { chunkDelayMs: number }).chunkDelayMs).toBe(250);
+      expect((v as { attrs: FaultAttrs }).attrs).toEqual({
+        kind: "slowStream",
+        path: "/api/x",
+        method: "GET",
+        chunkDelayMs: 250,
+      });
+    });
+
+    it("carries chunkSize when configured", async () => {
+      const fault = serverFaults({
+        slowStreaming: { rate: 1, chunkDelayMs: 50, chunkSize: 128 },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect((v as { chunkSize?: number }).chunkSize).toBe(128);
+      expect((v as { attrs: FaultAttrs }).attrs.chunkSize).toBe(128);
+    });
+
+    it("invokes observer.onFault for slowStream faults", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        slowStreaming: { rate: 1, chunkDelayMs: 100 },
+        observer: { onFault },
+      });
+      await fault.maybeInject(req("/api/x"));
+      expect(onFault).toHaveBeenCalledWith("slowStream", {
+        kind: "slowStream",
+        path: "/api/x",
+        method: "GET",
+        chunkDelayMs: 100,
+      });
+    });
+
+    it("rolls after partial — partial wins over slowStream", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        partialResponseRate: 1,
+        slowStreaming: { rate: 1, chunkDelayMs: 1 },
+        observer: { onFault },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("partial");
+    });
+
+    it("rolls before latency — slowStream wins over latency", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        slowStreaming: { rate: 1, chunkDelayMs: 1 },
+        latencyRate: 1,
+        latencyMs: 1,
+        observer: { onFault },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("slowStream");
+      expect(onFault).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("does not roll latency raffle when 5xx already won", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({
@@ -497,6 +562,23 @@ describe("serverFaults", () => {
       });
       expect("fault.target_status" in out).toBe(false);
       expect("fault.trace_id" in out).toBe(false);
+    });
+
+    it("maps chunkDelayMs and chunkSize for slowStream verdicts", () => {
+      const out = toOtelAttrs({
+        kind: "slowStream",
+        path: "/api/x",
+        method: "GET",
+        chunkDelayMs: 500,
+        chunkSize: 256,
+      });
+      expect(out).toEqual({
+        "fault.kind": "slowStream",
+        "fault.path": "/api/x",
+        "fault.method": "GET",
+        "fault.chunk_delay_ms": 500,
+        "fault.chunk_size": 256,
+      });
     });
 
     it("maps afterBytes for partial verdicts", () => {

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -410,6 +410,116 @@ describe("serverFaults", () => {
     });
   });
 
+  describe("statusFlapping", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns 5xx during the bad slice of each window", async () => {
+      // window = 30s, bad = 5s. At t=0 (start of period) the request is bad;
+      // at t=10s it is healthy.
+      vi.setSystemTime(0);
+      const fault = serverFaults({ statusFlapping: { windowMs: 30_000, badMs: 5_000 } });
+      const badV = await fault.maybeInject(req("/api/x"));
+      expect(badV?.kind).toBe("synthetic");
+      expect((badV as { response: Response }).response.status).toBe(503);
+
+      vi.setSystemTime(10_000);
+      const okV = await fault.maybeInject(req("/api/x"));
+      expect(okV).toBeNull();
+    });
+
+    it("emits via observer.onFault as kind '5xx' (same wire outcome as status5xxRate)", async () => {
+      vi.setSystemTime(0);
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        observer: { onFault },
+      });
+      await fault.maybeInject(req("/api/x"));
+      expect(onFault).toHaveBeenCalledWith("5xx", expect.objectContaining({ kind: "5xx" }));
+    });
+
+    it("honours statusFlapping.code override", async () => {
+      vi.setSystemTime(0);
+      const fault = serverFaults({
+        statusFlapping: { code: 504, windowMs: 30_000, badMs: 5_000 },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect((v as { response: Response }).response.status).toBe(504);
+    });
+
+    it("phaseOffsetMs shifts which calendar slice is bad", async () => {
+      // Without offset, t=0 is bad (phase 0 < 5_000).
+      // With offset=10_000, phase at t=0 becomes (0 - 10_000) mod 30_000 = 20_000 — healthy.
+      vi.setSystemTime(0);
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000, phaseOffsetMs: 10_000 },
+      });
+      expect(await fault.maybeInject(req("/api/x"))).toBeNull();
+      // At t=10_000 the phase becomes 0 — bad.
+      vi.setSystemTime(10_000);
+      expect((await fault.maybeInject(req("/api/x")))?.kind).toBe("synthetic");
+    });
+
+    it("composes with status5xxRate via OR (statusFlapping wins inside the bad window)", async () => {
+      vi.setSystemTime(0);
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        status5xxRate: 0, // would never roll on its own
+        observer: { onFault },
+      });
+      // Inside the bad window — emits 5xx even though status5xxRate=0.
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("synthetic");
+      expect(onFault).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls through to status5xxRate raffle when healthy", async () => {
+      vi.setSystemTime(10_000); // healthy slice
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        status5xxRate: 1, // always roll outside the bad window
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("synthetic");
+    });
+
+    it("abort still wins over statusFlapping", async () => {
+      vi.setSystemTime(0); // bad slice
+      const fault = serverFaults({
+        abortRate: 1,
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("abort");
+    });
+
+    it("metadataHeader works on flapped 5xx (same wire path as raffle 5xx)", async () => {
+      vi.setSystemTime(0);
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        metadataHeader: true,
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      const resp = (v as { response: Response }).response;
+      expect(resp.headers.get("x-chaos-fault-kind")).toBe("5xx");
+      expect(resp.headers.get("x-chaos-fault-target-status")).toBe("503");
+    });
+
+    it("ignores the gate when windowMs or badMs is 0", async () => {
+      vi.setSystemTime(0);
+      const a = serverFaults({ statusFlapping: { windowMs: 0, badMs: 5_000 } });
+      expect(await a.maybeInject(req("/api/x"))).toBeNull();
+      const b = serverFaults({ statusFlapping: { windowMs: 30_000, badMs: 0 } });
+      expect(await b.maybeInject(req("/api/x"))).toBeNull();
+    });
+  });
+
   describe("slowStreaming", () => {
     it("returns a slowStream verdict when raffle wins", async () => {
       const fault = serverFaults({

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -347,6 +347,69 @@ describe("serverFaults", () => {
     });
   });
 
+  describe("partialResponse", () => {
+    it("returns a partial verdict carrying afterBytes when raffle wins", async () => {
+      const fault = serverFaults({ partialResponseRate: 1, partialResponseAfterBytes: 64 });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("partial");
+      expect((v as { afterBytes: number }).afterBytes).toBe(64);
+      expect((v as { attrs: FaultAttrs }).attrs).toEqual({
+        kind: "partial",
+        path: "/api/x",
+        method: "GET",
+        afterBytes: 64,
+      });
+    });
+
+    it("defaults afterBytes to 0 when unset", async () => {
+      const fault = serverFaults({ partialResponseRate: 1 });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect((v as { afterBytes: number }).afterBytes).toBe(0);
+    });
+
+    it("invokes observer.onFault for partial faults", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        partialResponseRate: 1,
+        partialResponseAfterBytes: 128,
+        observer: { onFault },
+      });
+      await fault.maybeInject(req("/api/x"));
+      expect(onFault).toHaveBeenCalledWith("partial", {
+        kind: "partial",
+        path: "/api/x",
+        method: "GET",
+        afterBytes: 128,
+      });
+    });
+
+    it("rolls after abort/5xx — abort wins over partial", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        abortRate: 1,
+        partialResponseRate: 1,
+        observer: { onFault },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("abort");
+      expect(onFault).toHaveBeenCalledTimes(1);
+    });
+
+    it("rolls before latency — partial wins over latency", async () => {
+      const onFault = vi.fn();
+      const fault = serverFaults({
+        partialResponseRate: 1,
+        latencyRate: 1,
+        latencyMs: 1,
+        observer: { onFault },
+      });
+      const v = await fault.maybeInject(req("/api/x"));
+      expect(v?.kind).toBe("partial");
+      expect(onFault).toHaveBeenCalledTimes(1);
+      expect(onFault).toHaveBeenCalledWith("partial", expect.anything());
+    });
+  });
+
   it("does not roll latency raffle when 5xx already won", async () => {
     const onFault = vi.fn();
     const fault = serverFaults({
@@ -434,6 +497,21 @@ describe("serverFaults", () => {
       });
       expect("fault.target_status" in out).toBe(false);
       expect("fault.trace_id" in out).toBe(false);
+    });
+
+    it("maps afterBytes for partial verdicts", () => {
+      const out = toOtelAttrs({
+        kind: "partial",
+        path: "/api/x",
+        method: "GET",
+        afterBytes: 128,
+      });
+      expect(out).toEqual({
+        "fault.kind": "partial",
+        "fault.path": "/api/x",
+        "fault.method": "GET",
+        "fault.after_bytes": 128,
+      });
     });
 
     it("maps abortStyle for abort verdicts", () => {

--- a/packages/server-faults/src/server-faults.test.ts
+++ b/packages/server-faults/src/server-faults.test.ts
@@ -518,6 +518,50 @@ describe("serverFaults", () => {
       const b = serverFaults({ statusFlapping: { windowMs: 30_000, badMs: 0 } });
       expect(await b.maybeInject(req("/api/x"))).toBeNull();
     });
+
+    it("respects bypassHeader (no fault even inside the bad window)", async () => {
+      vi.setSystemTime(0);
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        bypassHeader: "x-chaos-bypass",
+      });
+      const r = new Request("https://test.local/api/x", {
+        headers: { "x-chaos-bypass": "1" },
+      });
+      expect(await fault.maybeInject(r)).toBeNull();
+    });
+
+    it("respects exemptPathPattern (no fault on exempt paths)", async () => {
+      vi.setSystemTime(0);
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        exemptPathPattern: /^\/health/,
+      });
+      expect(await fault.maybeInject(req("/health"))).toBeNull();
+      expect((await fault.maybeInject(req("/api/x")))?.kind).toBe("synthetic");
+    });
+
+    it("respects pathPattern (non-matching paths fall through)", async () => {
+      vi.setSystemTime(0);
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000 },
+        pathPattern: /^\/api\//,
+      });
+      expect(await fault.maybeInject(req("/static/x"))).toBeNull();
+      expect((await fault.maybeInject(req("/api/x")))?.kind).toBe("synthetic");
+    });
+
+    it("handles negative wall-clock values gracefully (e.g. Date.now() < phaseOffsetMs)", async () => {
+      // (Date.now() - phaseOffsetMs) can go negative; without the JS modulo
+      // correction the result would be a negative phase that always reads
+      // as < badMs. Verify the gate behaves sanely when offset > now.
+      vi.setSystemTime(100);
+      const fault = serverFaults({
+        statusFlapping: { windowMs: 30_000, badMs: 5_000, phaseOffsetMs: 10_000 },
+      });
+      // phase = ((100 - 10_000) mod 30_000 + 30_000) mod 30_000 = 20_100 → healthy
+      expect(await fault.maybeInject(req("/api/x"))).toBeNull();
+    });
   });
 
   describe("slowStreaming", () => {

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -12,7 +12,7 @@
  * (1 roll for 5xx, conditionally 1 roll for latency).
  */
 
-export type FaultKind = "5xx" | "latency" | "abort" | "partial";
+export type FaultKind = "5xx" | "latency" | "abort" | "partial" | "slowStream";
 
 /**
  * How an abort fault tears down the connection.
@@ -46,6 +46,10 @@ export interface FaultAttrs {
   abortStyle?: AbortStyle;
   /** Populated only on `kind: "partial"`. Number of bytes emitted from the real body before close. */
   afterBytes?: number;
+  /** Populated only on `kind: "slowStream"`. Milliseconds slept between chunks. */
+  chunkDelayMs?: number;
+  /** Populated only on `kind: "slowStream"`. Rechunk size in bytes (omitted = leave source chunking intact). */
+  chunkSize?: number;
   /** Trace-id from incoming traceparent (W3C Trace Context). 32 lowercase hex. */
   traceId?: string;
 }
@@ -66,6 +70,11 @@ export interface FaultAttrs {
  *   stream is closed. Status + headers are delivered normally (so
  *   `metadataHeader` works), but `Content-Length` MUST be stripped or
  *   recomputed by the adapter — the real value no longer matches.
+ * - `slowStream`: the real handler runs; the adapter wraps the response body
+ *   so each chunk is emitted with `chunkDelayMs` of sleep between. Status +
+ *   headers are delivered immediately, matching real-world "congested
+ *   backend" / "throttled pod" behaviour. `Content-Length` is preserved when
+ *   `chunkSize` is omitted (rechunking doesn't change total length).
  * - `null`: bypass / exempt / no raffle won — pass through unchanged.
  */
 export type FaultVerdict =
@@ -73,6 +82,7 @@ export type FaultVerdict =
   | { kind: "annotate"; attrs: FaultAttrs }
   | { kind: "abort"; attrs: FaultAttrs; abortStyle: AbortStyle }
   | { kind: "partial"; attrs: FaultAttrs; afterBytes: number }
+  | { kind: "slowStream"; attrs: FaultAttrs; chunkDelayMs: number; chunkSize?: number }
   | null;
 
 export interface ServerFaultObserver {
@@ -114,6 +124,26 @@ export interface ServerFaultConfig {
    * is the realistic failure mode, not a bug.
    */
   partialResponseAfterBytes?: number;
+  /**
+   * Slow-stream the response body: emit each chunk with a sleep in
+   * between. Mimics congested backend / throttled pod / slow disk where
+   * status + headers arrive immediately but bytes trickle. The whole-
+   * request `latencyMs` cannot expose this — it delays the response
+   * before it starts and then dumps the body in one shot.
+   *
+   * `chunkSize` (optional) rechunks the source body to fixed-size pieces
+   * before delaying — useful when the source is a single large chunk and
+   * you want to spread the slowness across many small ones. Omitting it
+   * preserves whatever chunking the source emits.
+   *
+   * Adapter support: Hono only at present. Express / Koa / Fastify throw
+   * at construction when set, same as `partialResponseRate`.
+   */
+  slowStreaming?: {
+    rate: number;
+    chunkDelayMs: number;
+    chunkSize?: number;
+  };
   /** RegExp or pattern string. Only matching paths are considered for fault injection. */
   pathPattern?: RegExp | string;
   /**
@@ -220,6 +250,8 @@ const FAULT_HEADER_KEY_SUFFIX: Record<keyof FaultAttrs, string> = {
   latencyMs: "latency-ms",
   abortStyle: "abort-style",
   afterBytes: "after-bytes",
+  chunkDelayMs: "chunk-delay-ms",
+  chunkSize: "chunk-size",
   traceId: "trace-id",
 };
 
@@ -275,6 +307,12 @@ export function assertAdapterSupportsConfig(cfg: ServerFaultConfig, adapter: str
   if ((cfg.partialResponseRate ?? 0) > 0) {
     throw new Error(
       `server-faults: ${adapter} adapter does not yet support partialResponseRate. ` +
+        `Use honoMiddleware for stream-based faults, or wait for Node-res interception.`,
+    );
+  }
+  if ((cfg.slowStreaming?.rate ?? 0) > 0) {
+    throw new Error(
+      `server-faults: ${adapter} adapter does not yet support slowStreaming. ` +
         `Use honoMiddleware for stream-based faults, or wait for Node-res interception.`,
     );
   }
@@ -361,6 +399,26 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         return { kind: "partial", attrs: attrsPartial, afterBytes };
       }
 
+      const slowCfg = cfg.slowStreaming;
+      const rS = slowCfg?.rate ?? 0;
+      if (rS > 0 && rng.next() < rS) {
+        const chunkDelayMs = slowCfg!.chunkDelayMs;
+        const chunkSize = slowCfg!.chunkSize;
+        const attrsSlow: FaultAttrs = {
+          kind: "slowStream",
+          path: url.pathname,
+          method,
+          chunkDelayMs,
+        };
+        if (chunkSize !== undefined) attrsSlow.chunkSize = chunkSize;
+        if (traceId !== undefined) attrsSlow.traceId = traceId;
+        Object.freeze(attrsSlow);
+        cfg.observer?.onFault?.("slowStream", attrsSlow);
+        return chunkSize !== undefined
+          ? { kind: "slowStream", attrs: attrsSlow, chunkDelayMs, chunkSize }
+          : { kind: "slowStream", attrs: attrsSlow, chunkDelayMs };
+      }
+
       const rL = cfg.latencyRate ?? 0;
       if (rL > 0 && rng.next() < rL) {
         const ms = pickLatencyMs(cfg.latencyMs);
@@ -400,6 +458,8 @@ const FAULT_KEY_MAP: Record<keyof FaultAttrs, string> = {
   latencyMs: "fault.latency_ms",
   abortStyle: "fault.abort_style",
   afterBytes: "fault.after_bytes",
+  chunkDelayMs: "fault.chunk_delay_ms",
+  chunkSize: "fault.chunk_size",
   traceId: "fault.trace_id",
 };
 

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -12,7 +12,7 @@
  * (1 roll for 5xx, conditionally 1 roll for latency).
  */
 
-export type FaultKind = "5xx" | "latency" | "abort";
+export type FaultKind = "5xx" | "latency" | "abort" | "partial";
 
 /**
  * How an abort fault tears down the connection.
@@ -44,6 +44,8 @@ export interface FaultAttrs {
   latencyMs?: number;
   /** Populated only on `kind: "abort"`. */
   abortStyle?: AbortStyle;
+  /** Populated only on `kind: "partial"`. Number of bytes emitted from the real body before close. */
+  afterBytes?: number;
   /** Trace-id from incoming traceparent (W3C Trace Context). 32 lowercase hex. */
   traceId?: string;
 }
@@ -59,12 +61,18 @@ export interface FaultAttrs {
  * - `abort`: the adapter must tear down the connection without sending a
  *   response. `metadataHeader` cannot round-trip on this path — no headers
  *   are ever delivered — so the only observability channel is `observer`.
+ * - `partial`: the real handler must run; the adapter then wraps the response
+ *   body so that only the first `afterBytes` bytes are emitted before the
+ *   stream is closed. Status + headers are delivered normally (so
+ *   `metadataHeader` works), but `Content-Length` MUST be stripped or
+ *   recomputed by the adapter — the real value no longer matches.
  * - `null`: bypass / exempt / no raffle won — pass through unchanged.
  */
 export type FaultVerdict =
   | { kind: "synthetic"; response: Response; attrs: FaultAttrs }
   | { kind: "annotate"; attrs: FaultAttrs }
   | { kind: "abort"; attrs: FaultAttrs; abortStyle: AbortStyle }
+  | { kind: "partial"; attrs: FaultAttrs; afterBytes: number }
   | null;
 
 export interface ServerFaultObserver {
@@ -88,6 +96,24 @@ export interface ServerFaultConfig {
   abortRate?: number;
   /** Connection-termination style when the abort raffle wins. Default `"hangup"`. */
   abortStyle?: AbortStyle;
+  /**
+   * 0..1, default 0. Probability of truncating the response body after a
+   * fixed number of bytes have been emitted. Rolled after `abort` and
+   * `status5xxRate` but before `latencyRate` — partial lets the handler
+   * run (like latency does) but transforms its output.
+   *
+   * Adapter support: Hono only at present. Express / Koa / Fastify throw
+   * at middleware construction when set, since they require Node-level
+   * `res.write` interception that is not yet implemented.
+   */
+  partialResponseRate?: number;
+  /**
+   * Bytes of the real response body to emit before closing. Default 0
+   * (close immediately after headers). The truncation point lands on a
+   * raw byte boundary, so multi-byte UTF-8 sequences may be split — that
+   * is the realistic failure mode, not a bug.
+   */
+  partialResponseAfterBytes?: number;
   /** RegExp or pattern string. Only matching paths are considered for fault injection. */
   pathPattern?: RegExp | string;
   /**
@@ -193,6 +219,7 @@ const FAULT_HEADER_KEY_SUFFIX: Record<keyof FaultAttrs, string> = {
   targetStatus: "target-status",
   latencyMs: "latency-ms",
   abortStyle: "abort-style",
+  afterBytes: "after-bytes",
   traceId: "trace-id",
 };
 
@@ -229,6 +256,28 @@ export function resolveMetadataPrefix(opt: ServerFaultConfig["metadataHeader"]):
   if (!opt) return null;
   if (opt === true) return DEFAULT_METADATA_PREFIX;
   return opt.prefix ?? DEFAULT_METADATA_PREFIX;
+}
+
+/**
+ * Throw a clear, sourceable error if a config asks for a fault kind the
+ * caller's adapter cannot honour. Each Node-based adapter (express,
+ * fastify, koa) calls this with its name; the Hono adapter does not,
+ * because it supports the full verdict set.
+ *
+ * Failing at middleware-construction time is a deliberate choice: a
+ * silent fall-through on a request would let `partialResponseRate=0.1`
+ * appear to "work" until a verdict actually fires, at which point the
+ * adapter would either no-op (masking chaos) or crash mid-request.
+ * Construction-time validation surfaces the misconfiguration before any
+ * traffic touches it.
+ */
+export function assertAdapterSupportsConfig(cfg: ServerFaultConfig, adapter: string): void {
+  if ((cfg.partialResponseRate ?? 0) > 0) {
+    throw new Error(
+      `server-faults: ${adapter} adapter does not yet support partialResponseRate. ` +
+        `Use honoMiddleware for stream-based faults, or wait for Node-res interception.`,
+    );
+  }
 }
 
 export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
@@ -297,6 +346,21 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         return { kind: "synthetic", response, attrs: attrs5xx };
       }
 
+      const rP = cfg.partialResponseRate ?? 0;
+      if (rP > 0 && rng.next() < rP) {
+        const afterBytes = cfg.partialResponseAfterBytes ?? 0;
+        const attrsPartial: FaultAttrs = {
+          kind: "partial",
+          path: url.pathname,
+          method,
+          afterBytes,
+        };
+        if (traceId !== undefined) attrsPartial.traceId = traceId;
+        Object.freeze(attrsPartial);
+        cfg.observer?.onFault?.("partial", attrsPartial);
+        return { kind: "partial", attrs: attrsPartial, afterBytes };
+      }
+
       const rL = cfg.latencyRate ?? 0;
       if (rL > 0 && rng.next() < rL) {
         const ms = pickLatencyMs(cfg.latencyMs);
@@ -335,6 +399,7 @@ const FAULT_KEY_MAP: Record<keyof FaultAttrs, string> = {
   targetStatus: "fault.target_status",
   latencyMs: "fault.latency_ms",
   abortStyle: "fault.abort_style",
+  afterBytes: "fault.after_bytes",
   traceId: "fault.trace_id",
 };
 

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -12,7 +12,19 @@
  * (1 roll for 5xx, conditionally 1 roll for latency).
  */
 
-export type FaultKind = "5xx" | "latency";
+export type FaultKind = "5xx" | "latency" | "abort";
+
+/**
+ * How an abort fault tears down the connection.
+ *
+ * - `hangup`: clean half-close (Node `socket.end()`). The peer sees EOF on
+ *   read with no error; equivalent to the server politely terminating.
+ * - `reset`: forced reset (Node `socket.destroy(err)`). The peer sees
+ *   `ECONNRESET` / `net::ERR_CONNECTION_RESET`.
+ *
+ * Not every framework can express both — see per-adapter docs.
+ */
+export type AbortStyle = "hangup" | "reset";
 
 /**
  * Stable attribute schema fed to `observer.onFault`.
@@ -30,6 +42,8 @@ export interface FaultAttrs {
   method: string;
   targetStatus?: number;
   latencyMs?: number;
+  /** Populated only on `kind: "abort"`. */
+  abortStyle?: AbortStyle;
   /** Trace-id from incoming traceparent (W3C Trace Context). 32 lowercase hex. */
   traceId?: string;
 }
@@ -42,11 +56,15 @@ export interface FaultAttrs {
  * - `annotate`: no synthetic response, but the request was perturbed (e.g.
  *   latency was injected). The adapter should run the real handler and
  *   surface `attrs` (as response headers, span attributes, etc.).
+ * - `abort`: the adapter must tear down the connection without sending a
+ *   response. `metadataHeader` cannot round-trip on this path — no headers
+ *   are ever delivered — so the only observability channel is `observer`.
  * - `null`: bypass / exempt / no raffle won — pass through unchanged.
  */
 export type FaultVerdict =
   | { kind: "synthetic"; response: Response; attrs: FaultAttrs }
   | { kind: "annotate"; attrs: FaultAttrs }
+  | { kind: "abort"; attrs: FaultAttrs; abortStyle: AbortStyle }
   | null;
 
 export interface ServerFaultObserver {
@@ -62,6 +80,14 @@ export interface ServerFaultConfig {
   latencyRate?: number;
   /** Sleep duration when the latency raffle wins. Number = constant ms; range = uniform pick. */
   latencyMs?: number | { minMs: number; maxMs: number };
+  /**
+   * 0..1, default 0. Probability of tearing down the connection without
+   * sending a response. Rolled before `status5xxRate` and `latencyRate` —
+   * a winning abort short-circuits all other kinds in the same request.
+   */
+  abortRate?: number;
+  /** Connection-termination style when the abort raffle wins. Default `"hangup"`. */
+  abortStyle?: AbortStyle;
   /** RegExp or pattern string. Only matching paths are considered for fault injection. */
   pathPattern?: RegExp | string;
   /**
@@ -166,6 +192,7 @@ const FAULT_HEADER_KEY_SUFFIX: Record<keyof FaultAttrs, string> = {
   method: "method",
   targetStatus: "target-status",
   latencyMs: "latency-ms",
+  abortStyle: "abort-style",
   traceId: "trace-id",
 };
 
@@ -224,6 +251,24 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
 
       const method = req.method.toUpperCase();
       const traceId = extractTraceId(req);
+
+      const rA = cfg.abortRate ?? 0;
+      if (rA > 0 && rng.next() < rA) {
+        const abortStyle: AbortStyle = cfg.abortStyle ?? "hangup";
+        const attrsAbort: FaultAttrs = {
+          kind: "abort",
+          path: url.pathname,
+          method,
+          abortStyle,
+        };
+        if (traceId !== undefined) attrsAbort.traceId = traceId;
+        // No metadata headers on the abort path: the connection is torn down
+        // before any headers can be delivered. Observers are the only channel.
+        Object.freeze(attrsAbort);
+        cfg.observer?.onFault?.("abort", attrsAbort);
+        return { kind: "abort", attrs: attrsAbort, abortStyle };
+      }
+
       const r5 = cfg.status5xxRate ?? 0;
       if (r5 > 0 && rng.next() < r5) {
         const status = cfg.status5xxCode ?? 503;
@@ -289,6 +334,7 @@ const FAULT_KEY_MAP: Record<keyof FaultAttrs, string> = {
   method: "fault.method",
   targetStatus: "fault.target_status",
   latencyMs: "fault.latency_ms",
+  abortStyle: "fault.abort_style",
   traceId: "fault.trace_id",
 };
 

--- a/packages/server-faults/src/server-faults.ts
+++ b/packages/server-faults/src/server-faults.ts
@@ -125,6 +125,43 @@ export interface ServerFaultConfig {
    */
   partialResponseAfterBytes?: number;
   /**
+   * Windowed 5xx flapping: inside a repeating `windowMs` period, the
+   * first `badMs` of each cycle returns 5xx unconditionally; outside
+   * that slice the request falls through to the other raffles.
+   *
+   * Models the canonical retry-with-backoff scenario: a constant 5xx
+   * rate is too easy because clients give up, but a 5-second sick
+   * window inside a 30-second healthy window catches retry storms,
+   * alerting de-dup quirks, and circuit-breaker thresholds that a
+   * stateless `status5xxRate` cannot reproduce.
+   *
+   * **Composes with `status5xxRate` via OR**: statusFlapping is checked
+   * first; if the window is bad, it short-circuits and emits 5xx. If
+   * the window is healthy, `status5xxRate` still rolls normally. So
+   * setting both yields "always bad inside the window, sometimes bad
+   * outside" — the layered shape most users want for testing.
+   *
+   * **Not seed-reproducible.** Time-based gates break the "same seed
+   * → same outcomes" contract because wall-clock varies between runs.
+   * Distributed deployments needing phase-locked flapping across
+   * multiple instances can pass `phaseOffsetMs` to stagger or align.
+   */
+  statusFlapping?: {
+    /** Status code returned during the bad window. Default 503. */
+    code?: 500 | 502 | 503 | 504;
+    /** Full period of the flap, in milliseconds. */
+    windowMs: number;
+    /** How long inside each period the server is "sick". Must be ≤ `windowMs`. */
+    badMs: number;
+    /**
+     * Optional millisecond offset added to `Date.now()` before the
+     * modulo. Lets multiple instances of `serverFaults` align (same
+     * offset → in phase) or stagger (different offsets → out of phase).
+     * Defaults to 0.
+     */
+    phaseOffsetMs?: number;
+  };
+  /**
    * Slow-stream the response body: emit each chunk with a sleep in
    * between. Mimics congested backend / throttled pod / slow disk where
    * status + headers arrive immediately but bytes trickle. The whole-
@@ -318,6 +355,45 @@ export function assertAdapterSupportsConfig(cfg: ServerFaultConfig, adapter: str
   }
 }
 
+/**
+ * Mint a `synthetic 5xx` verdict. Shared by the probabilistic
+ * `status5xxRate` raffle and the windowed `statusFlapping` gate — both
+ * produce the same wire-level outcome (a JSON 5xx) and the same observer
+ * event, only the decision rule differs.
+ */
+function mintSyntheticFault(
+  status: 500 | 502 | 503 | 504,
+  path: string,
+  method: string,
+  traceId: string | undefined,
+  cfg: ServerFaultConfig,
+  metadataPrefix: string | null,
+): { kind: "synthetic"; response: Response; attrs: FaultAttrs } {
+  const attrs: FaultAttrs = {
+    kind: "5xx",
+    path,
+    method,
+    targetStatus: status,
+  };
+  if (traceId !== undefined) attrs.traceId = traceId;
+  // Frozen because the same reference is handed to observer.onFault and
+  // returned in the verdict; either consumer mutating it would corrupt
+  // the other's view.
+  Object.freeze(attrs);
+  cfg.observer?.onFault?.("5xx", attrs);
+  const headers = new Headers();
+  if (metadataPrefix) {
+    for (const [name, value] of attrsToHeaderEntries(attrs, metadataPrefix)) {
+      headers.set(name, value);
+    }
+  }
+  const response = Response.json(
+    { error: "chaos: synthetic 5xx", path, status },
+    { status, headers },
+  );
+  return { kind: "synthetic", response, attrs };
+}
+
 export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
   const pattern = compileStatelessPattern(cfg.pathPattern);
   const exemptPattern = compileStatelessPattern(cfg.exemptPathPattern);
@@ -356,32 +432,20 @@ export function serverFaults(cfg: ServerFaultConfig): ServerFaultHandle {
         return { kind: "abort", attrs: attrsAbort, abortStyle };
       }
 
+      const flap = cfg.statusFlapping;
+      if (flap && flap.windowMs > 0 && flap.badMs > 0) {
+        const offset = flap.phaseOffsetMs ?? 0;
+        const phase = ((Date.now() - offset) % flap.windowMs + flap.windowMs) % flap.windowMs;
+        if (phase < flap.badMs) {
+          const status = flap.code ?? 503;
+          return mintSyntheticFault(status, url.pathname, method, traceId, cfg, metadataPrefix);
+        }
+      }
+
       const r5 = cfg.status5xxRate ?? 0;
       if (r5 > 0 && rng.next() < r5) {
         const status = cfg.status5xxCode ?? 503;
-        const attrs5xx: FaultAttrs = {
-          kind: "5xx",
-          path: url.pathname,
-          method,
-          targetStatus: status,
-        };
-        if (traceId !== undefined) attrs5xx.traceId = traceId;
-        // Frozen because the same reference is handed to observer.onFault and
-        // returned in the verdict; either consumer mutating it would corrupt
-        // the other's view.
-        Object.freeze(attrs5xx);
-        cfg.observer?.onFault?.("5xx", attrs5xx);
-        const headers = new Headers();
-        if (metadataPrefix) {
-          for (const [name, value] of attrsToHeaderEntries(attrs5xx, metadataPrefix)) {
-            headers.set(name, value);
-          }
-        }
-        const response = Response.json(
-          { error: "chaos: synthetic 5xx", path: url.pathname, status },
-          { status, headers },
-        );
-        return { kind: "synthetic", response, attrs: attrs5xx };
+        return mintSyntheticFault(status, url.pathname, method, traceId, cfg, metadataPrefix);
       }
 
       const rP = cfg.partialResponseRate ?? 0;

--- a/packages/server-faults/src/stream-transforms.test.ts
+++ b/packages/server-faults/src/stream-transforms.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { truncateStream } from "./stream-transforms.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { slowStream, truncateStream } from "./stream-transforms.js";
 
 function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   let i = 0;
@@ -56,5 +56,76 @@ describe("truncateStream", () => {
     const src = streamFromChunks([new Uint8Array([0xe3, 0x81, 0x82])]);
     const out = await readAll(truncateStream(src, 2));
     expect(Array.from(out)).toEqual([0xe3, 0x81]);
+  });
+});
+
+describe("slowStream", () => {
+  it("emits the same total bytes when chunkSize is omitted (preserves source chunking)", async () => {
+    const src = streamFromChunks([
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5]),
+      new Uint8Array([6, 7, 8, 9]),
+    ]);
+    const out = await readAll(slowStream(src, { chunkDelayMs: 0 }));
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it("rechunks to fixed chunkSize when set, preserving total bytes", async () => {
+    const src = streamFromChunks([new Uint8Array([1, 2, 3, 4, 5, 6, 7])]);
+    const stream = slowStream(src, { chunkDelayMs: 0, chunkSize: 3 });
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(chunks.map((c) => Array.from(c))).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7],
+    ]);
+  });
+
+  it("returns an empty stream when source is null", async () => {
+    const out = await readAll(slowStream(null, { chunkDelayMs: 100 }));
+    expect(out.byteLength).toBe(0);
+  });
+
+  describe("timing", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("sleeps chunkDelayMs before each emitted chunk", async () => {
+      const src = streamFromChunks([new Uint8Array([1]), new Uint8Array([2])]);
+      const stream = slowStream(src, { chunkDelayMs: 100 });
+      const reader = stream.getReader();
+      const p1 = reader.read();
+      // Before the timer advances, no chunk is yielded yet.
+      let r1Settled = false;
+      p1.then(() => {
+        r1Settled = true;
+      });
+      await Promise.resolve();
+      expect(r1Settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      const r1 = await p1;
+      expect(r1.done).toBe(false);
+      // Second chunk also waits 100ms.
+      const p2 = reader.read();
+      let r2Settled = false;
+      p2.then(() => {
+        r2Settled = true;
+      });
+      await Promise.resolve();
+      expect(r2Settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      const r2 = await p2;
+      expect(r2.done).toBe(false);
+    });
   });
 });

--- a/packages/server-faults/src/stream-transforms.test.ts
+++ b/packages/server-faults/src/stream-transforms.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { truncateStream } from "./stream-transforms.js";
+
+function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(chunks[i++]);
+    },
+  });
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const out: number[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    for (const b of value) out.push(b);
+  }
+  return new Uint8Array(out);
+}
+
+describe("truncateStream", () => {
+  it("emits exactly N bytes when source is longer", async () => {
+    const src = streamFromChunks([new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8])]);
+    const out = await readAll(truncateStream(src, 5));
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("emits the whole source when source is shorter than N", async () => {
+    const src = streamFromChunks([new Uint8Array([1, 2, 3])]);
+    const out = await readAll(truncateStream(src, 100));
+    expect(Array.from(out)).toEqual([1, 2, 3]);
+  });
+
+  it("emits zero bytes when N=0 (worst-case: declared content but empty body)", async () => {
+    const src = streamFromChunks([new Uint8Array([1, 2, 3, 4])]);
+    const out = await readAll(truncateStream(src, 0));
+    expect(out.byteLength).toBe(0);
+  });
+
+  it("returns an empty stream when source is null", async () => {
+    const out = await readAll(truncateStream(null, 100));
+    expect(out.byteLength).toBe(0);
+  });
+
+  it("cuts mid-chunk on byte boundary (splits multi-byte UTF-8 sequences)", async () => {
+    // "あ" in UTF-8 is 0xe3 0x81 0x82 (3 bytes). Cutting at 2 bytes leaves
+    // an invalid UTF-8 prefix — that is the realistic failure mode we
+    // want to expose, not a bug.
+    const src = streamFromChunks([new Uint8Array([0xe3, 0x81, 0x82])]);
+    const out = await readAll(truncateStream(src, 2));
+    expect(Array.from(out)).toEqual([0xe3, 0x81]);
+  });
+});

--- a/packages/server-faults/src/stream-transforms.ts
+++ b/packages/server-faults/src/stream-transforms.ts
@@ -1,0 +1,68 @@
+/**
+ * Stream transforms used by the `partial` and (future) `slowStream`
+ * fault verdicts. Operate on Web Standard `ReadableStream<Uint8Array>` so
+ * they compose cleanly with `Response.body` on Hono / Workers / Bun.
+ *
+ * Kept in their own module so the Hono adapter is the only file that
+ * pulls them in — the core `server-faults.ts` stays free of stream
+ * machinery for runtimes that never see these verdicts.
+ */
+
+/**
+ * Wrap `source` in a stream that emits at most `afterBytes` bytes of the
+ * source, then closes (no error). The truncation point is a raw-byte
+ * boundary — multi-byte UTF-8 sequences may be split. That mirrors the
+ * real-world failure (upstream cut, pod evicted mid-chunk) we want to
+ * exercise: silent body truncation is the bug consumers must detect.
+ *
+ * If `source` is `null` (handler set no body) the result is an empty
+ * stream that closes immediately. If `afterBytes` is `0` the body is
+ * dropped entirely after the headers — which is the worst-case "client
+ * has Content-Length but receives zero bytes" scenario.
+ */
+export function truncateStream(
+  source: ReadableStream<Uint8Array> | null,
+  afterBytes: number,
+): ReadableStream<Uint8Array> {
+  if (!source) {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+  }
+  const reader = source.getReader();
+  let remaining = Math.max(0, afterBytes);
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (remaining <= 0) {
+        controller.close();
+        // Best-effort: signal the upstream that we are done. Some sources
+        // (e.g. backed by a request body) keep producing until cancelled.
+        await reader.cancel();
+        return;
+      }
+      const { value, done } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      if (value.byteLength <= remaining) {
+        remaining -= value.byteLength;
+        controller.enqueue(value);
+        if (remaining <= 0) {
+          controller.close();
+          await reader.cancel();
+        }
+        return;
+      }
+      controller.enqueue(value.subarray(0, remaining));
+      remaining = 0;
+      controller.close();
+      await reader.cancel();
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+}

--- a/packages/server-faults/src/stream-transforms.ts
+++ b/packages/server-faults/src/stream-transforms.ts
@@ -8,6 +8,8 @@
  * machinery for runtimes that never see these verdicts.
  */
 
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 /**
  * Wrap `source` in a stream that emits at most `afterBytes` bytes of the
  * source, then closes (no error). The truncation point is a raw-byte
@@ -60,6 +62,89 @@ export function truncateStream(
       remaining = 0;
       controller.close();
       await reader.cancel();
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+}
+
+/**
+ * Wrap `source` in a stream that emits each chunk with `chunkDelayMs` of
+ * sleep between. Status + headers are NOT delayed — they leave the
+ * server immediately — so the consumer experiences "fast start, slow
+ * body", which is the realistic congested-backend / throttled-pod
+ * shape that whole-request `latencyMs` cannot reproduce.
+ *
+ * If `chunkSize` is set, the source is rechunked to fixed-size pieces
+ * before delaying — useful when the handler emits a single large buffer
+ * but you want the slowness spread across many small chunks. Omitting
+ * `chunkSize` preserves whatever chunking the source emits.
+ *
+ * The delay is applied BEFORE enqueueing each chunk (including the
+ * first), so a body with one chunk of N bytes and `chunkDelayMs=100`
+ * waits 100ms before any body bytes leave.
+ */
+export function slowStream(
+  source: ReadableStream<Uint8Array> | null,
+  opts: { chunkDelayMs: number; chunkSize?: number },
+): ReadableStream<Uint8Array> {
+  if (!source) {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+  }
+  const reader = source.getReader();
+  const chunkSize = opts.chunkSize;
+  // When chunkSize is set, we may have leftover bytes from the previous
+  // source chunk that didn't fit a full output chunk yet.
+  let pending: Uint8Array | null = null;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (chunkSize === undefined) {
+        const { value, done } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        await sleep(opts.chunkDelayMs);
+        controller.enqueue(value);
+        return;
+      }
+      // Rechunking branch: accumulate from source until we have `chunkSize`
+      // bytes, emit one chunk, sleep, repeat. On source EOF emit whatever
+      // remains as the last (possibly short) chunk.
+      while (true) {
+        if (pending && pending.byteLength >= chunkSize) {
+          const out = pending.subarray(0, chunkSize);
+          pending = pending.byteLength > chunkSize ? pending.subarray(chunkSize) : null;
+          await sleep(opts.chunkDelayMs);
+          controller.enqueue(out);
+          return;
+        }
+        const { value, done } = await reader.read();
+        if (done) {
+          if (pending && pending.byteLength > 0) {
+            const out = pending;
+            pending = null;
+            await sleep(opts.chunkDelayMs);
+            controller.enqueue(out);
+            return;
+          }
+          controller.close();
+          return;
+        }
+        if (!pending) {
+          pending = value;
+        } else {
+          const merged = new Uint8Array(pending.byteLength + value.byteLength);
+          merged.set(pending, 0);
+          merged.set(value, pending.byteLength);
+          pending = merged;
+        }
+      }
     },
     async cancel(reason) {
       await reader.cancel(reason);


### PR DESCRIPTION
## Summary

Works through every currently-open issue except #96 (which the issue itself recommends deferring until #94 ships) plus follow-up test/quality work on the new code.

Branch: 14 commits, ~870 tests passing (server-faults 117, chaosbringer 783). One pre-existing chaos.test.ts case requires Playwright browsers — environment-only, not introduced here.

### Issues closed

- **#87** — `saveReport` `mkdirSync(dirname(path), { recursive: true })` so `--output` with a missing parent directory works on the success path (the failure-artifacts directory created it implicitly before).
- **#80** — `abort` fault kind. New `FaultKind: "abort"`, `abortStyle: "hangup" | "reset"`, roll order `abort → 5xx → latency`. Express/Koa/Fastify tear down `req.socket` (`socket.end()` for hangup, `socket.destroy(err)` for reset). Hono throws `ServerFaultsAbortError` since no portable socket access exists across its runtime targets — runtimes propagate as connection error; Node-hosts can translate in `onError`. `metadataHeader` is meaningless on this path (no response delivered), documented.
- **#81** — `partial` fault kind. Real handler runs, body wrapped in a truncating `ReadableStream` after N bytes, `Content-Length` stripped because the declared length no longer matches. Hono full support; Express/Koa/Fastify throw at middleware construction (clear failure beats silent no-op until Node-`res` interception lands). Introduces `stream-transforms.ts` as a shared module.
- **#82** — `slowStream` fault kind. Reuses the stream-transforms substrate from #81. Each chunk emitted with `chunkDelayMs` of sleep; optional `chunkSize` rechunks before delaying. Headers leave immediately so `metadataHeader` round-trips; Content-Length preserved (total body length unchanged). Roll order: `abort → 5xx → partial → slowStream → latency`.
- **#83** — `statusFlapping` windowed 5xx gate. Inside a repeating `windowMs`, the first `badMs` returns 5xx; outside falls through to the existing `status5xxRate` raffle (OR composition per the issue's preference). `phaseOffsetMs` aligns/staggers multiple instances. Time-based, so not seed-reproducible — documented. Reuses the existing synthetic 5xx wire shape, so observers, metadata headers, OTel attrs see the same outcome regardless of which gate fired.
- **#88** — all four sub-features of the dual-runtime workflow helpers:
  1. **`chaosbringer diff <left.json> <right.json>`** — reuses `diffReports` but reframes output as symmetric left-only / right-only / shared. `--json` / `--left-only` / `--right-only` / `--shared-only` filters.
  2. **`IGNORE_PRESETS` + `--ignore-preset <name>`** — named bundles (`analytics`, `maps`, `media-embeds`, `pdf-orb`, `iframe-sandbox`). Composes with `--exclude`. Unknown name throws at parse time with the known list.
  3. **`chaosbringer cluster-artifacts <report.json> --bundle-dir <dir>`** — one representative bundle per cluster, copying `page.html` / `trace.jsonl` / `repro.sh` from the matching per-page failure bundle and writing a filtered `errors.json` (only the cluster's own errors). Also wired into the main crawl as `--cluster-artifacts` + `--cluster-min-count` so the inline flow doesn't need a second step.
  4. **`chaosbringer parity --left URL --right URL --paths file`** — non-random side-by-side HTTP probe. Status / redirect / failure mismatches. Default mode is manual redirects (more sensitive for routing bugs). Fetch-based only — JS exceptions / body predicates would need a Playwright session per probe and were deliberately scoped out. Exits non-zero on any mismatch so it slots into CI as a gate.
- **#96** — deferred per the issue's own recommendation ("Defer until #94 (CLI) ships").

### Test / quality follow-ups

Test coverage on this branch's new code increased from initial happy-path tests to comprehensive edge coverage:

- CLI dispatchers for `cluster-artifacts` and `parity` had no tests on first ship — added 15 covering positional parsing, exit-code wiring, `--json` output, missing-flag handling.
- `parity` library: timeout AbortController wiring, `redirect: manual` vs `follow` defaults, 3xx-vs-200 classified as status not redirect.
- `cluster-artifacts` library: empty-cluster report, non-existent bundleDir, earliest-sequence bundle selection when multiple bundles exist for one URL, cluster-key sanitisation.
- `statusFlapping` filter uniformity: bypassHeader / exemptPathPattern / pathPattern all apply to the gate (catches refactor that moves the gate past a filter).
- Stream-verdict adapter paths: partial with N > body length, slowStream chunkSize rechunking, slowStream null-body short-circuit.
- Ignore presets pinned to representative noise strings (catches mis-escaped regex) + over-broadness regression guard (catches accidental real-error matches).
- Public package entry exposes the new utilities (`IGNORE_PRESETS`, `writeClusterArtifacts`, `runParity` + types) — `diffReports` was already public, this just makes the sibling additions consistent. Smoke test catches dropped re-exports at import time.

Plus one small refactor: the CLI's 8 subcommand if-blocks (80 lines of try/catch + dynamic-import boilerplate) collapse to a table-driven dispatcher (24 lines). Behaviour preserved.

## Test plan

- [x] `pnpm -F @mizchi/server-faults test` — 117 passed (3 files)
- [x] `pnpm -F chaosbringer test` against `src/` — 783 passed, 1 pre-existing chaos.test.ts case fails when Playwright browsers aren't installed (unrelated to this branch)
- [x] `pnpm -r build` — all 5 workspace packages build clean
- [ ] CI / maintainer review

Resolves #80, #81, #82, #83, #87, #88. Notes #96 as deferred per the issue's own recommendation.

---
_Generated by [Claude Code](https://claude.ai/code/session_016akfbHeRMhsvBRxJW2HBFi)_