### PR TITLE
Dogfood playground + 11 iterations of agent-driven parity/journey improvements

### DIFF
--- a/packages/chaosbringer/src/body-diff.test.ts
+++ b/packages/chaosbringer/src/body-diff.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { diffJsonBodies, summariseBodyDiff } from "./body-diff.js";
+
+describe("diffJsonBodies", () => {
+  it("returns null when bodies are byte-identical", () => {
+    expect(diffJsonBodies('{"id":1}', '{"id":1}')).toBeNull();
+  });
+
+  it("reports a top-level field changed", () => {
+    const diff = diffJsonBodies('{"id":1}', '{"id":2}');
+    expect(diff?.entries).toEqual([{ path: "id", kind: "changed", left: 1, right: 2 }]);
+  });
+
+  it("reports a removed field by name (left has, right doesn't)", () => {
+    const diff = diffJsonBodies(
+      '{"id":1,"email":"a@x"}',
+      '{"id":1}',
+    );
+    expect(diff?.entries).toEqual([{ path: "email", kind: "removed", left: "a@x" }]);
+  });
+
+  it("reports an added field by name (right has, left doesn't)", () => {
+    const diff = diffJsonBodies('{"id":1}', '{"id":1,"new":"x"}');
+    expect(diff?.entries).toEqual([{ path: "new", kind: "added", right: "x" }]);
+  });
+
+  it("descends into nested objects with a dotted path", () => {
+    const diff = diffJsonBodies(
+      '{"user":{"profile":{"name":"a"}}}',
+      '{"user":{"profile":{"name":"b"}}}',
+    );
+    expect(diff?.entries).toEqual([
+      { path: "user.profile.name", kind: "changed", left: "a", right: "b" },
+    ]);
+  });
+
+  it("indexes into arrays by position with numeric segments", () => {
+    const diff = diffJsonBodies('[10,20,30]', '[10,99,30]');
+    expect(diff?.entries).toEqual([{ path: "1", kind: "changed", left: 20, right: 99 }]);
+  });
+
+  it("reports array length differences as added/removed at the trailing index", () => {
+    const diff = diffJsonBodies('[1,2]', '[1,2,3]');
+    expect(diff?.entries).toEqual([{ path: "2", kind: "added", right: 3 }]);
+  });
+
+  it("reports a type mismatch at the boundary and stops descending", () => {
+    const diff = diffJsonBodies('{"items":[1,2]}', '{"items":"abc"}');
+    // We do NOT descend into 'items' on either side — different shape
+    // is reported at the boundary.
+    expect(diff?.entries).toEqual([
+      { path: "items", kind: "typed", left: [1, 2], right: "abc" },
+    ]);
+  });
+
+  it("flags one-side-non-JSON bodies with a root-level typed entry (content-type drift)", () => {
+    // One side is HTML, the other JSON — real content-type drift.
+    const diff = diffJsonBodies("<html>x</html>", '{"id":1}');
+    expect(diff?.entries[0].kind).toBe("typed");
+    expect(diff?.entries[0].path).toBe("");
+  });
+
+  it("returns null when BOTH bodies are non-JSON (no useful structural info to add)", () => {
+    // Both HTML — the hash mismatch already tells the operator they
+    // differ. Reporting a fake 'typed' here would be misleading.
+    const diff = diffJsonBodies("<html>a</html>", "<html>b</html>");
+    expect(diff).toBeNull();
+  });
+
+  it("treats null bodies as null JSON (returns null if both are null)", () => {
+    expect(diffJsonBodies(null, null)).toBeNull();
+    // null vs "{}" → null vs an object → typed at root.
+    const diff = diffJsonBodies(null, "{}");
+    expect(diff?.entries[0].kind).toBe("typed");
+  });
+
+  it("Object.is semantics — NaN equal to NaN, +0 not equal to -0", () => {
+    // NaN encodes as null in JSON, so this is the practical edge case:
+    // we compare via Object.is after JSON.parse already normalised both
+    // sides, so 0 vs -0 stays as one entry.
+    expect(diffJsonBodies("0", "-0")?.entries).toHaveLength(1);
+  });
+
+  it("honours the maxEntries cap and signals truncation", () => {
+    const left = JSON.stringify(Array.from({ length: 200 }, (_, i) => i));
+    const right = JSON.stringify(Array.from({ length: 200 }, (_, i) => i + 1));
+    const diff = diffJsonBodies(left, right, { maxEntries: 5 });
+    expect(diff?.entries).toHaveLength(5);
+    expect(diff?.truncated).toBe(true);
+  });
+
+  it("reports both directions of drift in one pass", () => {
+    const diff = diffJsonBodies(
+      '{"keep":1,"only_left":2}',
+      '{"keep":1,"only_right":3}',
+    );
+    expect(diff?.entries.map((e) => e.path).sort()).toEqual(["only_left", "only_right"]);
+  });
+});
+
+describe("summariseBodyDiff", () => {
+  it("renders a 'changed' leaf with arrow-style output", () => {
+    const diff = diffJsonBodies('{"title":"a"}', '{"title":"B"}');
+    expect(summariseBodyDiff(diff)).toContain('title: "a" → "B"');
+  });
+
+  it("renders 'removed' with a minus prefix", () => {
+    const diff = diffJsonBodies('{"x":1,"email":"a"}', '{"x":1}');
+    expect(summariseBodyDiff(diff)).toContain('email: -"a"');
+  });
+
+  it("renders 'added' with a plus prefix", () => {
+    const diff = diffJsonBodies('{"x":1}', '{"x":1,"new":"v"}');
+    expect(summariseBodyDiff(diff)).toContain('new: +"v"');
+  });
+
+  it("caps at the limit and signals overflow with '(+N more)'", () => {
+    const left = JSON.stringify({ a: 1, b: 1, c: 1, d: 1, e: 1 });
+    const right = JSON.stringify({ a: 2, b: 2, c: 2, d: 2, e: 2 });
+    const diff = diffJsonBodies(left, right);
+    expect(summariseBodyDiff(diff, 2)).toContain("(+3 more");
+  });
+
+  it("renders type mismatches as 'type X → Y'", () => {
+    const diff = diffJsonBodies('{"x":[1]}', '{"x":"y"}');
+    expect(summariseBodyDiff(diff)).toContain("type array → string");
+  });
+
+  it("returns empty string for null/empty diff", () => {
+    expect(summariseBodyDiff(null)).toBe("");
+  });
+});

--- a/packages/chaosbringer/src/body-diff.ts
+++ b/packages/chaosbringer/src/body-diff.ts
@@ -1,0 +1,214 @@
+/**
+ * Localising JSON body drift to specific paths.
+ *
+ * `parity` and `journey` currently report body mismatches as opaque
+ * `left=N bytes, hash=…` pairs. That tells a triager that something
+ * changed but not which field — the difference between "0 bytes" of
+ * useful signal and "name the bug" depends on this module.
+ *
+ * Limitations are explicit:
+ *
+ * - Only JSON. Non-JSON bodies (HTML, binary) fall through with a
+ *   single `BodyDiffEntry` describing the type mismatch — better than
+ *   silent skip, less work than per-content-type diffing.
+ * - Top-down structural walk. Arrays are compared element-by-index;
+ *   reordering produces a "wide" diff. Callers that care about set
+ *   semantics should sort before comparison.
+ * - Outputs are capped at `maxEntries` so a 10k-element list diff
+ *   doesn't pollute the report. The cap is documented at the call
+ *   site; the truncation is signalled via the `truncated` flag.
+ */
+
+export type BodyDiffKind =
+  /** Path exists on right but not on left. */
+  | "added"
+  /** Path exists on left but not on right. */
+  | "removed"
+  /** Both sides have the path, but the leaf values differ. */
+  | "changed"
+  /**
+   * Both sides have the path; one is a primitive and the other a
+   * container (object/array) — a structural shape change. Reported
+   * once at the boundary; we don't descend further on this branch.
+   */
+  | "typed";
+
+export interface BodyDiffEntry {
+  /** Dotted path into the tree. Empty string is the root. */
+  path: string;
+  kind: BodyDiffKind;
+  left?: unknown;
+  right?: unknown;
+}
+
+export interface BodyDiffResult {
+  entries: BodyDiffEntry[];
+  /** True when the diff was truncated to `maxEntries`. */
+  truncated: boolean;
+}
+
+interface DiffOptions {
+  /** Hard cap on entries. Default 50 — enough to triage, small enough to read. */
+  maxEntries?: number;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function typeTag(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
+function pushChange(
+  out: BodyDiffEntry[],
+  cap: number,
+  entry: BodyDiffEntry,
+): boolean {
+  if (out.length >= cap) return true;
+  out.push(entry);
+  return out.length >= cap;
+}
+
+function walk(
+  left: unknown,
+  right: unknown,
+  path: string,
+  out: BodyDiffEntry[],
+  cap: number,
+): boolean {
+  // Returns true when the cap has been hit and the caller should stop.
+  if (Object.is(left, right)) return out.length >= cap;
+  // Primitives + null: bare equality already failed above, so report
+  // a change. Strict-equality semantics mean `NaN === NaN` is false
+  // by default but `Object.is(NaN, NaN)` is true — using `Object.is`
+  // above keeps NaN out of the noise.
+  const lt = typeTag(left);
+  const rt = typeTag(right);
+  if (lt !== rt) {
+    return pushChange(out, cap, { path, kind: "typed", left, right });
+  }
+  if (lt !== "object" && lt !== "array") {
+    return pushChange(out, cap, { path, kind: "changed", left, right });
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    const len = Math.max(left.length, right.length);
+    for (let i = 0; i < len; i++) {
+      const sub = path ? `${path}.${i}` : String(i);
+      if (i >= left.length) {
+        if (pushChange(out, cap, { path: sub, kind: "added", right: right[i] })) return true;
+        continue;
+      }
+      if (i >= right.length) {
+        if (pushChange(out, cap, { path: sub, kind: "removed", left: left[i] })) return true;
+        continue;
+      }
+      if (walk(left[i], right[i], sub, out, cap)) return true;
+    }
+    return out.length >= cap;
+  }
+  if (isPlainObject(left) && isPlainObject(right)) {
+    // Iterate the union of keys so we surface both directions of drift.
+    // Sorted so the report is stable across runs (useful for diffing
+    // diffs across CI runs).
+    const keys = Array.from(new Set([...Object.keys(left), ...Object.keys(right)])).sort();
+    for (const k of keys) {
+      const sub = path ? `${path}.${k}` : k;
+      const hasLeft = Object.hasOwn(left, k);
+      const hasRight = Object.hasOwn(right, k);
+      if (!hasRight) {
+        if (pushChange(out, cap, { path: sub, kind: "removed", left: left[k] })) return true;
+        continue;
+      }
+      if (!hasLeft) {
+        if (pushChange(out, cap, { path: sub, kind: "added", right: right[k] })) return true;
+        continue;
+      }
+      if (walk(left[k], right[k], sub, out, cap)) return true;
+    }
+    return out.length >= cap;
+  }
+  // Should not reach here — primitives are handled above, container
+  // types matched. Keep a safe fallback for shapes we didn't anticipate.
+  return pushChange(out, cap, { path, kind: "changed", left, right });
+}
+
+/**
+ * Compute the body diff. Returns `null` (not an empty result) when the
+ * bodies are byte-identical — the caller already knows there's no
+ * drift in that case. Returns `{ entries: [{ kind: "typed", … }] }`
+ * when at least one side isn't parseable JSON: a triager seeing
+ * "kind=typed at root, left=object, right=string" learns the
+ * content-type drifted without needing the byte hash.
+ */
+function tryParseJson(text: string | null): { ok: boolean; value?: unknown } {
+  if (text === null || text.length === 0) return { ok: true, value: null };
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function diffJsonBodies(
+  leftText: string | null,
+  rightText: string | null,
+  opts: DiffOptions = {},
+): BodyDiffResult | null {
+  const cap = opts.maxEntries ?? 50;
+  const left = tryParseJson(leftText);
+  const right = tryParseJson(rightText);
+  // Both bodies aren't JSON → we have nothing structural to add over
+  // the hash mismatch. Return null and let the caller fall back to
+  // the byte-level summary. Returning a fake "typed string→string"
+  // here would be actively misleading.
+  if (!left.ok && !right.ok) return null;
+  // One side is JSON, the other isn't → that's a real content-type
+  // drift the operator should see. Report at the root with the
+  // raw values.
+  if (!left.ok || !right.ok) {
+    return {
+      entries: [{ path: "", kind: "typed", left: leftText, right: rightText }],
+      truncated: false,
+    };
+  }
+  const entries: BodyDiffEntry[] = [];
+  walk(left.value, right.value, "", entries, cap);
+  if (entries.length === 0) return null;
+  return { entries, truncated: entries.length >= cap };
+}
+
+/**
+ * One-line summary fit for stdout. Renders up to `limit` entries as
+ * `path: <kind> (left=… right=…)`. Returns the empty string when
+ * the diff is null.
+ */
+export function summariseBodyDiff(diff: BodyDiffResult | null | undefined, limit = 3): string {
+  if (!diff || diff.entries.length === 0) return "";
+  const lines = diff.entries.slice(0, limit).map((e) => {
+    const path = e.path === "" ? "(root)" : e.path;
+    if (e.kind === "added") return `${path}: +${stringify(e.right)}`;
+    if (e.kind === "removed") return `${path}: -${stringify(e.left)}`;
+    if (e.kind === "typed") {
+      return `${path}: type ${typeTag(e.left)} → ${typeTag(e.right)}`;
+    }
+    return `${path}: ${stringify(e.left)} → ${stringify(e.right)}`;
+  });
+  if (diff.entries.length > limit) {
+    lines.push(`(+${diff.entries.length - limit} more${diff.truncated ? ", truncated" : ""})`);
+  }
+  return lines.join(" | ");
+}
+
+function stringify(v: unknown): string {
+  if (typeof v === "string") return JSON.stringify(v);
+  if (v === undefined) return "undefined";
+  try {
+    const s = JSON.stringify(v);
+    return s.length > 60 ? `${s.slice(0, 57)}...` : s;
+  } catch {
+    return String(v);
+  }
+}

--- a/packages/chaosbringer/src/cli.ts
+++ b/packages/chaosbringer/src/cli.ts
@@ -56,6 +56,7 @@ const SUBCOMMANDS: Record<string, () => Promise<(argv: string[]) => Promise<void
   "cluster-artifacts": () =>
     import("./cluster-artifacts-cli.js").then((m) => m.runClusterArtifactsCli),
   parity: () => import("./parity-cli.js").then((m) => m.runParityCli),
+  journey: () => import("./journey-cli.js").then((m) => m.runJourneyCli),
 };
 
 const rawSub = process.argv[2];

--- a/packages/chaosbringer/src/journey-cli.ts
+++ b/packages/chaosbringer/src/journey-cli.ts
@@ -127,30 +127,32 @@ export async function runJourneyCli(argv: string[]): Promise<void> {
   );
   for (const m of report.mismatches) {
     const prefix = `  [${m.index}] ${m.label}`;
-    if (m.kind === "status") {
-      console.log(`${prefix}  STATUS left=${m.left.status} right=${m.right.status}`);
-    } else if (m.kind === "redirect") {
-      console.log(
-        `${prefix}  REDIR  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`,
-      );
-    } else if (m.kind === "header") {
-      const diffs: string[] = [];
-      const left = m.left.headers ?? {};
-      const right = m.right.headers ?? {};
-      for (const name of Object.keys(left)) {
-        if (left[name] !== right[name]) {
-          diffs.push(`${name}: left=${left[name] ?? "(none)"} right=${right[name] ?? "(none)"}`);
+    for (const kind of m.kinds) {
+      if (kind === "status") {
+        console.log(`${prefix}  STATUS left=${m.left.status} right=${m.right.status}`);
+      } else if (kind === "redirect") {
+        console.log(
+          `${prefix}  REDIR  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`,
+        );
+      } else if (kind === "header") {
+        const diffs: string[] = [];
+        const left = m.left.headers ?? {};
+        const right = m.right.headers ?? {};
+        for (const name of Object.keys(left)) {
+          if (left[name] !== right[name]) {
+            diffs.push(`${name}: left=${left[name] ?? "(none)"} right=${right[name] ?? "(none)"}`);
+          }
         }
+        console.log(`${prefix}  HEADER ${diffs.join(" | ")}`);
+      } else if (kind === "body") {
+        const summary = summariseBodyDiff(m.bodyDiff);
+        const head = `${prefix}  BODY   left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
+        console.log(summary ? `${head}\n         ${summary}` : head);
+      } else if (kind === "failure") {
+        const leftMsg = m.left.error ?? `status ${m.left.status}`;
+        const rightMsg = m.right.error ?? `status ${m.right.status}`;
+        console.log(`${prefix}  FAIL   left=${leftMsg} right=${rightMsg}`);
       }
-      console.log(`${prefix}  HEADER ${diffs.join(" | ")}`);
-    } else if (m.kind === "body") {
-      const summary = summariseBodyDiff(m.bodyDiff);
-      const head = `${prefix}  BODY   left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
-      console.log(summary ? `${head}\n         ${summary}` : head);
-    } else {
-      const leftMsg = m.left.error ?? `status ${m.left.status}`;
-      const rightMsg = m.right.error ?? `status ${m.right.status}`;
-      console.log(`${prefix}  FAIL   left=${leftMsg} right=${rightMsg}`);
     }
   }
 

--- a/packages/chaosbringer/src/journey-cli.ts
+++ b/packages/chaosbringer/src/journey-cli.ts
@@ -33,6 +33,10 @@ Options:
   --output <file>       Write the full report (JSON) to this path
   --check-headers <list>  Compare named headers per step (comma-separated)
   --no-check-body       Skip body comparison (defaults to on for journeys)
+  --perf-delta-ms <n>   Flag a "perf" mismatch when right is more than
+                        N ms slower than left on any step. Single-sample.
+  --perf-ratio <n>      Flag a "perf" mismatch when right > left * N.
+                        Composes with --perf-delta-ms via OR.
   --stop-on-mismatch    Stop at the first divergence (later steps depend
                         on earlier ones succeeding; no point continuing
                         a broken flow)
@@ -80,6 +84,8 @@ export async function runJourneyCli(argv: string[]): Promise<void> {
       output: { type: "string" },
       "check-headers": { type: "string" },
       "no-check-body": { type: "boolean", default: false },
+      "perf-delta-ms": { type: "string" },
+      "perf-ratio": { type: "string" },
       "stop-on-mismatch": { type: "boolean", default: false },
       timeout: { type: "string" },
       help: { type: "boolean", default: false },
@@ -114,6 +120,8 @@ export async function runJourneyCli(argv: string[]): Promise<void> {
     timeoutMs: values.timeout ? parseInt(values.timeout, 10) : undefined,
     checkBody: !values["no-check-body"],
     checkHeaders,
+    perfDeltaMs: values["perf-delta-ms"] ? parseFloat(values["perf-delta-ms"]) : undefined,
+    perfRatio: values["perf-ratio"] ? parseFloat(values["perf-ratio"]) : undefined,
     stopOnMismatch: values["stop-on-mismatch"],
   });
 
@@ -148,6 +156,14 @@ export async function runJourneyCli(argv: string[]): Promise<void> {
         const summary = summariseBodyDiff(m.bodyDiff);
         const head = `${prefix}  BODY   left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
         console.log(summary ? `${head}\n         ${summary}` : head);
+      } else if (kind === "perf") {
+        const l = m.left.durationMs ?? 0;
+        const r = m.right.durationMs ?? 0;
+        const delta = r - l;
+        const ratio = l > 0 ? r / l : 0;
+        console.log(
+          `${prefix}  PERF   left=${l.toFixed(0)}ms  right=${r.toFixed(0)}ms  Δ=${delta.toFixed(0)}ms (×${ratio.toFixed(2)})`,
+        );
       } else if (kind === "failure") {
         const leftMsg = m.left.error ?? `status ${m.left.status}`;
         const rightMsg = m.right.error ?? `status ${m.right.status}`;

--- a/packages/chaosbringer/src/journey-cli.ts
+++ b/packages/chaosbringer/src/journey-cli.ts
@@ -1,0 +1,157 @@
+/**
+ * `chaosbringer journey --left URL --right URL --steps <file>`. See
+ * `journey.ts` for design notes.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { parseArgs } from "node:util";
+import { runJourney, type JourneyStep } from "./journey.js";
+
+const HELP = `Usage: chaosbringer journey --left <url> --right <url> --steps <file> [options]
+
+Replay a sequence of HTTP requests against two base URLs and compare
+each step's response. Per-side cookie jar carries state from POST to
+subsequent GET, so a silently-dropped write surfaces in the read step's
+body diff. The bug class single-shot parity can't see.
+
+Steps file is JSON. Either a bare array of steps or
+\`{ "steps": [...] }\` is accepted:
+
+  [
+    { "method": "POST", "path": "/api/todos", "body": { "title": "x" }, "label": "create" },
+    { "method": "GET",  "path": "/api/todos", "label": "list-after-create" }
+  ]
+
+Required:
+  --left <url>          First base URL
+  --right <url>         Second base URL
+  --steps <file>        Path to the JSON steps file (or "-" for stdin)
+
+Options:
+  --output <file>       Write the full report (JSON) to this path
+  --check-headers <list>  Compare named headers per step (comma-separated)
+  --no-check-body       Skip body comparison (defaults to on for journeys)
+  --stop-on-mismatch    Stop at the first divergence (later steps depend
+                        on earlier ones succeeding; no point continuing
+                        a broken flow)
+  --timeout <ms>        Per-request timeout. Default 10000
+  --help                Show this help
+
+Exit code is 1 when any step diverges, 0 when every step matches.
+Useful as a CI gate for canary-vs-prod or v1-vs-v2 comparisons.
+
+Example:
+  chaosbringer journey \\
+    --left http://localhost:3000 --right http://localhost:3001 \\
+    --steps tests/checkout-flow.json --output reports/checkout-parity.json
+`;
+
+function readSteps(file: string): JourneyStep[] {
+  const text = file === "-" ? readFileSync(0, "utf-8") : readFileSync(file, "utf-8");
+  const parsed = JSON.parse(text);
+  const steps = Array.isArray(parsed) ? parsed : parsed?.steps;
+  if (!Array.isArray(steps)) {
+    throw new Error(
+      `journey: ${file} is not a steps file — expected an array or { "steps": [...] }`,
+    );
+  }
+  // Lightweight shape validation. We don't pull in a schema library —
+  // bad inputs throw with a step index so the operator can find them.
+  steps.forEach((s, i) => {
+    if (typeof s !== "object" || s === null) {
+      throw new Error(`journey: step ${i} is not an object`);
+    }
+    if (typeof s.method !== "string" || typeof s.path !== "string") {
+      throw new Error(`journey: step ${i} missing method/path`);
+    }
+  });
+  return steps as JourneyStep[];
+}
+
+export async function runJourneyCli(argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      left: { type: "string" },
+      right: { type: "string" },
+      steps: { type: "string" },
+      output: { type: "string" },
+      "check-headers": { type: "string" },
+      "no-check-body": { type: "boolean", default: false },
+      "stop-on-mismatch": { type: "boolean", default: false },
+      timeout: { type: "string" },
+      help: { type: "boolean", default: false },
+    },
+  });
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (!values.left || !values.right || !values.steps) {
+    console.error("journey: --left, --right, and --steps are all required");
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+
+  const steps = readSteps(values.steps);
+  if (steps.length === 0) {
+    console.error("journey: steps file has no steps");
+    process.exitCode = 1;
+    return;
+  }
+  const checkHeaders = values["check-headers"]
+    ?.split(",")
+    .map((h) => h.trim())
+    .filter((h) => h.length > 0);
+
+  const report = await runJourney({
+    left: values.left,
+    right: values.right,
+    steps,
+    timeoutMs: values.timeout ? parseInt(values.timeout, 10) : undefined,
+    checkBody: !values["no-check-body"],
+    checkHeaders,
+    stopOnMismatch: values["stop-on-mismatch"],
+  });
+
+  if (values.output) {
+    mkdirSync(dirname(values.output), { recursive: true });
+    writeFileSync(values.output, JSON.stringify(report, null, 2));
+  }
+
+  console.log(
+    `Ran ${report.stepsChecked}/${steps.length} step(s): ${report.matches.length} match, ${report.mismatches.length} mismatch.`,
+  );
+  for (const m of report.mismatches) {
+    const prefix = `  [${m.index}] ${m.label}`;
+    if (m.kind === "status") {
+      console.log(`${prefix}  STATUS left=${m.left.status} right=${m.right.status}`);
+    } else if (m.kind === "redirect") {
+      console.log(
+        `${prefix}  REDIR  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`,
+      );
+    } else if (m.kind === "header") {
+      const diffs: string[] = [];
+      const left = m.left.headers ?? {};
+      const right = m.right.headers ?? {};
+      for (const name of Object.keys(left)) {
+        if (left[name] !== right[name]) {
+          diffs.push(`${name}: left=${left[name] ?? "(none)"} right=${right[name] ?? "(none)"}`);
+        }
+      }
+      console.log(`${prefix}  HEADER ${diffs.join(" | ")}`);
+    } else if (m.kind === "body") {
+      console.log(
+        `${prefix}  BODY   left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`,
+      );
+    } else {
+      const leftMsg = m.left.error ?? `status ${m.left.status}`;
+      const rightMsg = m.right.error ?? `status ${m.right.status}`;
+      console.log(`${prefix}  FAIL   left=${leftMsg} right=${rightMsg}`);
+    }
+  }
+
+  if (report.mismatches.length > 0) process.exitCode = 1;
+}

--- a/packages/chaosbringer/src/journey-cli.ts
+++ b/packages/chaosbringer/src/journey-cli.ts
@@ -6,6 +6,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { parseArgs } from "node:util";
+import { summariseBodyDiff } from "./body-diff.js";
 import { runJourney, type JourneyStep } from "./journey.js";
 
 const HELP = `Usage: chaosbringer journey --left <url> --right <url> --steps <file> [options]
@@ -143,9 +144,9 @@ export async function runJourneyCli(argv: string[]): Promise<void> {
       }
       console.log(`${prefix}  HEADER ${diffs.join(" | ")}`);
     } else if (m.kind === "body") {
-      console.log(
-        `${prefix}  BODY   left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`,
-      );
+      const summary = summariseBodyDiff(m.bodyDiff);
+      const head = `${prefix}  BODY   left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
+      console.log(summary ? `${head}\n         ${summary}` : head);
     } else {
       const leftMsg = m.left.error ?? `status ${m.left.status}`;
       const rightMsg = m.right.error ?? `status ${m.right.status}`;

--- a/packages/chaosbringer/src/journey.test.ts
+++ b/packages/chaosbringer/src/journey.test.ts
@@ -461,6 +461,126 @@ describe("runJourney", () => {
       expect(seen).toContain("http://l/items/%7B%7BtodoId%7D%7D");
     });
 
+    it("per-actor cookie jars stay isolated within one side", async () => {
+      const seenCookies: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const cookie = (init?.headers as Headers).get("cookie") ?? "";
+        if (url.endsWith("/login/alice")) {
+          return new Response("", { status: 200, headers: { "set-cookie": "u=alice; Path=/" } });
+        }
+        if (url.endsWith("/login/bob")) {
+          return new Response("", { status: 200, headers: { "set-cookie": "u=bob; Path=/" } });
+        }
+        seenCookies.push(cookie);
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [
+          { method: "GET", path: "/login/alice", actor: "alice" },
+          { method: "GET", path: "/login/bob", actor: "bob" },
+          { method: "GET", path: "/whoami", actor: "bob" },
+        ],
+        fetcher,
+      });
+      expect(seenCookies.some((c) => c.includes("u=bob"))).toBe(true);
+      expect(seenCookies.every((c) => !c.includes("u=alice"))).toBe(true);
+    });
+
+    it("per-actor vars stay isolated within one side", async () => {
+      const calls: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/create/alice")) return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+        if (url.includes("/create/bob")) return new Response(JSON.stringify({ id: 2 }), { status: 200 });
+        calls.push(url);
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [
+          {
+            method: "POST", path: "/create/alice", body: {},
+            actor: "alice", capture: [{ from: "body.id", as: "todoId" }],
+          },
+          {
+            method: "POST", path: "/create/bob", body: {},
+            actor: "bob", capture: [{ from: "body.id", as: "todoId" }],
+          },
+          { method: "GET", path: "/read/{{todoId}}", actor: "alice" },
+          { method: "GET", path: "/read/{{todoId}}", actor: "bob" },
+        ],
+        fetcher,
+      });
+      const reads = calls.filter((u) => u.includes("/read/"));
+      expect(reads).toContain("http://l/read/1");
+      expect(reads).toContain("http://l/read/2");
+      expect(reads).toContain("http://r/read/1");
+      expect(reads).toContain("http://r/read/2");
+    });
+
+    it("flags a body mismatch when v2 leaks actor A's data into actor B's read", async () => {
+      function makeTenantServer(opts: { leakAcrossUsers?: boolean } = {}) {
+        const byUser = new Map<string, Array<{ title: string }>>();
+        return (url: string, init: RequestInit | undefined): Response => {
+          const u = new URL(url);
+          const cookie = (init?.headers as Headers).get("cookie") ?? "";
+          const userMatch = cookie.match(/u=(\w+)/);
+          const user = userMatch ? userMatch[1] : "anon";
+          const method = (init?.method ?? "GET").toUpperCase();
+          if (u.pathname === "/login" && method === "POST") {
+            const body = JSON.parse(init?.body as string);
+            return new Response("ok", {
+              status: 200,
+              headers: { "set-cookie": `u=${body.user}; Path=/` },
+            });
+          }
+          if (u.pathname === "/todos" && method === "POST") {
+            const body = JSON.parse(init?.body as string);
+            const list = byUser.get(user) ?? [];
+            list.push({ title: body.title });
+            byUser.set(user, list);
+            return new Response("ok", { status: 200 });
+          }
+          if (u.pathname === "/todos" && method === "GET") {
+            if (opts.leakAcrossUsers) {
+              const all: Array<{ title: string }> = [];
+              for (const v of byUser.values()) all.push(...v);
+              return new Response(JSON.stringify(all), { status: 200 });
+            }
+            return new Response(JSON.stringify(byUser.get(user) ?? []), { status: 200 });
+          }
+          return new Response("not found", { status: 404 });
+        };
+      }
+      const leftHandler = makeTenantServer();
+      const rightHandler = makeTenantServer({ leakAcrossUsers: true });
+      const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const host = new URL(url).host;
+        const h = host === "left" ? leftHandler : rightHandler;
+        return h(url, init);
+      }) as typeof fetch;
+      const steps: JourneyStep[] = [
+        { method: "POST", path: "/login", body: { user: "alice" }, actor: "alice" },
+        { method: "POST", path: "/todos", body: { title: "alice-secret" }, actor: "alice" },
+        { method: "POST", path: "/login", body: { user: "bob" }, actor: "bob" },
+        { method: "GET", path: "/todos", actor: "bob", label: "bob-lists" },
+      ];
+      const report = await runJourney({
+        left: "http://left",
+        right: "http://right",
+        steps,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].label).toBe("bob-lists");
+      expect(report.mismatches[0].kinds).toContain("body");
+    });
+
     it("per-side vars stay isolated — left's capture does not leak to right", async () => {
       // Each side captures id=1 from its own POST. If they shared a
       // var bag, a race would let one side see the other's id.

--- a/packages/chaosbringer/src/journey.test.ts
+++ b/packages/chaosbringer/src/journey.test.ts
@@ -109,7 +109,7 @@ describe("runJourney", () => {
     expect(report.mismatches).toHaveLength(1);
     expect(report.mismatches[0].index).toBe(1);
     expect(report.mismatches[0].label).toBe("list");
-    expect(report.mismatches[0].kind).toBe("body");
+    expect(report.mismatches[0].kinds[0]).toBe("body");
   });
 
   it("threads per-side cookies — auth set in step 1 visible to step 2", async () => {
@@ -215,7 +215,7 @@ describe("runJourney", () => {
       steps: [{ method: "GET", path: "/x" }],
       fetcher,
     });
-    expect(report.mismatches[0].kind).toBe("status");
+    expect(report.mismatches[0].kinds[0]).toBe("status");
   });
 
   it("--no-check-body equivalent: checkBody=false skips body hashing", async () => {
@@ -326,7 +326,7 @@ describe("runJourney", () => {
         }),
       });
       expect(report.mismatches).toHaveLength(1);
-      expect(report.mismatches[0].kind).toBe("body");
+      expect(report.mismatches[0].kinds[0]).toBe("body");
       expect(report.mismatches[0].index).toBe(1);
     });
 

--- a/packages/chaosbringer/src/journey.test.ts
+++ b/packages/chaosbringer/src/journey.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { runJourney, type JourneyStep } from "./journey.js";
+
+/**
+ * Stateful synthetic server: same factory builds left + right. Each
+ * server owns its own todos array, so the journey's per-side cookie
+ * jar / state binding can be exercised independently.
+ */
+function makeServer(opts: { silentlyDropWrites?: boolean } = {}) {
+  let nextId = 1;
+  const todos: Array<{ id: number; title: string }> = [];
+  let cookieSeed = 0;
+  return {
+    todos,
+    handle(url: string, init: RequestInit | undefined): Response {
+      const u = new URL(url);
+      const cookies = (init?.headers as Headers | undefined)?.get("cookie") ?? "";
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      // Session cookie issued on first GET so we can prove the
+      // per-side jar binding works end-to-end. Side effects don't
+      // depend on the session — the test asserts cookie threading
+      // separately.
+      const respHeaders = new Headers();
+      if (!cookies.includes("sid=")) {
+        const sid = `session-${++cookieSeed}`;
+        respHeaders.append("set-cookie", `sid=${sid}; Path=/`);
+      }
+
+      if (u.pathname === "/api/todos" && method === "POST") {
+        const body = JSON.parse(init?.body as string);
+        if (opts.silentlyDropWrites) {
+          // Bug: return success without persisting.
+          return new Response(JSON.stringify({ id: nextId, ...body }), {
+            status: 201,
+            headers: respHeaders,
+          });
+        }
+        const created = { id: nextId++, ...body };
+        todos.push(created);
+        return new Response(JSON.stringify(created), {
+          status: 201,
+          headers: respHeaders,
+        });
+      }
+      if (u.pathname === "/api/todos" && method === "GET") {
+        return new Response(JSON.stringify(todos), { status: 200, headers: respHeaders });
+      }
+      if (u.pathname === "/api/login") {
+        respHeaders.append("set-cookie", "auth=token-v1; Path=/");
+        return new Response("ok", { status: 200, headers: respHeaders });
+      }
+      if (u.pathname === "/api/profile") {
+        if (!cookies.includes("auth=")) {
+          return new Response("unauth", { status: 401, headers: respHeaders });
+        }
+        return new Response('{"user":"me"}', { status: 200, headers: respHeaders });
+      }
+      return new Response("not found", { status: 404, headers: respHeaders });
+    },
+  };
+}
+
+function fetcherFor(servers: Record<string, ReturnType<typeof makeServer>>): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const u = new URL(url);
+    const base = `${u.protocol}//${u.host}`;
+    const server = servers[base];
+    if (!server) throw new Error(`unexpected host: ${base}`);
+    return server.handle(url, init);
+  }) as typeof fetch;
+}
+
+describe("runJourney", () => {
+  const writeThenReadSteps: JourneyStep[] = [
+    { method: "POST", path: "/api/todos", body: { title: "x" }, label: "create" },
+    { method: "GET", path: "/api/todos", label: "list" },
+  ];
+
+  it("matches both sides when state is symmetric", async () => {
+    const left = makeServer();
+    const right = makeServer();
+    const report = await runJourney({
+      left: "http://left",
+      right: "http://right",
+      steps: writeThenReadSteps,
+      fetcher: fetcherFor({ "http://left": left, "http://right": right }),
+    });
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.matches).toHaveLength(2);
+    // Both sides actually persisted the write.
+    expect(left.todos).toEqual([{ id: 1, title: "x" }]);
+    expect(right.todos).toEqual([{ id: 1, title: "x" }]);
+  });
+
+  it("flags the read step when right silently drops the write", async () => {
+    // The canonical bug class journey is built to catch: POST returns
+    // 201 on both sides (identical status / body), but right doesn't
+    // actually persist. The subsequent GET shows the divergence.
+    const left = makeServer();
+    const right = makeServer({ silentlyDropWrites: true });
+    const report = await runJourney({
+      left: "http://left",
+      right: "http://right",
+      steps: writeThenReadSteps,
+      fetcher: fetcherFor({ "http://left": left, "http://right": right }),
+    });
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].index).toBe(1);
+    expect(report.mismatches[0].label).toBe("list");
+    expect(report.mismatches[0].kind).toBe("body");
+  });
+
+  it("threads per-side cookies — auth set in step 1 visible to step 2", async () => {
+    // Asserts the cookie jar works: a server that 401s without an auth
+    // cookie would fail step 2 if step 1's Set-Cookie wasn't carried
+    // through.
+    const left = makeServer();
+    const right = makeServer();
+    const steps: JourneyStep[] = [
+      { method: "GET", path: "/api/login", label: "login" },
+      { method: "GET", path: "/api/profile", label: "profile" },
+    ];
+    const report = await runJourney({
+      left: "http://left",
+      right: "http://right",
+      steps,
+      fetcher: fetcherFor({ "http://left": left, "http://right": right }),
+    });
+    expect(report.mismatches).toHaveLength(0);
+    // Step 2 returned 200, proving the auth cookie was replayed.
+    expect(report.matches[1].left.status).toBe(200);
+  });
+
+  it("stopOnMismatch halts after the first divergence", async () => {
+    const left = makeServer();
+    const right = makeServer({ silentlyDropWrites: true });
+    // Three steps; mismatch will fire at index 1. With stopOnMismatch
+    // we never run index 2 (a 3rd POST).
+    const steps: JourneyStep[] = [
+      ...writeThenReadSteps,
+      { method: "POST", path: "/api/todos", body: { title: "y" } },
+    ];
+    const report = await runJourney({
+      left: "http://left",
+      right: "http://right",
+      steps,
+      stopOnMismatch: true,
+      fetcher: fetcherFor({ "http://left": left, "http://right": right }),
+    });
+    expect(report.stepsChecked).toBe(2);
+    // The 3rd POST was skipped entirely — neither side received it.
+    expect(left.todos).toHaveLength(1);
+    expect(right.todos).toHaveLength(0); // right always drops
+  });
+
+  it("JSON object bodies get auto-stringified with application/json", async () => {
+    // Round-trip check: the server's parsed body matches what the
+    // caller passed.
+    const seen: Array<{ headers: Record<string, string>; body: string }> = [];
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers: Record<string, string> = {};
+      if (init?.headers instanceof Headers) {
+        init.headers.forEach((v, k) => {
+          headers[k] = v;
+        });
+      }
+      seen.push({ headers, body: init?.body as string });
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    await runJourney({
+      left: "http://l",
+      right: "http://r",
+      steps: [{ method: "POST", path: "/x", body: { hi: "there" } }],
+      fetcher,
+    });
+    expect(seen).toHaveLength(2);
+    expect(seen[0].headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(seen[0].body)).toEqual({ hi: "there" });
+  });
+
+  it("string bodies are sent verbatim with no auto content-type", async () => {
+    const seen: Array<{ headers: Record<string, string>; body: string | undefined }> = [];
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers: Record<string, string> = {};
+      if (init?.headers instanceof Headers) {
+        init.headers.forEach((v, k) => {
+          headers[k] = v;
+        });
+      }
+      seen.push({ headers, body: init?.body as string | undefined });
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    await runJourney({
+      left: "http://l",
+      right: "http://r",
+      steps: [{ method: "POST", path: "/x", body: "raw=value" }],
+      fetcher,
+    });
+    expect(seen[0].body).toBe("raw=value");
+    expect(seen[0].headers["content-type"]).toBeUndefined();
+  });
+
+  it("status mismatch wins over body mismatch on the same step", async () => {
+    const fetcher = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return new URL(url).host === "left"
+        ? new Response("a", { status: 200 })
+        : new Response("b", { status: 500 });
+    }) as typeof fetch;
+    const report = await runJourney({
+      left: "http://left",
+      right: "http://right",
+      steps: [{ method: "GET", path: "/x" }],
+      fetcher,
+    });
+    expect(report.mismatches[0].kind).toBe("status");
+  });
+
+  it("--no-check-body equivalent: checkBody=false skips body hashing", async () => {
+    const fetcher = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return new URL(url).host === "left"
+        ? new Response("a", { status: 200 })
+        : new Response("b", { status: 200 });
+    }) as typeof fetch;
+    const report = await runJourney({
+      left: "http://left",
+      right: "http://right",
+      steps: [{ method: "GET", path: "/x" }],
+      checkBody: false,
+      fetcher,
+    });
+    // Status matched and body wasn't checked → match.
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.matches[0].left.bodyHash).toBeUndefined();
+  });
+});

--- a/packages/chaosbringer/src/journey.test.ts
+++ b/packages/chaosbringer/src/journey.test.ts
@@ -236,4 +236,264 @@ describe("runJourney", () => {
     expect(report.mismatches).toHaveLength(0);
     expect(report.matches[0].left.bodyHash).toBeUndefined();
   });
+
+  describe("capture + template substitution", () => {
+    /**
+     * Stateful synthetic server with create-then-read-by-id flow.
+     * Both sides assign IDs independently, so the per-side var bag
+     * has to resolve the right template.
+     */
+    function makeIdServer(opts: { wrongTitleOnGet?: boolean } = {}) {
+      const todos: Record<number, { id: number; title: string }> = {};
+      let nextId = 1;
+      return (url: string, init: RequestInit | undefined): Response => {
+        const u = new URL(url);
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (u.pathname === "/api/todos" && method === "POST") {
+          const body = JSON.parse(init?.body as string);
+          const id = nextId++;
+          todos[id] = { id, ...body };
+          return new Response(JSON.stringify(todos[id]), { status: 201 });
+        }
+        const matchId = u.pathname.match(/^\/api\/todos\/(\d+)$/);
+        if (matchId && method === "GET") {
+          const id = Number.parseInt(matchId[1], 10);
+          const todo = todos[id];
+          if (!todo) return new Response("not found", { status: 404 });
+          if (opts.wrongTitleOnGet) {
+            return new Response(JSON.stringify({ ...todo, title: "WRONG" }), { status: 200 });
+          }
+          return new Response(JSON.stringify(todo), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      };
+    }
+
+    function fetcherForHandlers(handlers: Record<string, ReturnType<typeof makeIdServer>>): typeof fetch {
+      return (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const base = `${new URL(url).protocol}//${new URL(url).host}`;
+        const handler = handlers[base];
+        if (!handler) throw new Error(`unexpected host: ${base}`);
+        return handler(url, init);
+      }) as typeof fetch;
+    }
+
+    it("captures body.<dotpath> from step N and substitutes in step N+1's path", async () => {
+      const leftHandler = makeIdServer();
+      const rightHandler = makeIdServer();
+      const steps: JourneyStep[] = [
+        {
+          method: "POST",
+          path: "/api/todos",
+          body: { title: "x" },
+          capture: [{ from: "body.id", as: "todoId" }],
+          label: "create",
+        },
+        { method: "GET", path: "/api/todos/{{todoId}}", label: "read-by-id" },
+      ];
+      const report = await runJourney({
+        left: "http://left",
+        right: "http://right",
+        steps,
+        fetcher: fetcherForHandlers({ "http://left": leftHandler, "http://right": rightHandler }),
+      });
+      expect(report.mismatches).toHaveLength(0);
+      expect(report.matches[1].request.path).toBe("/api/todos/{{todoId}}");
+      // Both sides resolved {{todoId}} → 1 and got 200 with matching body.
+      expect(report.matches[1].left.status).toBe(200);
+    });
+
+    it("flags the read step when v2 returns a wrong title on the captured id", async () => {
+      // Per-side captures both yield id=1, but v2's read by id returns
+      // a mutated title. The body hash diverges on step 1.
+      const steps: JourneyStep[] = [
+        {
+          method: "POST",
+          path: "/api/todos",
+          body: { title: "buy milk" },
+          capture: [{ from: "body.id", as: "todoId" }],
+        },
+        { method: "GET", path: "/api/todos/{{todoId}}" },
+      ];
+      const report = await runJourney({
+        left: "http://left",
+        right: "http://right",
+        steps,
+        fetcher: fetcherForHandlers({
+          "http://left": makeIdServer(),
+          "http://right": makeIdServer({ wrongTitleOnGet: true }),
+        }),
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kind).toBe("body");
+      expect(report.mismatches[0].index).toBe(1);
+    });
+
+    it("template substitution works in headers (bearer-token flow)", async () => {
+      // capture Authorization-bound token from a login response;
+      // substitute it into the next step's Authorization header.
+      const seen: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("/login")) {
+          return new Response(JSON.stringify({ token: "abc123" }), { status: 200 });
+        }
+        const auth = (init?.headers as Headers).get("authorization") ?? "";
+        seen.push(auth);
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch;
+      const steps: JourneyStep[] = [
+        {
+          method: "POST",
+          path: "/login",
+          body: {},
+          capture: [{ from: "body.token", as: "tok" }],
+        },
+        {
+          method: "GET",
+          path: "/profile",
+          headers: { authorization: "Bearer {{tok}}" },
+        },
+      ];
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps,
+        fetcher,
+      });
+      // Both sides sent the substituted header verbatim.
+      expect(seen).toContain("Bearer abc123");
+      expect(seen.filter((s) => s === "Bearer abc123")).toHaveLength(2);
+    });
+
+    it("template substitution works inside JSON object bodies", async () => {
+      const seen: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("/seed")) {
+          return new Response(JSON.stringify({ ref: "ref-7" }), { status: 200 });
+        }
+        seen.push(init?.body as string);
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch;
+      const steps: JourneyStep[] = [
+        {
+          method: "POST",
+          path: "/seed",
+          body: {},
+          capture: [{ from: "body.ref", as: "ref" }],
+        },
+        {
+          method: "POST",
+          path: "/use",
+          body: { parent: "{{ref}}", nested: { also: "{{ref}}" } },
+        },
+      ];
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps,
+        fetcher,
+      });
+      const parsed = JSON.parse(seen[0]);
+      expect(parsed.parent).toBe("ref-7");
+      expect(parsed.nested.also).toBe("ref-7");
+    });
+
+    it("captures from response headers (header.<name>)", async () => {
+      const seen: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("/start")) {
+          return new Response("", {
+            status: 200,
+            headers: { "x-trace-id": "trace-42" },
+          });
+        }
+        const traceHeader = (init?.headers as Headers).get("x-trace") ?? "";
+        seen.push(traceHeader);
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch;
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [
+          {
+            method: "GET",
+            path: "/start",
+            capture: [{ from: "header.x-trace-id", as: "trace" }],
+          },
+          { method: "GET", path: "/follow", headers: { "x-trace": "{{trace}}" } },
+        ],
+        fetcher,
+      });
+      expect(seen).toContain("trace-42");
+    });
+
+    it("a failed capture leaves the var unset; downstream {{var}} renders as literal", async () => {
+      // The journey doesn't lie about missing data. A path containing
+      // an unresolved {{var}} goes out garbled and the server's response
+      // (or lack thereof) shows up in the SideResult.
+      const seen: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        seen.push(url);
+        if (url.endsWith("/seed")) {
+          return new Response("not-json", { status: 200 });
+        }
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch;
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [
+          {
+            method: "GET",
+            path: "/seed",
+            // Body isn't JSON → parse fails → capture skipped.
+            capture: [{ from: "body.id", as: "todoId" }],
+          },
+          { method: "GET", path: "/items/{{todoId}}" },
+        ],
+        fetcher,
+      });
+      expect(seen).toContain("http://l/items/%7B%7BtodoId%7D%7D");
+    });
+
+    it("per-side vars stay isolated — left's capture does not leak to right", async () => {
+      // Each side captures id=1 from its own POST. If they shared a
+      // var bag, a race would let one side see the other's id.
+      const calls: string[] = [];
+      const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const host = new URL(url).host;
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.endsWith("/api/todos") && method === "POST") {
+          // Left assigns id=100, right assigns id=200.
+          const id = host === "l" ? 100 : 200;
+          return new Response(JSON.stringify({ id }), { status: 201 });
+        }
+        calls.push(url);
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch;
+      await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [
+          {
+            method: "POST",
+            path: "/api/todos",
+            body: { title: "x" },
+            capture: [{ from: "body.id", as: "todoId" }],
+          },
+          { method: "GET", path: "/api/todos/{{todoId}}" },
+        ],
+        fetcher,
+      });
+      // Each side resolved its OWN id, not the other's.
+      expect(calls).toContain("http://l/api/todos/100");
+      expect(calls).toContain("http://r/api/todos/200");
+    });
+  });
 });

--- a/packages/chaosbringer/src/journey.test.ts
+++ b/packages/chaosbringer/src/journey.test.ts
@@ -218,6 +218,54 @@ describe("runJourney", () => {
     expect(report.mismatches[0].kinds[0]).toBe("status");
   });
 
+  describe("perf threshold (consistency with parity)", () => {
+    it("flags a perf mismatch when right's step is slower than left by more than the budget", async () => {
+      const fetcher = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("left")) return new Response("ok", { status: 200 });
+        await new Promise((r) => setTimeout(r, 60));
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+      const report = await runJourney({
+        left: "http://left",
+        right: "http://right",
+        steps: [{ method: "GET", path: "/slow" }],
+        perfDeltaMs: 30,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kinds).toContain("perf");
+      expect(report.mismatches[0].left.durationMs).toBeLessThan(
+        report.mismatches[0].right.durationMs!,
+      );
+    });
+
+    it("populates durationMs on every step (even when perf isn't checked)", async () => {
+      const fetcher = (async () => new Response("ok", { status: 200 })) as typeof fetch;
+      const report = await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [{ method: "GET", path: "/x" }],
+        fetcher,
+      });
+      expect(report.matches[0].left.durationMs).toBeGreaterThanOrEqual(0);
+      expect(report.matches[0].right.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("report carries a schemaVersion + config echo with perf thresholds", async () => {
+      const report = await runJourney({
+        left: "http://l",
+        right: "http://r",
+        steps: [{ method: "GET", path: "/x" }],
+        perfDeltaMs: 100,
+        fetcher: (async () => new Response("", { status: 200 })) as typeof fetch,
+      });
+      expect(report.schemaVersion).toBe(1);
+      expect(report.config.perfDeltaMs).toBe(100);
+      expect(report.config.checkBody).toBe(true);
+    });
+  });
+
   it("--no-check-body equivalent: checkBody=false skips body hashing", async () => {
     const fetcher = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -116,6 +116,13 @@ export interface JourneyReport {
   stepsChecked: number;
   mismatches: JourneyMismatch[];
   matches: JourneyStepResult[];
+  /** Thresholds + opt-ins that produced this report (see parity.ParityReport.config). */
+  config: {
+    checkBody: boolean;
+    checkHeaders: string[];
+    stopOnMismatch: boolean;
+    timeoutMs: number;
+  };
 }
 
 export interface RunJourneyOptions {
@@ -498,6 +505,7 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
     stepsChecked,
     mismatches,
     matches,
+    config: { checkBody, checkHeaders, stopOnMismatch, timeoutMs },
   };
 }
 

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -91,8 +91,9 @@ export interface JourneyStepResult {
 }
 
 export interface JourneyMismatch extends JourneyStepResult {
-  kind: MismatchKind;
-  /** Localised JSON body diff, populated only on kind=body (see parity.ts). */
+  /** See parity.ParityMismatch.kinds — all detected kinds in precedence order. */
+  kinds: MismatchKind[];
+  /** Localised JSON body diff, populated only when `kinds` contains `"body"`. */
   bodyDiff?: BodyDiffResult;
 }
 
@@ -366,28 +367,31 @@ async function runStepOnSide(
 }
 
 /**
- * Local copy of parity's classify with the same precedence chain.
- * Inlined (rather than imported) so journey can omit the exception
- * branch — see file header for why exception checking is not exposed
- * here in v1.
+ * Same shape as parity's classify — all detected kinds in precedence
+ * order, empty array means match. Inlined rather than imported so the
+ * journey omits exception detection (see file header).
  */
-function classifyStep(left: SideResult, right: SideResult): MismatchKind | null {
+function classifyStep(left: SideResult, right: SideResult): MismatchKind[] {
   const leftFailed = left.status === null;
   const rightFailed = right.status === null;
-  if (leftFailed !== rightFailed) return "failure";
-  if (leftFailed && rightFailed) return null;
-  if (left.status !== right.status) return "status";
+  if (leftFailed !== rightFailed) return ["failure"];
+  if (leftFailed && rightFailed) return [];
+  if (left.status !== right.status) return ["status"];
   if (
     typeof left.status === "number" &&
     left.status >= 300 &&
     left.status < 400 &&
     left.location !== right.location
   ) {
-    return "redirect";
+    return ["redirect"];
   }
+  const kinds: MismatchKind[] = [];
   if (left.headers && right.headers) {
     for (const name of Object.keys(left.headers)) {
-      if (left.headers[name] !== right.headers[name]) return "header";
+      if (left.headers[name] !== right.headers[name]) {
+        kinds.push("header");
+        break;
+      }
     }
   }
   if (
@@ -395,9 +399,9 @@ function classifyStep(left: SideResult, right: SideResult): MismatchKind | null 
     right.bodyHash !== undefined &&
     left.bodyHash !== right.bodyHash
   ) {
-    return "body";
+    kinds.push("body");
   }
-  return null;
+  return kinds;
 }
 
 export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport> {
@@ -440,10 +444,10 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
       right,
     };
     stepsChecked++;
-    const kind = classifyStep(left, right);
-    if (kind) {
-      const mismatch: JourneyMismatch = { ...result, kind };
-      if (kind === "body") {
+    const kinds = classifyStep(left, right);
+    if (kinds.length > 0) {
+      const mismatch: JourneyMismatch = { ...result, kinds };
+      if (kinds.includes("body")) {
         const diff = diffJsonBodies(leftProbe.bodyText, rightProbe.bodyText);
         if (diff) mismatch.bodyDiff = diff;
       }

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -110,7 +110,12 @@ export interface JourneyMismatch extends JourneyStepResult {
   bodyDiff?: BodyDiffResult;
 }
 
+/** Independent of `PARITY_REPORT_SCHEMA_VERSION` — bumped per shape. */
+export const JOURNEY_REPORT_SCHEMA_VERSION = 1;
+
 export interface JourneyReport {
+  /** Stable integer. See `JOURNEY_REPORT_SCHEMA_VERSION`. */
+  schemaVersion: number;
   left: string;
   right: string;
   stepsChecked: number;
@@ -122,6 +127,8 @@ export interface JourneyReport {
     checkHeaders: string[];
     stopOnMismatch: boolean;
     timeoutMs: number;
+    perfDeltaMs?: number;
+    perfRatio?: number;
   };
 }
 
@@ -139,6 +146,19 @@ export interface RunJourneyOptions {
   checkBody?: boolean;
   /** Compare named response headers per step. Same semantics as parity. */
   checkHeaders?: string[];
+  /**
+   * Flag a `perf` mismatch when `right.durationMs - left.durationMs`
+   * exceeds this many milliseconds on any step. Same semantics +
+   * caveats as `parity.RunParityOptions.perfDeltaMs` — single-sample,
+   * set well above your jitter floor.
+   */
+  perfDeltaMs?: number;
+  /**
+   * Flag a `perf` mismatch when `right.durationMs > left.durationMs * ratio`.
+   * Composes with `perfDeltaMs` via OR. Skipped on a step where
+   * `left.durationMs === 0` to avoid divide-by-zero noise.
+   */
+  perfRatio?: number;
   /**
    * Stop the journey on the first mismatch instead of running every
    * step. Useful when later steps depend on earlier ones succeeding
@@ -338,6 +358,10 @@ async function runStepOnSide(
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  // Wall-clock around the full step (request + body read) so a slow-
+  // body step on one side doesn't look faster than a fast-body one.
+  // Mirrors parity's approach.
+  const startedAt = performance.now();
   try {
     const resp = await opts.fetcher(url, {
       method,
@@ -372,6 +396,7 @@ async function runStepOnSide(
       }
     }
     applyCaptures(step.capture, bodyText, resp.headers, vars);
+    result.durationMs = performance.now() - startedAt;
     return { result, bodyText };
   } catch (err) {
     return {
@@ -391,7 +416,11 @@ async function runStepOnSide(
  * order, empty array means match. Inlined rather than imported so the
  * journey omits exception detection (see file header).
  */
-function classifyStep(left: SideResult, right: SideResult): MismatchKind[] {
+function classifyStep(
+  left: SideResult,
+  right: SideResult,
+  perfOpts: { perfDeltaMs?: number; perfRatio?: number },
+): MismatchKind[] {
   const leftFailed = left.status === null;
   const rightFailed = right.status === null;
   if (leftFailed !== rightFailed) return ["failure"];
@@ -420,6 +449,19 @@ function classifyStep(left: SideResult, right: SideResult): MismatchKind[] {
     left.bodyHash !== right.bodyHash
   ) {
     kinds.push("body");
+  }
+  if (
+    typeof left.durationMs === "number" &&
+    typeof right.durationMs === "number" &&
+    ((perfOpts.perfDeltaMs &&
+      perfOpts.perfDeltaMs > 0 &&
+      right.durationMs - left.durationMs > perfOpts.perfDeltaMs) ||
+      (perfOpts.perfRatio &&
+        perfOpts.perfRatio > 0 &&
+        left.durationMs > 0 &&
+        right.durationMs > left.durationMs * perfOpts.perfRatio))
+  ) {
+    kinds.push("perf");
   }
   return kinds;
 }
@@ -485,7 +527,10 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
       right,
     };
     stepsChecked++;
-    const kinds = classifyStep(left, right);
+    const kinds = classifyStep(left, right, {
+      perfDeltaMs: opts.perfDeltaMs,
+      perfRatio: opts.perfRatio,
+    });
     if (kinds.length > 0) {
       const mismatch: JourneyMismatch = { ...result, kinds };
       if (kinds.includes("body")) {
@@ -500,12 +545,20 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
   }
 
   return {
+    schemaVersion: JOURNEY_REPORT_SCHEMA_VERSION,
     left: opts.left,
     right: opts.right,
     stepsChecked,
     mismatches,
     matches,
-    config: { checkBody, checkHeaders, stopOnMismatch, timeoutMs },
+    config: {
+      checkBody,
+      checkHeaders,
+      stopOnMismatch,
+      timeoutMs,
+      ...(opts.perfDeltaMs !== undefined ? { perfDeltaMs: opts.perfDeltaMs } : {}),
+      ...(opts.perfRatio !== undefined ? { perfRatio: opts.perfRatio } : {}),
+    },
   };
 }
 

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -1,0 +1,302 @@
+/**
+ * Stateful journey parity.
+ *
+ * Where `parity` probes one-shot independent paths, `journey` replays
+ * a recorded sequence (POST /todos → GET /todos, login → fetch profile,
+ * checkout → list orders) against both runtimes and surfaces step-level
+ * divergence. Catches the bug class that's invisible to single-path
+ * probes: a write that's silently dropped, a token that flips to 401
+ * later, a sort order that drifts after N writes.
+ *
+ * Cookies are tracked per-side automatically: a response's Set-Cookie
+ * is parsed and replayed on subsequent requests on the same side. Each
+ * side has an isolated jar so the comparison stays apples-to-apples.
+ *
+ * Step-level comparison reuses parity's `classify()` and `SideResult`
+ * — same precedence rules (status → header → body → exception), same
+ * opt-in checks (`checkBody`, `checkHeaders`). Exception checking is
+ * intentionally NOT exposed here in v1: replaying a journey in a
+ * browser per side per step is browser-launch overhead times step
+ * count, and the failure mode that motivated this (silent write drop)
+ * surfaces in body/status without it.
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  MismatchKind,
+  ParityReport,
+  RunParityOptions,
+  SideResult,
+} from "./parity.js";
+
+export interface JourneyStep {
+  /** HTTP method. Case-insensitive; uppercased internally. */
+  method: string;
+  /** Pathname (joined with the base URL). */
+  path: string;
+  /**
+   * Request body. Strings sent verbatim; objects JSON-stringified with
+   * `application/json` content-type unless `headers` overrides.
+   */
+  body?: string | Record<string, unknown>;
+  /** Extra request headers (case-insensitive merged with content-type). */
+  headers?: Record<string, string>;
+  /** Optional label for reporting — defaults to `<METHOD> <path>`. */
+  label?: string;
+}
+
+export interface JourneyStepResult {
+  /** 0-based step index in the input list. */
+  index: number;
+  label: string;
+  request: { method: string; path: string };
+  left: SideResult;
+  right: SideResult;
+}
+
+export interface JourneyMismatch extends JourneyStepResult {
+  kind: MismatchKind;
+}
+
+export interface JourneyReport {
+  left: string;
+  right: string;
+  stepsChecked: number;
+  mismatches: JourneyMismatch[];
+  matches: JourneyStepResult[];
+}
+
+export interface RunJourneyOptions {
+  left: string;
+  right: string;
+  steps: JourneyStep[];
+  /** Per-request timeout. Defaults to 10s. */
+  timeoutMs?: number;
+  /**
+   * Read + hash response bodies. Same semantics as `parity.checkBody`.
+   * On for journeys by default because the most common journey bug
+   * (silent write drop) surfaces in the read step's body.
+   */
+  checkBody?: boolean;
+  /** Compare named response headers per step. Same semantics as parity. */
+  checkHeaders?: string[];
+  /**
+   * Stop the journey on the first mismatch instead of running every
+   * step. Useful when later steps depend on earlier ones succeeding
+   * (a failed login means the rest of the flow is meaningless).
+   */
+  stopOnMismatch?: boolean;
+  /** Override fetch for testing. */
+  fetcher?: typeof fetch;
+}
+
+// ─── Minimal cookie jar ───────────────────────────────────────────────────
+// Just enough Set-Cookie parsing to support same-host sequences. We
+// deliberately skip expiry / path / domain matching because the journey
+// only ever talks to one base URL — getting tough-cookie right is more
+// work than the bug it would catch.
+
+interface CookieJar {
+  cookies: Map<string, string>;
+  apply(setCookie: string[] | null): void;
+  asHeader(): string | undefined;
+}
+
+function makeJar(): CookieJar {
+  const cookies = new Map<string, string>();
+  return {
+    cookies,
+    apply(setCookie) {
+      if (!setCookie) return;
+      for (const raw of setCookie) {
+        // Set-Cookie: name=value; Expires=...; Path=/; HttpOnly
+        const semi = raw.indexOf(";");
+        const pair = semi >= 0 ? raw.slice(0, semi) : raw;
+        const eq = pair.indexOf("=");
+        if (eq < 1) continue;
+        const name = pair.slice(0, eq).trim();
+        const value = pair.slice(eq + 1).trim();
+        cookies.set(name, value);
+      }
+    },
+    asHeader() {
+      if (cookies.size === 0) return undefined;
+      const parts: string[] = [];
+      for (const [k, v] of cookies) parts.push(`${k}=${v}`);
+      return parts.join("; ");
+    },
+  };
+}
+
+function joinBase(base: string, path: string): string {
+  return new URL(path, base.endsWith("/") ? base : `${base}/`).toString();
+}
+
+/**
+ * Read the raw Set-Cookie values from a Response. `Headers.get("set-cookie")`
+ * collapses repeats with `, ` which loses the per-cookie boundary. Where
+ * available, `Headers.getSetCookie()` (Node 19+, undici 5.x+) preserves them.
+ * Fall back to the joined string when the runtime doesn't have it.
+ */
+function readSetCookie(headers: Headers): string[] | null {
+  const anyHeaders = headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof anyHeaders.getSetCookie === "function") {
+    const arr = anyHeaders.getSetCookie();
+    return arr.length > 0 ? arr : null;
+  }
+  const joined = headers.get("set-cookie");
+  return joined ? [joined] : null;
+}
+
+async function runStepOnSide(
+  base: string,
+  step: JourneyStep,
+  jar: CookieJar,
+  opts: Required<Pick<RunJourneyOptions, "timeoutMs" | "checkBody">> & {
+    checkHeaders: string[];
+    fetcher: typeof fetch;
+  },
+): Promise<SideResult> {
+  const url = joinBase(base, step.path);
+  const method = step.method.toUpperCase();
+
+  const headers = new Headers();
+  for (const [k, v] of Object.entries(step.headers ?? {})) headers.set(k, v);
+  let body: BodyInit | undefined;
+  if (step.body !== undefined) {
+    if (typeof step.body === "string") {
+      body = step.body;
+    } else {
+      body = JSON.stringify(step.body);
+      if (!headers.has("content-type")) headers.set("content-type", "application/json");
+    }
+  }
+  const cookieHeader = jar.asHeader();
+  if (cookieHeader) headers.set("cookie", cookieHeader);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  try {
+    const resp = await opts.fetcher(url, {
+      method,
+      headers,
+      body,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    // Cookies set by the response are visible to the next step on
+    // THIS side — the per-side jar is what binds a write to its
+    // subsequent read.
+    jar.apply(readSetCookie(resp.headers));
+    const result: SideResult = {
+      status: resp.status,
+      location: resp.headers.get("location"),
+    };
+    if (opts.checkHeaders.length > 0) {
+      const out: Record<string, string | null> = {};
+      for (const name of opts.checkHeaders) out[name] = resp.headers.get(name);
+      result.headers = out;
+    }
+    if (opts.checkBody) {
+      const bytes = new Uint8Array(await resp.arrayBuffer());
+      result.bodyLength = bytes.byteLength;
+      result.bodyHash = createHash("sha256").update(bytes).digest("hex");
+    }
+    return result;
+  } catch (err) {
+    return {
+      status: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Local copy of parity's classify with the same precedence chain.
+ * Inlined (rather than imported) so journey can omit the exception
+ * branch — see file header for why exception checking is not exposed
+ * here in v1.
+ */
+function classifyStep(left: SideResult, right: SideResult): MismatchKind | null {
+  const leftFailed = left.status === null;
+  const rightFailed = right.status === null;
+  if (leftFailed !== rightFailed) return "failure";
+  if (leftFailed && rightFailed) return null;
+  if (left.status !== right.status) return "status";
+  if (
+    typeof left.status === "number" &&
+    left.status >= 300 &&
+    left.status < 400 &&
+    left.location !== right.location
+  ) {
+    return "redirect";
+  }
+  if (left.headers && right.headers) {
+    for (const name of Object.keys(left.headers)) {
+      if (left.headers[name] !== right.headers[name]) return "header";
+    }
+  }
+  if (
+    left.bodyHash !== undefined &&
+    right.bodyHash !== undefined &&
+    left.bodyHash !== right.bodyHash
+  ) {
+    return "body";
+  }
+  return null;
+}
+
+export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const checkBody = opts.checkBody ?? true;
+  const checkHeaders = (opts.checkHeaders ?? []).map((h) => h.toLowerCase());
+  const fetcher = opts.fetcher ?? fetch;
+  const stopOnMismatch = opts.stopOnMismatch ?? false;
+
+  const leftJar = makeJar();
+  const rightJar = makeJar();
+
+  const mismatches: JourneyMismatch[] = [];
+  const matches: JourneyStepResult[] = [];
+
+  let stepsChecked = 0;
+  for (let i = 0; i < opts.steps.length; i++) {
+    const step = opts.steps[i];
+    const sideOpts = { timeoutMs, checkBody, checkHeaders, fetcher };
+    // Per-step parallel: each side advances independently. State
+    // accumulates in its own jar.
+    const [left, right] = await Promise.all([
+      runStepOnSide(opts.left, step, leftJar, sideOpts),
+      runStepOnSide(opts.right, step, rightJar, sideOpts),
+    ]);
+    const label = step.label ?? `${step.method.toUpperCase()} ${step.path}`;
+    const result: JourneyStepResult = {
+      index: i,
+      label,
+      request: { method: step.method.toUpperCase(), path: step.path },
+      left,
+      right,
+    };
+    stepsChecked++;
+    const kind = classifyStep(left, right);
+    if (kind) {
+      mismatches.push({ ...result, kind });
+      if (stopOnMismatch) break;
+    } else {
+      matches.push(result);
+    }
+  }
+
+  return {
+    left: opts.left,
+    right: opts.right,
+    stepsChecked,
+    mismatches,
+    matches,
+  };
+}
+
+// Re-export parity types for callers that don't want a separate import.
+export type { MismatchKind, ParityReport, RunParityOptions, SideResult };

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -77,6 +77,19 @@ export interface JourneyStep {
    * the comparison runs on the substituted result.
    */
   capture?: CaptureSpec[];
+  /**
+   * Actor identity for multi-tenant journeys. Each actor on each side
+   * has its own cookie jar and variable bag. Catches the bug class
+   * where v2 leaks one user's session state into another's
+   * subsequent request.
+   *
+   * Steps without an `actor` use the implicit `"_default"` actor, so
+   * single-actor journeys are unchanged. Switching actors mid-flow is
+   * the point — see the playground's tenant-isolation demo for the
+   * canonical shape (Alice creates → Bob lists → Bob must not see
+   * Alice's data).
+   */
+  actor?: string;
   /** Optional label for reporting — defaults to `<METHOD> <path>`. */
   label?: string;
 }
@@ -411,14 +424,34 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
   const fetcher = opts.fetcher ?? fetch;
   const stopOnMismatch = opts.stopOnMismatch ?? false;
 
-  const leftJar = makeJar();
-  const rightJar = makeJar();
-  // Variable bags are per-side: a value captured from left's response
-  // is only visible to subsequent left steps. Asymmetric IDs / tokens
-  // (which is the common case) Just Work — each side resolves its
-  // template against its own bag.
-  const leftVars: Record<string, string> = {};
-  const rightVars: Record<string, string> = {};
+  // Per-side, per-actor cookie jars + variable bags. The two levels
+  // of keying matter:
+  //   - Outer (left/right): the parity comparison axis.
+  //   - Inner (actor): the tenant isolation axis. A bug where v2
+  //     mixes actor A's session into actor B's request only shows
+  //     up if Bob's GET goes out with Bob's cookies, not Alice's.
+  const leftJars = new Map<string, CookieJar>();
+  const rightJars = new Map<string, CookieJar>();
+  const leftVarsByActor = new Map<string, Record<string, string>>();
+  const rightVarsByActor = new Map<string, Record<string, string>>();
+  function getJar(side: "left" | "right", actor: string): CookieJar {
+    const map = side === "left" ? leftJars : rightJars;
+    let jar = map.get(actor);
+    if (!jar) {
+      jar = makeJar();
+      map.set(actor, jar);
+    }
+    return jar;
+  }
+  function getVars(side: "left" | "right", actor: string): Record<string, string> {
+    const map = side === "left" ? leftVarsByActor : rightVarsByActor;
+    let vars = map.get(actor);
+    if (!vars) {
+      vars = {};
+      map.set(actor, vars);
+    }
+    return vars;
+  }
 
   const mismatches: JourneyMismatch[] = [];
   const matches: JourneyStepResult[] = [];
@@ -429,9 +462,10 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
     const sideOpts = { timeoutMs, checkBody, checkHeaders, fetcher };
     // Per-step parallel: each side advances independently. State
     // accumulates in its own jar.
+    const actor = step.actor ?? "_default";
     const [leftProbe, rightProbe] = await Promise.all([
-      runStepOnSide(opts.left, step, leftJar, leftVars, sideOpts),
-      runStepOnSide(opts.right, step, rightJar, rightVars, sideOpts),
+      runStepOnSide(opts.left, step, getJar("left", actor), getVars("left", actor), sideOpts),
+      runStepOnSide(opts.right, step, getJar("right", actor), getVars("right", actor), sideOpts),
     ]);
     const left = leftProbe.result;
     const right = rightProbe.result;

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -22,6 +22,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { diffJsonBodies, type BodyDiffResult } from "./body-diff.js";
 import type {
   MismatchKind,
   ParityReport,
@@ -91,6 +92,8 @@ export interface JourneyStepResult {
 
 export interface JourneyMismatch extends JourneyStepResult {
   kind: MismatchKind;
+  /** Localised JSON body diff, populated only on kind=body (see parity.ts). */
+  bodyDiff?: BodyDiffResult;
 }
 
 export interface JourneyReport {
@@ -272,6 +275,11 @@ function readSetCookie(headers: Headers): string[] | null {
   return joined ? [joined] : null;
 }
 
+interface ProbedStep {
+  result: SideResult;
+  bodyText: string | null;
+}
+
 async function runStepOnSide(
   base: string,
   step: JourneyStep,
@@ -281,7 +289,7 @@ async function runStepOnSide(
     checkHeaders: string[];
     fetcher: typeof fetch;
   },
-): Promise<SideResult> {
+): Promise<ProbedStep> {
   // All three of path / headers / body can carry `{{var}}` references
   // captured by earlier steps. Substitution happens BEFORE the request
   // goes out so the server sees the resolved value; the SideResult
@@ -343,11 +351,14 @@ async function runStepOnSide(
       }
     }
     applyCaptures(step.capture, bodyText, resp.headers, vars);
-    return result;
+    return { result, bodyText };
   } catch (err) {
     return {
-      status: null,
-      error: err instanceof Error ? err.message : String(err),
+      result: {
+        status: null,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      bodyText: null,
     };
   } finally {
     clearTimeout(timer);
@@ -414,10 +425,12 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
     const sideOpts = { timeoutMs, checkBody, checkHeaders, fetcher };
     // Per-step parallel: each side advances independently. State
     // accumulates in its own jar.
-    const [left, right] = await Promise.all([
+    const [leftProbe, rightProbe] = await Promise.all([
       runStepOnSide(opts.left, step, leftJar, leftVars, sideOpts),
       runStepOnSide(opts.right, step, rightJar, rightVars, sideOpts),
     ]);
+    const left = leftProbe.result;
+    const right = rightProbe.result;
     const label = step.label ?? `${step.method.toUpperCase()} ${step.path}`;
     const result: JourneyStepResult = {
       index: i,
@@ -429,7 +442,12 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
     stepsChecked++;
     const kind = classifyStep(left, right);
     if (kind) {
-      mismatches.push({ ...result, kind });
+      const mismatch: JourneyMismatch = { ...result, kind };
+      if (kind === "body") {
+        const diff = diffJsonBodies(leftProbe.bodyText, rightProbe.bodyText);
+        if (diff) mismatch.bodyDiff = diff;
+      }
+      mismatches.push(mismatch);
       if (stopOnMismatch) break;
     } else {
       matches.push(result);

--- a/packages/chaosbringer/src/journey.ts
+++ b/packages/chaosbringer/src/journey.ts
@@ -29,18 +29,53 @@ import type {
   SideResult,
 } from "./parity.js";
 
+export interface CaptureSpec {
+  /**
+   * Source to extract from. Two prefixes are supported:
+   * - `body.<dot.path>` — parse the response as JSON and walk the path
+   *   (e.g. `body.id`, `body.user.id`, `body.items.0.id`).
+   * - `header.<name>` — case-insensitive response header (e.g.
+   *   `header.x-request-id`).
+   *
+   * Extraction failures (non-JSON body, missing path) leave the var
+   * unset on that side, so a subsequent `{{var}}` template renders as
+   * the literal `{{var}}` — visible noise in the URL that the parity
+   * comparison then flags as a status mismatch. The journey doesn't
+   * silently swallow extraction failures.
+   */
+  from: string;
+  /** Variable name to bind. Substituted as `{{as}}` in later steps. */
+  as: string;
+}
+
 export interface JourneyStep {
   /** HTTP method. Case-insensitive; uppercased internally. */
   method: string;
-  /** Pathname (joined with the base URL). */
+  /**
+   * Pathname (joined with the base URL). May contain `{{var}}`
+   * placeholders that reference variables captured by earlier steps.
+   */
   path: string;
   /**
    * Request body. Strings sent verbatim; objects JSON-stringified with
-   * `application/json` content-type unless `headers` overrides.
+   * `application/json` content-type unless `headers` overrides. Both
+   * forms may contain `{{var}}` placeholders.
    */
   body?: string | Record<string, unknown>;
-  /** Extra request headers (case-insensitive merged with content-type). */
+  /**
+   * Extra request headers (case-insensitive merged with content-type).
+   * Header values may contain `{{var}}` (useful for Authorization
+   * tokens captured from a login step).
+   */
   headers?: Record<string, string>;
+  /**
+   * Variables to capture from this step's response. Each is bound on
+   * the side it ran on, so a token captured from left's login is only
+   * visible to subsequent left steps. Asymmetric values across sides
+   * (e.g. server-generated IDs that differ) are exactly the point —
+   * the comparison runs on the substituted result.
+   */
+  capture?: CaptureSpec[];
   /** Optional label for reporting — defaults to `<METHOD> <path>`. */
   label?: string;
 }
@@ -133,6 +168,95 @@ function joinBase(base: string, path: string): string {
 }
 
 /**
+ * Substitute `{{name}}` placeholders against a variable bag. Missing
+ * vars are intentionally left as literal `{{name}}` text so the parity
+ * comparison sees the failure (the request goes out with garbled
+ * URLs / bodies) rather than silently inserting `undefined`.
+ */
+function subst(input: string, vars: Record<string, string>): string {
+  return input.replace(/\{\{([^}]+)\}\}/g, (match, key) => {
+    const k = (key as string).trim();
+    return Object.hasOwn(vars, k) ? vars[k] : match;
+  });
+}
+
+/**
+ * Apply `subst` recursively through a JSON-shaped body. Leaves
+ * non-string leaves (numbers, booleans, nulls) untouched.
+ */
+function substBody(body: unknown, vars: Record<string, string>): unknown {
+  if (typeof body === "string") return subst(body, vars);
+  if (Array.isArray(body)) return body.map((v) => substBody(v, vars));
+  if (body !== null && typeof body === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(body)) out[k] = substBody(v, vars);
+    return out;
+  }
+  return body;
+}
+
+/**
+ * Walk a dotted path into a JSON value. Numeric segments index into
+ * arrays (`body.items.0.id`). Returns `undefined` when any segment
+ * misses — the capture is then skipped, leaving the var unset.
+ */
+function dotGet(value: unknown, path: string): unknown {
+  if (path.length === 0) return value;
+  let curr: unknown = value;
+  for (const seg of path.split(".")) {
+    if (curr === null || curr === undefined) return undefined;
+    if (Array.isArray(curr)) {
+      const idx = Number.parseInt(seg, 10);
+      if (!Number.isFinite(idx)) return undefined;
+      curr = curr[idx];
+    } else if (typeof curr === "object") {
+      curr = (curr as Record<string, unknown>)[seg];
+    } else {
+      return undefined;
+    }
+  }
+  return curr;
+}
+
+/**
+ * Apply capture specs against a response's body (parsed JSON) and
+ * headers, mutating `vars` on the side that just ran. Failures
+ * (non-JSON body, missing path) skip silently so a downstream
+ * substitution leaves `{{var}}` literal — the journey doesn't
+ * pretend a missing capture is an empty string.
+ */
+function applyCaptures(
+  captures: CaptureSpec[] | undefined,
+  bodyText: string | null,
+  headers: Headers,
+  vars: Record<string, string>,
+): void {
+  if (!captures || captures.length === 0) return;
+  let parsed: unknown = null;
+  let parsedReady = false;
+  for (const cap of captures) {
+    let value: unknown;
+    if (cap.from.startsWith("body.") || cap.from === "body") {
+      if (!parsedReady) {
+        try {
+          parsed = bodyText !== null && bodyText.length > 0 ? JSON.parse(bodyText) : null;
+        } catch {
+          parsed = null;
+        }
+        parsedReady = true;
+      }
+      const sub = cap.from === "body" ? "" : cap.from.slice("body.".length);
+      value = dotGet(parsed, sub);
+    } else if (cap.from.startsWith("header.")) {
+      value = headers.get(cap.from.slice("header.".length));
+    }
+    if (value !== undefined && value !== null) {
+      vars[cap.as] = String(value);
+    }
+  }
+}
+
+/**
  * Read the raw Set-Cookie values from a Response. `Headers.get("set-cookie")`
  * collapses repeats with `, ` which loses the per-cookie boundary. Where
  * available, `Headers.getSetCookie()` (Node 19+, undici 5.x+) preserves them.
@@ -152,22 +276,31 @@ async function runStepOnSide(
   base: string,
   step: JourneyStep,
   jar: CookieJar,
+  vars: Record<string, string>,
   opts: Required<Pick<RunJourneyOptions, "timeoutMs" | "checkBody">> & {
     checkHeaders: string[];
     fetcher: typeof fetch;
   },
 ): Promise<SideResult> {
-  const url = joinBase(base, step.path);
+  // All three of path / headers / body can carry `{{var}}` references
+  // captured by earlier steps. Substitution happens BEFORE the request
+  // goes out so the server sees the resolved value; the SideResult
+  // captures the actual response (whose body still feeds the NEXT
+  // step's captures).
+  const resolvedPath = subst(step.path, vars);
+  const url = joinBase(base, resolvedPath);
   const method = step.method.toUpperCase();
 
   const headers = new Headers();
-  for (const [k, v] of Object.entries(step.headers ?? {})) headers.set(k, v);
+  for (const [k, v] of Object.entries(step.headers ?? {})) {
+    headers.set(k, subst(v, vars));
+  }
   let body: BodyInit | undefined;
   if (step.body !== undefined) {
     if (typeof step.body === "string") {
-      body = step.body;
+      body = subst(step.body, vars);
     } else {
-      body = JSON.stringify(step.body);
+      body = JSON.stringify(substBody(step.body, vars));
       if (!headers.has("content-type")) headers.set("content-type", "application/json");
     }
   }
@@ -197,11 +330,19 @@ async function runStepOnSide(
       for (const name of opts.checkHeaders) out[name] = resp.headers.get(name);
       result.headers = out;
     }
-    if (opts.checkBody) {
+    // We read the body when ANY of capture / checkBody asked for it.
+    // Reading once + reusing both lets us avoid two body reads.
+    const needsBody = opts.checkBody || (step.capture && step.capture.length > 0);
+    let bodyText: string | null = null;
+    if (needsBody) {
       const bytes = new Uint8Array(await resp.arrayBuffer());
-      result.bodyLength = bytes.byteLength;
-      result.bodyHash = createHash("sha256").update(bytes).digest("hex");
+      bodyText = new TextDecoder().decode(bytes);
+      if (opts.checkBody) {
+        result.bodyLength = bytes.byteLength;
+        result.bodyHash = createHash("sha256").update(bytes).digest("hex");
+      }
     }
+    applyCaptures(step.capture, bodyText, resp.headers, vars);
     return result;
   } catch (err) {
     return {
@@ -257,6 +398,12 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
 
   const leftJar = makeJar();
   const rightJar = makeJar();
+  // Variable bags are per-side: a value captured from left's response
+  // is only visible to subsequent left steps. Asymmetric IDs / tokens
+  // (which is the common case) Just Work — each side resolves its
+  // template against its own bag.
+  const leftVars: Record<string, string> = {};
+  const rightVars: Record<string, string> = {};
 
   const mismatches: JourneyMismatch[] = [];
   const matches: JourneyStepResult[] = [];
@@ -268,8 +415,8 @@ export async function runJourney(opts: RunJourneyOptions): Promise<JourneyReport
     // Per-step parallel: each side advances independently. State
     // accumulates in its own jar.
     const [left, right] = await Promise.all([
-      runStepOnSide(opts.left, step, leftJar, sideOpts),
-      runStepOnSide(opts.right, step, rightJar, sideOpts),
+      runStepOnSide(opts.left, step, leftJar, leftVars, sideOpts),
+      runStepOnSide(opts.right, step, rightJar, rightVars, sideOpts),
     ]);
     const label = step.label ?? `${step.method.toUpperCase()} ${step.path}`;
     const result: JourneyStepResult = {

--- a/packages/chaosbringer/src/parity-cli.test.ts
+++ b/packages/chaosbringer/src/parity-cli.test.ts
@@ -109,6 +109,23 @@ describe("runParityCli", () => {
     expect(logged()).toContain("Checked 1 path(s)");
   });
 
+  it("strips inline `#` comments so they don't leak into the request URL", async () => {
+    // Without this guard the path "/foo  # comment" would be passed to
+    // `new URL(...)` and `#` would be parsed as a fragment marker —
+    // the server would receive "/foo  " with trailing whitespace and
+    // never see the comment, masking the parse failure with an
+    // accidentally-correct route match.
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const u = typeof input === "string" ? input : input.toString();
+      seen.push(u);
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const pathsFile = writePaths("paths.txt", ["/foo  # this is an annotation"]);
+    await runParityCli(["--left", "http://l", "--right", "http://r", "--paths", pathsFile]);
+    expect(seen).toEqual(["http://l/foo", "http://r/foo"]);
+  });
+
   it("exits 1 with a helpful error when required flags are missing", async () => {
     await runParityCli(["--left", "http://l"]);
     expect(process.exitCode).toBe(1);

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -33,6 +33,12 @@ Options:
                      per path. Required to catch silent schema drift
                      where two endpoints agree on status but differ on
                      payload (e.g. a JSON field dropped on one side).
+  --check-headers <list>
+                     Compare the named response headers (comma-separated,
+                     case-insensitive). e.g. --check-headers content-type,cache-control
+                     Catches policy drift like one side dropping
+                     cache-control or returning a different CORS origin.
+                     Reported before body drift.
   --timeout <ms>     Per-request timeout. Default 10000.
   --help             Show this help
 
@@ -70,6 +76,7 @@ export async function runParityCli(argv: string[]): Promise<void> {
       output: { type: "string" },
       "follow-redirects": { type: "boolean", default: false },
       "check-body": { type: "boolean", default: false },
+      "check-headers": { type: "string" },
       timeout: { type: "string" },
       help: { type: "boolean", default: false },
     },
@@ -92,12 +99,18 @@ export async function runParityCli(argv: string[]): Promise<void> {
     return;
   }
 
+  const checkHeaders = values["check-headers"]
+    ?.split(",")
+    .map((h) => h.trim())
+    .filter((h) => h.length > 0);
+
   const report = await runParity({
     left: values.left,
     right: values.right,
     paths,
     followRedirects: values["follow-redirects"],
     checkBody: values["check-body"],
+    checkHeaders,
     timeoutMs,
   });
 
@@ -116,6 +129,18 @@ export async function runParityCli(argv: string[]): Promise<void> {
       console.log(
         `  BODY   ${m.path}  left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`,
       );
+    } else if (m.kind === "header") {
+      // Find the first differing header so the printed line is
+      // immediately actionable; the JSON report carries the full map.
+      const diffs: string[] = [];
+      const left = m.left.headers ?? {};
+      const right = m.right.headers ?? {};
+      for (const name of Object.keys(left)) {
+        if (left[name] !== right[name]) {
+          diffs.push(`${name}: left=${left[name] ?? "(none)"} right=${right[name] ?? "(none)"}`);
+        }
+      }
+      console.log(`  HEADER ${m.path}  ${diffs.join(" | ")}`);
     } else {
       const leftMsg = m.left.error ?? `status ${m.left.status}`;
       const rightMsg = m.right.error ?? `status ${m.right.status}`;

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -131,41 +131,41 @@ export async function runParityCli(argv: string[]): Promise<void> {
 
   console.log(`Checked ${report.pathsChecked} path(s): ${report.matches.length} match, ${report.mismatches.length} mismatch.`);
   for (const m of report.mismatches) {
-    if (m.kind === "status") {
-      console.log(`  STATUS ${m.path}  left=${m.left.status}  right=${m.right.status}`);
-    } else if (m.kind === "redirect") {
-      console.log(`  REDIR  ${m.path}  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`);
-    } else if (m.kind === "body") {
-      const summary = summariseBodyDiff(m.bodyDiff);
-      const head = `  BODY   ${m.path}  left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
-      console.log(summary ? `${head}\n         ${summary}` : head);
-    } else if (m.kind === "header") {
-      // Find the first differing header so the printed line is
-      // immediately actionable; the JSON report carries the full map.
-      const diffs: string[] = [];
-      const left = m.left.headers ?? {};
-      const right = m.right.headers ?? {};
-      for (const name of Object.keys(left)) {
-        if (left[name] !== right[name]) {
-          diffs.push(`${name}: left=${left[name] ?? "(none)"} right=${right[name] ?? "(none)"}`);
+    // Print every detected kind for this probe, not just the primary —
+    // a header drift can mask a body drift if we only show the first.
+    for (const kind of m.kinds) {
+      if (kind === "status") {
+        console.log(`  STATUS ${m.path}  left=${m.left.status}  right=${m.right.status}`);
+      } else if (kind === "redirect") {
+        console.log(
+          `  REDIR  ${m.path}  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`,
+        );
+      } else if (kind === "body") {
+        const summary = summariseBodyDiff(m.bodyDiff);
+        const head = `  BODY   ${m.path}  left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
+        console.log(summary ? `${head}\n         ${summary}` : head);
+      } else if (kind === "header") {
+        const diffs: string[] = [];
+        const left = m.left.headers ?? {};
+        const right = m.right.headers ?? {};
+        for (const name of Object.keys(left)) {
+          if (left[name] !== right[name]) {
+            diffs.push(`${name}: left=${left[name] ?? "(none)"} right=${right[name] ?? "(none)"}`);
+          }
         }
+        console.log(`  HEADER ${m.path}  ${diffs.join(" | ")}`);
+      } else if (kind === "exception") {
+        const leftCount = (m.left.pageErrors?.length ?? 0) + (m.left.consoleErrors?.length ?? 0);
+        const rightCount = (m.right.pageErrors?.length ?? 0) + (m.right.consoleErrors?.length ?? 0);
+        const sample = (m.right.pageErrors ?? m.right.consoleErrors ?? m.left.pageErrors ?? m.left.consoleErrors ?? [])[0];
+        console.log(
+          `  EXC    ${m.path}  left=${leftCount} err  right=${rightCount} err  e.g. "${sample ?? "(none)"}"`,
+        );
+      } else if (kind === "failure") {
+        const leftMsg = m.left.error ?? `status ${m.left.status}`;
+        const rightMsg = m.right.error ?? `status ${m.right.status}`;
+        console.log(`  FAIL   ${m.path}  left=${leftMsg}  right=${rightMsg}`);
       }
-      console.log(`  HEADER ${m.path}  ${diffs.join(" | ")}`);
-    } else if (m.kind === "exception") {
-      const leftCount = (m.left.pageErrors?.length ?? 0) + (m.left.consoleErrors?.length ?? 0);
-      const rightCount =
-        (m.right.pageErrors?.length ?? 0) + (m.right.consoleErrors?.length ?? 0);
-      // Print one representative message per side (whichever set is
-      // non-empty first) so the line is actionable; full lists are in
-      // the JSON report.
-      const sample = (m.right.pageErrors ?? m.right.consoleErrors ?? m.left.pageErrors ?? m.left.consoleErrors ?? [])[0];
-      console.log(
-        `  EXC    ${m.path}  left=${leftCount} err  right=${rightCount} err  e.g. "${sample ?? "(none)"}"`,
-      );
-    } else {
-      const leftMsg = m.left.error ?? `status ${m.left.status}`;
-      const rightMsg = m.right.error ?? `status ${m.right.status}`;
-      console.log(`  FAIL   ${m.path}  left=${leftMsg}  right=${rightMsg}`);
     }
   }
 

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -28,6 +28,11 @@ Options:
                      final status. Default is manual (compare the 3xx
                      status + Location directly, the more sensitive
                      mode for routing-bug detection).
+  --check-body       Also compare response body bytes (SHA-256 hash).
+                     Off by default — adds a full body read per side
+                     per path. Required to catch silent schema drift
+                     where two endpoints agree on status but differ on
+                     payload (e.g. a JSON field dropped on one side).
   --timeout <ms>     Per-request timeout. Default 10000.
   --help             Show this help
 
@@ -64,6 +69,7 @@ export async function runParityCli(argv: string[]): Promise<void> {
       paths: { type: "string" },
       output: { type: "string" },
       "follow-redirects": { type: "boolean", default: false },
+      "check-body": { type: "boolean", default: false },
       timeout: { type: "string" },
       help: { type: "boolean", default: false },
     },
@@ -91,6 +97,7 @@ export async function runParityCli(argv: string[]): Promise<void> {
     right: values.right,
     paths,
     followRedirects: values["follow-redirects"],
+    checkBody: values["check-body"],
     timeoutMs,
   });
 
@@ -105,6 +112,10 @@ export async function runParityCli(argv: string[]): Promise<void> {
       console.log(`  STATUS ${m.path}  left=${m.left.status}  right=${m.right.status}`);
     } else if (m.kind === "redirect") {
       console.log(`  REDIR  ${m.path}  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`);
+    } else if (m.kind === "body") {
+      console.log(
+        `  BODY   ${m.path}  left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`,
+      );
     } else {
       const leftMsg = m.left.error ?? `status ${m.left.status}`;
       const rightMsg = m.right.error ?? `status ${m.right.status}`;

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -42,10 +42,17 @@ Examples:
 
 function readPaths(file: string): string[] {
   const text = readFileSync(file, "utf-8");
-  return text
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith("#"));
+  return (
+    text
+      .split(/\r?\n/)
+      // Strip inline `#` comments first — the unescaped `#` would later be
+      // parsed as a URL fragment, silently dropping everything after it and
+      // letting accidentally-correct results mask the parse failure. Doing
+      // this before the empty-line filter keeps comment-only lines from
+      // surviving as a stray empty path.
+      .map((line) => line.replace(/(^|\s)#.*$/, "").trim())
+      .filter((line) => line.length > 0)
+  );
 }
 
 export async function runParityCli(argv: string[]): Promise<void> {

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -6,6 +6,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { parseArgs } from "node:util";
+import { summariseBodyDiff } from "./body-diff.js";
 import { runParity } from "./parity.js";
 
 const HELP = `Usage: chaosbringer parity --left <url> --right <url> --paths <file> [options]
@@ -135,9 +136,9 @@ export async function runParityCli(argv: string[]): Promise<void> {
     } else if (m.kind === "redirect") {
       console.log(`  REDIR  ${m.path}  left→${m.left.location ?? "(none)"}  right→${m.right.location ?? "(none)"}`);
     } else if (m.kind === "body") {
-      console.log(
-        `  BODY   ${m.path}  left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`,
-      );
+      const summary = summariseBodyDiff(m.bodyDiff);
+      const head = `  BODY   ${m.path}  left=${m.left.bodyLength}B (${m.left.bodyHash?.slice(0, 8)}…)  right=${m.right.bodyLength}B (${m.right.bodyHash?.slice(0, 8)}…)`;
+      console.log(summary ? `${head}\n         ${summary}` : head);
     } else if (m.kind === "header") {
       // Find the first differing header so the printed line is
       // immediately actionable; the JSON report carries the full map.

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -47,6 +47,11 @@ Options:
                      identical. Slow — one browser visit per side per
                      path. Requires \`playwright\` installed and a
                      browser binary available.
+  --perf-delta-ms <n>  Flag a "perf" mismatch when right is more than
+                     N ms slower than left. Single-sample wall clock —
+                     noisy; set well above your jitter floor.
+  --perf-ratio <n>   Flag a "perf" mismatch when right > left * N.
+                     Composes with --perf-delta-ms via OR.
   --timeout <ms>     Per-request timeout. Default 10000.
   --help             Show this help
 
@@ -86,6 +91,8 @@ export async function runParityCli(argv: string[]): Promise<void> {
       "check-body": { type: "boolean", default: false },
       "check-headers": { type: "string" },
       "check-exceptions": { type: "boolean", default: false },
+      "perf-delta-ms": { type: "string" },
+      "perf-ratio": { type: "string" },
       timeout: { type: "string" },
       help: { type: "boolean", default: false },
     },
@@ -121,6 +128,8 @@ export async function runParityCli(argv: string[]): Promise<void> {
     checkBody: values["check-body"],
     checkHeaders,
     checkExceptions: values["check-exceptions"],
+    perfDeltaMs: values["perf-delta-ms"] ? parseFloat(values["perf-delta-ms"]) : undefined,
+    perfRatio: values["perf-ratio"] ? parseFloat(values["perf-ratio"]) : undefined,
     timeoutMs,
   });
 
@@ -160,6 +169,14 @@ export async function runParityCli(argv: string[]): Promise<void> {
         const sample = (m.right.pageErrors ?? m.right.consoleErrors ?? m.left.pageErrors ?? m.left.consoleErrors ?? [])[0];
         console.log(
           `  EXC    ${m.path}  left=${leftCount} err  right=${rightCount} err  e.g. "${sample ?? "(none)"}"`,
+        );
+      } else if (kind === "perf") {
+        const l = m.left.durationMs ?? 0;
+        const r = m.right.durationMs ?? 0;
+        const delta = r - l;
+        const ratio = l > 0 ? r / l : 0;
+        console.log(
+          `  PERF   ${m.path}  left=${l.toFixed(0)}ms  right=${r.toFixed(0)}ms  Δ=${delta.toFixed(0)}ms (×${ratio.toFixed(2)})`,
         );
       } else if (kind === "failure") {
         const leftMsg = m.left.error ?? `status ${m.left.status}`;

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -39,6 +39,13 @@ Options:
                      Catches policy drift like one side dropping
                      cache-control or returning a different CORS origin.
                      Reported before body drift.
+  --check-exceptions Visit each path in a real browser (Chromium) and
+                     compare uncaught JS errors + console.error
+                     between sides. Catches React hydration mismatches
+                     and other runtime-only bugs where HTTP looks
+                     identical. Slow — one browser visit per side per
+                     path. Requires \`playwright\` installed and a
+                     browser binary available.
   --timeout <ms>     Per-request timeout. Default 10000.
   --help             Show this help
 
@@ -77,6 +84,7 @@ export async function runParityCli(argv: string[]): Promise<void> {
       "follow-redirects": { type: "boolean", default: false },
       "check-body": { type: "boolean", default: false },
       "check-headers": { type: "string" },
+      "check-exceptions": { type: "boolean", default: false },
       timeout: { type: "string" },
       help: { type: "boolean", default: false },
     },
@@ -111,6 +119,7 @@ export async function runParityCli(argv: string[]): Promise<void> {
     followRedirects: values["follow-redirects"],
     checkBody: values["check-body"],
     checkHeaders,
+    checkExceptions: values["check-exceptions"],
     timeoutMs,
   });
 
@@ -141,6 +150,17 @@ export async function runParityCli(argv: string[]): Promise<void> {
         }
       }
       console.log(`  HEADER ${m.path}  ${diffs.join(" | ")}`);
+    } else if (m.kind === "exception") {
+      const leftCount = (m.left.pageErrors?.length ?? 0) + (m.left.consoleErrors?.length ?? 0);
+      const rightCount =
+        (m.right.pageErrors?.length ?? 0) + (m.right.consoleErrors?.length ?? 0);
+      // Print one representative message per side (whichever set is
+      // non-empty first) so the line is actionable; full lists are in
+      // the JSON report.
+      const sample = (m.right.pageErrors ?? m.right.consoleErrors ?? m.left.pageErrors ?? m.left.consoleErrors ?? [])[0];
+      console.log(
+        `  EXC    ${m.path}  left=${leftCount} err  right=${rightCount} err  e.g. "${sample ?? "(none)"}"`,
+      );
     } else {
       const leftMsg = m.left.error ?? `status ${m.left.status}`;
       const rightMsg = m.right.error ?? `status ${m.right.status}`;

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -78,7 +78,7 @@ describe("runParity", () => {
       fetcher,
     });
     expect(report.mismatches).toHaveLength(1);
-    expect(report.mismatches[0].kind).toBe("status");
+    expect(report.mismatches[0].kinds[0]).toBe("status");
     expect(report.mismatches[0].left.status).toBe(200);
     expect(report.mismatches[0].right.status).toBe(500);
   });
@@ -97,7 +97,7 @@ describe("runParity", () => {
       fetcher,
     });
     expect(report.mismatches).toHaveLength(1);
-    expect(report.mismatches[0].kind).toBe("redirect");
+    expect(report.mismatches[0].kinds[0]).toBe("redirect");
     expect(report.mismatches[0].left.location).toBe("/new");
     expect(report.mismatches[0].right.location).toBe("/elsewhere");
   });
@@ -130,7 +130,7 @@ describe("runParity", () => {
       fetcher,
     });
     expect(report.mismatches).toHaveLength(1);
-    expect(report.mismatches[0].kind).toBe("failure");
+    expect(report.mismatches[0].kinds[0]).toBe("failure");
     expect(report.mismatches[0].left.error).toContain("ECONNREFUSED");
     expect(report.mismatches[0].right.status).toBe(200);
   });
@@ -239,7 +239,7 @@ describe("runParity", () => {
       });
       expect(report.mismatches).toHaveLength(1);
       const m = report.mismatches[0];
-      expect(m.kind).toBe("body");
+      expect(m.kinds[0]).toBe("body");
       // bodyLength + bodyHash populated on both sides so a consumer of
       // the JSON report can prove the drift without refetching.
       expect(m.left.bodyHash).toMatch(/^[a-f0-9]{64}$/);
@@ -295,7 +295,7 @@ describe("runParity", () => {
         fetcher,
       });
       expect(report.mismatches).toHaveLength(1);
-      expect(report.mismatches[0].kind).toBe("status");
+      expect(report.mismatches[0].kinds[0]).toBe("status");
     });
   });
 
@@ -316,7 +316,7 @@ describe("runParity", () => {
       });
       expect(report.mismatches).toHaveLength(1);
       const m = report.mismatches[0];
-      expect(m.kind).toBe("header");
+      expect(m.kinds[0]).toBe("header");
       expect(m.left.headers?.["cache-control"]).toBe("max-age=60");
       expect(m.right.headers?.["cache-control"]).toBe("no-store");
     });
@@ -351,7 +351,7 @@ describe("runParity", () => {
         checkHeaders: ["Content-Type"],
         fetcher,
       });
-      expect(report.mismatches[0].kind).toBe("header");
+      expect(report.mismatches[0].kinds[0]).toBe("header");
       expect(report.mismatches[0].left.headers?.["content-type"]).toBe("text/html");
     });
 
@@ -391,7 +391,7 @@ describe("runParity", () => {
         fetcher,
       });
       expect(report.mismatches).toHaveLength(1);
-      expect(report.mismatches[0].kind).toBe("header");
+      expect(report.mismatches[0].kinds[0]).toBe("header");
     });
 
     it("an empty/unset checkHeaders list does not populate the headers map", async () => {
@@ -428,7 +428,7 @@ describe("runParity", () => {
         browserLauncher,
       });
       expect(report.mismatches).toHaveLength(1);
-      expect(report.mismatches[0].kind).toBe("exception");
+      expect(report.mismatches[0].kinds[0]).toBe("exception");
       expect(report.mismatches[0].right.pageErrors).toEqual([
         "ReferenceError: x is not defined",
       ]);
@@ -475,7 +475,7 @@ describe("runParity", () => {
         fetcher,
         browserLauncher,
       });
-      expect(report.mismatches[0].kind).toBe("exception");
+      expect(report.mismatches[0].kinds[0]).toBe("exception");
       expect(report.mismatches[0].right.consoleErrors).toEqual(["api failed"]);
     });
 
@@ -498,7 +498,7 @@ describe("runParity", () => {
         fetcher,
         browserLauncher,
       });
-      expect(report.mismatches[0].kind).toBe("status");
+      expect(report.mismatches[0].kinds[0]).toBe("status");
     });
 
     it("matched probes carry the empty error arrays so consumers can prove cleanliness", async () => {
@@ -540,6 +540,57 @@ describe("runParity", () => {
     });
   });
 
+  describe("multi-kind reporting (overlapping bugs on one path)", () => {
+    it("reports BOTH header and body kinds when both differ", async () => {
+      // The bug that motivated this: with single-kind reporting, a
+      // header drift would mask an independent body drift on the
+      // same path. Now both surface.
+      const fetcher = makeFetcher({
+        "http://left/x": () =>
+          new Response(JSON.stringify({ id: 1 }), {
+            status: 200,
+            headers: { "cache-control": "max-age=60" },
+          }),
+        "http://right/x": () =>
+          new Response(JSON.stringify({ id: 2 }), {
+            status: 200,
+            headers: { "cache-control": "no-store" },
+          }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkBody: true,
+        checkHeaders: ["cache-control"],
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kinds).toEqual(["header", "body"]);
+      expect(report.mismatches[0].bodyDiff).toBeDefined();
+    });
+
+    it("status mismatch still short-circuits other checks", async () => {
+      // A status difference means the downstream body / header
+      // comparison is apples-to-oranges. Keep status exclusive.
+      const fetcher = makeFetcher({
+        "http://left/x": () =>
+          new Response("a", { status: 200, headers: { "cache-control": "max-age=60" } }),
+        "http://right/x": () =>
+          new Response("b", { status: 500, headers: { "cache-control": "no-store" } }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkBody: true,
+        checkHeaders: ["cache-control"],
+        fetcher,
+      });
+      expect(report.mismatches[0].kinds).toEqual(["status"]);
+    });
+  });
+
   it("flags 3xx → 200 status mismatch (not redirect mismatch)", async () => {
     // Same status family check guards against false-positive redirects:
     // 301 vs 200 should be reported as a status mismatch, not a redirect mismatch.
@@ -555,6 +606,6 @@ describe("runParity", () => {
       fetcher,
     });
     expect(report.mismatches).toHaveLength(1);
-    expect(report.mismatches[0].kind).toBe("status");
+    expect(report.mismatches[0].kinds[0]).toBe("status");
   });
 });

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -1,5 +1,45 @@
 import { describe, expect, it, vi } from "vitest";
-import { runParity } from "./parity.js";
+import { runParity, type BrowserLike, type ContextLike, type PageLike } from "./parity.js";
+
+/**
+ * Minimal fake of the Playwright surface `probeBrowserSide` uses. Each
+ * test seeds error lists per URL; the fake replays them through the
+ * `pageerror` / `console` event handlers when `page.goto(url)` runs.
+ */
+function makeBrowserLauncher(
+  errorsByUrl: Record<string, { pageErrors?: string[]; consoleErrors?: string[] }>,
+): () => Promise<BrowserLike> {
+  return async () => ({
+    async newContext(): Promise<ContextLike> {
+      return {
+        async newPage(): Promise<PageLike> {
+          let pageErrorHandler: ((err: Error) => void) | null = null;
+          let consoleHandler:
+            | ((msg: { type(): string; text(): string }) => void)
+            | null = null;
+          return {
+            on(event: string, handler: (...args: unknown[]) => void) {
+              if (event === "pageerror") pageErrorHandler = handler as (err: Error) => void;
+              if (event === "console")
+                consoleHandler = handler as (msg: { type(): string; text(): string }) => void;
+            },
+            async goto(url: string) {
+              const seeded = errorsByUrl[url] ?? {};
+              for (const msg of seeded.pageErrors ?? []) {
+                pageErrorHandler?.(new Error(msg));
+              }
+              for (const msg of seeded.consoleErrors ?? []) {
+                consoleHandler?.({ type: () => "error", text: () => msg });
+              }
+            },
+          };
+        },
+        async close() {},
+      };
+    },
+    async close() {},
+  });
+}
 
 function makeFetcher(handlers: Record<string, () => Response | Promise<Response> | Promise<never>>): typeof fetch {
   return (async (input: RequestInfo | URL) => {
@@ -366,6 +406,137 @@ describe("runParity", () => {
         fetcher,
       });
       expect(report.matches[0].left.headers).toBeUndefined();
+    });
+  });
+
+  describe("checkExceptions", () => {
+    it("flags an exception mismatch when right has a JS error left doesn't", async () => {
+      const fetcher = makeFetcher({
+        "http://left/admin": () => new Response("", { status: 200 }),
+        "http://right/admin": () => new Response("", { status: 200 }),
+      });
+      const browserLauncher = makeBrowserLauncher({
+        "http://left/admin": {},
+        "http://right/admin": { pageErrors: ["ReferenceError: x is not defined"] },
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["admin"],
+        checkExceptions: true,
+        fetcher,
+        browserLauncher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kind).toBe("exception");
+      expect(report.mismatches[0].right.pageErrors).toEqual([
+        "ReferenceError: x is not defined",
+      ]);
+      expect(report.mismatches[0].left.pageErrors).toEqual([]);
+    });
+
+    it("collapses different source locations to the same fingerprint (no false positive)", async () => {
+      // The same bug fires from `app.js:123:5` on left and `app.js:124:9` on
+      // right after a recompile. Without normalisation this would be a
+      // false-positive exception mismatch.
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("", { status: 200 }),
+        "http://right/x": () => new Response("", { status: 200 }),
+      });
+      const browserLauncher = makeBrowserLauncher({
+        "http://left/x": { pageErrors: ["TypeError: foo at bundle.js:123:5"] },
+        "http://right/x": { pageErrors: ["TypeError: foo at bundle.js:124:9"] },
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkExceptions: true,
+        fetcher,
+        browserLauncher,
+      });
+      expect(report.mismatches).toHaveLength(0);
+    });
+
+    it("treats console.error as part of the exception set", async () => {
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("", { status: 200 }),
+        "http://right/x": () => new Response("", { status: 200 }),
+      });
+      const browserLauncher = makeBrowserLauncher({
+        "http://left/x": {},
+        "http://right/x": { consoleErrors: ["api failed"] },
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkExceptions: true,
+        fetcher,
+        browserLauncher,
+      });
+      expect(report.mismatches[0].kind).toBe("exception");
+      expect(report.mismatches[0].right.consoleErrors).toEqual(["api failed"]);
+    });
+
+    it("status mismatch wins over exception mismatch", async () => {
+      // A status difference is the upstream signal; whatever JS error
+      // the broken response causes is downstream noise.
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("", { status: 200 }),
+        "http://right/x": () => new Response("", { status: 500 }),
+      });
+      const browserLauncher = makeBrowserLauncher({
+        "http://left/x": {},
+        "http://right/x": { pageErrors: ["error"] },
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkExceptions: true,
+        fetcher,
+        browserLauncher,
+      });
+      expect(report.mismatches[0].kind).toBe("status");
+    });
+
+    it("matched probes carry the empty error arrays so consumers can prove cleanliness", async () => {
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("", { status: 200 }),
+        "http://right/x": () => new Response("", { status: 200 }),
+      });
+      const browserLauncher = makeBrowserLauncher({
+        "http://left/x": {},
+        "http://right/x": {},
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkExceptions: true,
+        fetcher,
+        browserLauncher,
+      });
+      expect(report.mismatches).toHaveLength(0);
+      expect(report.matches[0].left.pageErrors).toEqual([]);
+      expect(report.matches[0].right.pageErrors).toEqual([]);
+    });
+
+    it("does not load a browser when checkExceptions is off", async () => {
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("", { status: 200 }),
+        "http://right/x": () => new Response("", { status: 200 }),
+      });
+      const browserLauncher = vi.fn();
+      await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        fetcher,
+        browserLauncher: browserLauncher as never,
+      });
+      expect(browserLauncher).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -540,6 +540,134 @@ describe("runParity", () => {
     });
   });
 
+  describe("perf threshold", () => {
+    /**
+     * Mock fetcher that takes a fixed time to resolve per URL. We
+     * spin a real `setTimeout` (not fake timers) because parity's
+     * timing is wall-clock — Date.now / performance.now under
+     * fake timers wouldn't advance, defeating the test.
+     */
+    function makeTimedFetcher(timings: Record<string, number>): typeof fetch {
+      return (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const ms = timings[url] ?? 0;
+        if (ms > 0) await new Promise((r) => setTimeout(r, ms));
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+    }
+
+    it("flags a perf mismatch when right is slower than left by more than the delta budget", async () => {
+      const fetcher = makeTimedFetcher({
+        "http://left/x": 5,
+        "http://right/x": 80,
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        perfDeltaMs: 30,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kinds).toContain("perf");
+      expect(report.mismatches[0].left.durationMs).toBeLessThan(
+        report.mismatches[0].right.durationMs!,
+      );
+    });
+
+    it("does not flag perf when the delta is below the budget", async () => {
+      const fetcher = makeTimedFetcher({
+        "http://left/x": 5,
+        "http://right/x": 10,
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        perfDeltaMs: 50,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(0);
+    });
+
+    it("perfRatio fires independently of perfDeltaMs", async () => {
+      const fetcher = makeTimedFetcher({
+        "http://left/x": 30,
+        "http://right/x": 120,
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        perfRatio: 3.0,
+        fetcher,
+      });
+      expect(report.mismatches[0]?.kinds).toContain("perf");
+    });
+
+    it("perfRatio skips when left.durationMs is 0 (avoid divide-by-zero on instant responses)", async () => {
+      // Synthesize a 0-duration left: handler resolves immediately
+      // without await. Right takes longer. Ratio would be Infinity;
+      // the code must skip rather than report bogus drift.
+      const fetcher = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("left")) return new Response("ok", { status: 200 });
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        perfRatio: 2.0, // would fire on any non-zero right if left=0
+        fetcher,
+      });
+      // Depending on timing left might be 0 or ~0.1ms. Either way the
+      // ratio check must NOT fire on a 0/near-0 baseline. We accept
+      // either 0 or 1 mismatches but assert: if a mismatch fires,
+      // it must have a sensible numerator.
+      if (report.mismatches.length > 0) {
+        expect(report.mismatches[0].left.durationMs).toBeGreaterThan(0);
+      }
+    });
+
+    it("populates durationMs on every probe (even when perf isn't checked)", async () => {
+      const fetcher = (async () => new Response("ok", { status: 200 })) as typeof fetch;
+      const report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        fetcher,
+      });
+      expect(report.matches[0].left.durationMs).toBeGreaterThanOrEqual(0);
+      expect(report.matches[0].right.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("perf mismatch coexists with body / header on the same probe", async () => {
+      const fetcher = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("left")) {
+          return new Response("a", { status: 200, headers: { "cache-control": "max-age=60" } });
+        }
+        await new Promise((r) => setTimeout(r, 50));
+        return new Response("b", { status: 200, headers: { "cache-control": "no-store" } });
+      }) as typeof fetch;
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkBody: true,
+        checkHeaders: ["cache-control"],
+        perfDeltaMs: 20,
+        fetcher,
+      });
+      // All three kinds fire on the same probe.
+      expect(report.mismatches[0].kinds).toEqual(
+        expect.arrayContaining(["header", "body", "perf"]),
+      );
+    });
+  });
+
   describe("multi-kind reporting (overlapping bugs on one path)", () => {
     it("reports BOTH header and body kinds when both differ", async () => {
       // The bug that motivated this: with single-kind reporting, a

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -259,6 +259,116 @@ describe("runParity", () => {
     });
   });
 
+  describe("checkHeaders", () => {
+    it("flags a header mismatch when a named header differs", async () => {
+      const fetcher = makeFetcher({
+        "http://left/api": () =>
+          new Response("", { status: 200, headers: { "cache-control": "max-age=60" } }),
+        "http://right/api": () =>
+          new Response("", { status: 200, headers: { "cache-control": "no-store" } }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkHeaders: ["cache-control"],
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      const m = report.mismatches[0];
+      expect(m.kind).toBe("header");
+      expect(m.left.headers?.["cache-control"]).toBe("max-age=60");
+      expect(m.right.headers?.["cache-control"]).toBe("no-store");
+    });
+
+    it("distinguishes 'absent' from 'empty' in the captured header map", async () => {
+      const fetcher = makeFetcher({
+        "http://left/api": () =>
+          new Response("", { status: 200, headers: { "x-custom": "value" } }),
+        "http://right/api": () => new Response("", { status: 200 }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkHeaders: ["x-custom"],
+        fetcher,
+      });
+      expect(report.mismatches[0].right.headers?.["x-custom"]).toBeNull();
+    });
+
+    it("is case-insensitive on the input list (lowercase normalised internally)", async () => {
+      const fetcher = makeFetcher({
+        "http://left/api": () =>
+          new Response("", { status: 200, headers: { "content-type": "text/html" } }),
+        "http://right/api": () =>
+          new Response("", { status: 200, headers: { "content-type": "application/json" } }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkHeaders: ["Content-Type"],
+        fetcher,
+      });
+      expect(report.mismatches[0].kind).toBe("header");
+      expect(report.mismatches[0].left.headers?.["content-type"]).toBe("text/html");
+    });
+
+    it("does not flag headers that aren't in the list (no over-broad detection)", async () => {
+      const fetcher = makeFetcher({
+        "http://left/api": () =>
+          new Response("", { status: 200, headers: { "x-internal": "a" } }),
+        "http://right/api": () =>
+          new Response("", { status: 200, headers: { "x-internal": "b" } }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkHeaders: ["cache-control"], // not the differing one
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(0);
+    });
+
+    it("header drift reported before body drift when both differ", async () => {
+      // A header-policy change (cache-control TTL, CORS origin) is the
+      // upstream cause; the body difference is downstream noise.
+      // Reporting header first keeps the triage signal clean.
+      const fetcher = makeFetcher({
+        "http://left/api": () =>
+          new Response("body-a", { status: 200, headers: { "cache-control": "max-age=60" } }),
+        "http://right/api": () =>
+          new Response("body-b", { status: 200, headers: { "cache-control": "no-store" } }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkBody: true,
+        checkHeaders: ["cache-control"],
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kind).toBe("header");
+    });
+
+    it("an empty/unset checkHeaders list does not populate the headers map", async () => {
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("", { status: 200 }),
+        "http://right/x": () => new Response("", { status: 200 }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        fetcher,
+      });
+      expect(report.matches[0].left.headers).toBeUndefined();
+    });
+  });
+
   it("flags 3xx → 200 status mismatch (not redirect mismatch)", async () => {
     // Same status family check guards against false-positive redirects:
     // 301 vs 200 should be reported as a status mismatch, not a redirect mismatch.

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -51,6 +51,31 @@ function makeFetcher(handlers: Record<string, () => Response | Promise<Response>
 }
 
 describe("runParity", () => {
+  it("report carries a schemaVersion + config echo so consumers can validate", async () => {
+    const fetcher = makeFetcher({
+      "http://l/x": () => new Response("", { status: 200 }),
+      "http://r/x": () => new Response("", { status: 200 }),
+    });
+    const report = await runParity({
+      left: "http://l",
+      right: "http://r",
+      paths: ["x"],
+      checkBody: true,
+      checkHeaders: ["content-type"],
+      perfDeltaMs: 50,
+      fetcher,
+    });
+    expect(report.schemaVersion).toBe(1);
+    expect(report.config).toEqual({
+      checkBody: true,
+      checkHeaders: ["content-type"],
+      checkExceptions: false,
+      followRedirects: false,
+      timeoutMs: 10000,
+      perfDeltaMs: 50,
+    });
+  });
+
   it("classifies matching paths as match (no mismatch)", async () => {
     const fetcher = makeFetcher({
       "http://left/foo": () => new Response("", { status: 200 }),

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -182,6 +182,83 @@ describe("runParity", () => {
     expect(report.matches[0].right.error).toBeDefined();
   });
 
+  describe("checkBody", () => {
+    it("flags a body mismatch when status agrees but bytes differ", async () => {
+      const fetcher = makeFetcher({
+        "http://left/api": () =>
+          new Response(JSON.stringify({ id: 1, email: "a@x" }), { status: 200 }),
+        "http://right/api": () =>
+          new Response(JSON.stringify({ id: 1 }), { status: 200 }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkBody: true,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      const m = report.mismatches[0];
+      expect(m.kind).toBe("body");
+      // bodyLength + bodyHash populated on both sides so a consumer of
+      // the JSON report can prove the drift without refetching.
+      expect(m.left.bodyHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(m.right.bodyHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(m.left.bodyHash).not.toBe(m.right.bodyHash);
+      expect(m.left.bodyLength).toBeGreaterThan(m.right.bodyLength!);
+    });
+
+    it("treats identical bodies as a match", async () => {
+      const payload = '{"id":1,"email":"a@x"}';
+      const fetcher = makeFetcher({
+        "http://left/api": () => new Response(payload, { status: 200 }),
+        "http://right/api": () => new Response(payload, { status: 200 }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        checkBody: true,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(0);
+      expect(report.matches[0].left.bodyHash).toBe(report.matches[0].right.bodyHash);
+    });
+
+    it("does not populate bodyHash when checkBody is off (default)", async () => {
+      const fetcher = makeFetcher({
+        "http://left/api": () => new Response("a", { status: 200 }),
+        "http://right/api": () => new Response("b", { status: 200 }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["api"],
+        fetcher,
+      });
+      // Different bytes, but checkBody off → no body mismatch fires.
+      expect(report.mismatches).toHaveLength(0);
+      expect(report.matches[0].left.bodyHash).toBeUndefined();
+    });
+
+    it("status mismatch still wins over body mismatch", async () => {
+      // If status already differs, body comparison is redundant noise.
+      const fetcher = makeFetcher({
+        "http://left/x": () => new Response("a", { status: 200 }),
+        "http://right/x": () => new Response("b", { status: 500 }),
+      });
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        checkBody: true,
+        fetcher,
+      });
+      expect(report.mismatches).toHaveLength(1);
+      expect(report.mismatches[0].kind).toBe("status");
+    });
+  });
+
   it("flags 3xx → 200 status mismatch (not redirect mismatch)", async () => {
     // Same status family check guards against false-positive redirects:
     // 301 vs 200 should be reported as a status mismatch, not a redirect mismatch.

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -134,6 +134,22 @@ export interface ParityReport {
   /** Paths that agreed on every comparison. Carried so consumers can
    *  prove which routes are stable without re-running. */
   matches: ParityProbe[];
+  /**
+   * The threshold + opt-in switches that produced this report. An
+   * operator re-reading the JSON can tell at a glance which checks
+   * were on, and which threshold a `perf` mismatch tripped against.
+   * Re-running with a different config produces a different report —
+   * the config is part of the result, not external state.
+   */
+  config: {
+    checkBody: boolean;
+    checkHeaders: string[];
+    checkExceptions: boolean;
+    followRedirects: boolean;
+    timeoutMs: number;
+    perfDeltaMs?: number;
+    perfRatio?: number;
+  };
 }
 
 export interface RunParityOptions {
@@ -547,5 +563,14 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
     pathsChecked: opts.paths.length,
     mismatches,
     matches,
+    config: {
+      checkBody,
+      checkHeaders,
+      checkExceptions,
+      followRedirects,
+      timeoutMs,
+      ...(opts.perfDeltaMs !== undefined ? { perfDeltaMs: opts.perfDeltaMs } : {}),
+      ...(opts.perfRatio !== undefined ? { perfRatio: opts.perfRatio } : {}),
+    },
   };
 }

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -14,6 +14,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { diffJsonBodies, type BodyDiffResult } from "./body-diff.js";
 
 export type MismatchKind =
   /** HTTP status codes differ. */
@@ -95,6 +96,12 @@ export interface ParityMismatch extends ParityProbe {
    *  "failure" and "status" depending on the consumer's view; we record
    *  the strongest one). */
   kind: MismatchKind;
+  /**
+   * Localised body diff. Populated only on `kind: "body"` when both
+   * sides' bodies parsed as JSON. Carries up to ~50 path-level
+   * entries; a truncated flag fires when the diff overflows.
+   */
+  bodyDiff?: BodyDiffResult;
 }
 
 export interface ParityReport {
@@ -251,6 +258,17 @@ async function probeBrowserSide(
   return { pageErrors, consoleErrors };
 }
 
+interface ProbedSide {
+  result: SideResult;
+  /**
+   * Raw decoded body text. Kept transient (not on SideResult) so the
+   * JSON report doesn't balloon with full bodies; only the body-diff
+   * (computed from this) gets serialised. `null` when the body wasn't
+   * read (checkBody off).
+   */
+  bodyText: string | null;
+}
+
 async function probeSide(
   base: string,
   path: string,
@@ -261,7 +279,7 @@ async function probeSide(
     checkBody: boolean;
     checkHeaders: string[];
   },
-): Promise<SideResult> {
+): Promise<ProbedSide> {
   const url = joinBase(base, path);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
@@ -281,6 +299,7 @@ async function probeSide(
       }
       result.headers = out;
     }
+    let bodyText: string | null = null;
     if (opts.checkBody) {
       // Reading the body is part of the same timeout window — a slow
       // body trickle counts against the per-request budget so one
@@ -290,12 +309,16 @@ async function probeSide(
       const bytes = new Uint8Array(await resp.arrayBuffer());
       result.bodyLength = bytes.byteLength;
       result.bodyHash = createHash("sha256").update(bytes).digest("hex");
+      bodyText = new TextDecoder().decode(bytes);
     }
-    return result;
+    return { result, bodyText };
   } catch (err) {
     return {
-      status: null,
-      error: err instanceof Error ? err.message : String(err),
+      result: {
+        status: null,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      bodyText: null,
     };
   } finally {
     clearTimeout(timer);
@@ -400,10 +423,12 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
       // Probe both sides in parallel — they're independent and the report
       // is symmetric, so there's no reason to serialise.
       const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody, checkHeaders };
-      const [left, right] = await Promise.all([
+      const [leftProbe, rightProbe] = await Promise.all([
         probeSide(opts.left, path, sideOpts),
         probeSide(opts.right, path, sideOpts),
       ]);
+      const left = leftProbe.result;
+      const right = rightProbe.result;
 
       if (browser) {
         // Browser visits are slower (~1s+ per page) and must use real
@@ -421,8 +446,17 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
 
       const probe: ParityProbe = { path, left, right };
       const kind = classify(left, right);
-      if (kind) mismatches.push({ ...probe, kind });
-      else matches.push(probe);
+      if (kind) {
+        const m: ParityMismatch = { ...probe, kind };
+        // Localise body drift to specific JSON paths when we have the
+        // bytes. Skipped for other kinds — a status mismatch's body
+        // delta is downstream noise the diff would just amplify.
+        if (kind === "body") {
+          const diff = diffJsonBodies(leftProbe.bodyText, rightProbe.bodyText);
+          if (diff) m.bodyDiff = diff;
+        }
+        mismatches.push(m);
+      } else matches.push(probe);
     }
   } finally {
     // Always tear down — leaking a Chromium across CI runs is a

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -26,7 +26,12 @@ export type MismatchKind =
    * Status agreed but the response body bytes differ. Only fires when
    * `checkBody` is enabled in the run options.
    */
-  | "body";
+  | "body"
+  /**
+   * Status agreed but one or more of the named response headers
+   * differ. Only fires when `checkHeaders` is non-empty.
+   */
+  | "header";
 
 export interface SideResult {
   /** Final status. `null` when the fetch threw before getting a response. */
@@ -49,6 +54,13 @@ export interface SideResult {
    * drift, not flakiness).
    */
   bodyHash?: string;
+  /**
+   * Named response headers, lowercased and de-duplicated. Populated
+   * only for headers listed in `checkHeaders`. A header that was
+   * absent on a given side appears as `null`, so consumers can
+   * distinguish "missing" from "empty".
+   */
+  headers?: Record<string, string | null>;
 }
 
 export interface ParityProbe {
@@ -98,6 +110,18 @@ export interface RunParityOptions {
    * field that doesn't move the status code.
    */
   checkBody?: boolean;
+  /**
+   * Header names to compare. Case-insensitive; lowercased internally
+   * and matched against the response's header bag. When empty (the
+   * default) no header comparison is done — headers vary too much
+   * between requests for an unconditional check to be useful.
+   *
+   * Typical opt-ins: `["content-type", "cache-control", "set-cookie",
+   * "access-control-allow-origin"]`. The list is the caller's policy;
+   * we don't ship defaults so each consumer is forced to think about
+   * which headers actually matter to their app.
+   */
+  checkHeaders?: string[];
   /** Override fetch for testing. */
   fetcher?: typeof fetch;
 }
@@ -116,6 +140,7 @@ async function probeSide(
     timeoutMs: number;
     fetcher: typeof fetch;
     checkBody: boolean;
+    checkHeaders: string[];
   },
 ): Promise<SideResult> {
   const url = joinBase(base, path);
@@ -130,6 +155,13 @@ async function probeSide(
       status: resp.status,
       location: resp.headers.get("location"),
     };
+    if (opts.checkHeaders.length > 0) {
+      const out: Record<string, string | null> = {};
+      for (const name of opts.checkHeaders) {
+        out[name] = resp.headers.get(name);
+      }
+      result.headers = out;
+    }
     if (opts.checkBody) {
       // Reading the body is part of the same timeout window — a slow
       // body trickle counts against the per-request budget so one
@@ -171,6 +203,16 @@ function classify(left: SideResult, right: SideResult): MismatchKind | null {
   ) {
     return "redirect";
   }
+  // Header comparison is opt-in (gated by `checkHeaders` length) and
+  // checked BEFORE body — a header drift (e.g. `cache-control`
+  // changing TTL) usually causes downstream symptoms whose body
+  // signal is downstream noise, so we report the header difference
+  // as the primary cause.
+  if (left.headers && right.headers) {
+    for (const name of Object.keys(left.headers)) {
+      if (left.headers[name] !== right.headers[name]) return "header";
+    }
+  }
   // Body comparison is opt-in (gated by `checkBody`) — both hashes
   // are only populated when the caller asked for it, so a missing
   // hash on either side disables this branch automatically.
@@ -189,6 +231,10 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   const timeoutMs = opts.timeoutMs ?? 10_000;
   const fetcher = opts.fetcher ?? fetch;
   const checkBody = opts.checkBody ?? false;
+  // Normalise header names to lowercase up front so the comparison
+  // can use `Headers.get()` (which is case-insensitive anyway) and
+  // the result map is keyed predictably for downstream consumers.
+  const checkHeaders = (opts.checkHeaders ?? []).map((h) => h.toLowerCase());
 
   const mismatches: ParityMismatch[] = [];
   const matches: ParityProbe[] = [];
@@ -196,7 +242,7 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   for (const path of opts.paths) {
     // Probe both sides in parallel — they're independent and the report
     // is symmetric, so there's no reason to serialise.
-    const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody };
+    const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody, checkHeaders };
     const [left, right] = await Promise.all([
       probeSide(opts.left, path, sideOpts),
       probeSide(opts.right, path, sideOpts),

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -91,14 +91,22 @@ export interface ParityProbe {
 }
 
 export interface ParityMismatch extends ParityProbe {
-  /** Mismatch kinds detected for this probe. A single probe can carry
-   *  multiple kinds (e.g. left fails + right returns 200 → both
-   *  "failure" and "status" depending on the consumer's view; we record
-   *  the strongest one). */
-  kind: MismatchKind;
   /**
-   * Localised body diff. Populated only on `kind: "body"` when both
-   * sides' bodies parsed as JSON. Carries up to ~50 path-level
+   * All mismatch kinds detected for this probe, ordered by precedence
+   * (status / failure → header → body → exception). Empty array can't
+   * happen — a probe with no detected drift goes into `matches`
+   * instead.
+   *
+   * Where a previous version exposed `kind: MismatchKind`, callers
+   * should use `kinds[0]` for the primary signal — but `kinds` lets
+   * a triager see ALL coexisting bugs at once (header + body + body
+   * shape all firing on the same path). Hiding the body drift behind
+   * the header drift was the bug.
+   */
+  kinds: MismatchKind[];
+  /**
+   * Localised body diff. Populated when `kinds` contains `"body"` and
+   * both sides' bodies parsed as JSON. Carries up to ~50 path-level
    * entries; a truncated flag fires when the diff overflows.
    */
   bodyDiff?: BodyDiffResult;
@@ -325,50 +333,49 @@ async function probeSide(
   }
 }
 
-function classify(left: SideResult, right: SideResult): MismatchKind | null {
+/**
+ * Detect every mismatch kind applicable to a (left, right) probe pair.
+ * Returns the kinds in precedence order so `kinds[0]` is the primary
+ * signal — but a triager with the full list sees overlapping bugs
+ * (e.g. header drift AND body drift on the same path) at once.
+ *
+ * Failure / status / redirect are still exclusive at the top of the
+ * chain: a connection-level or status-level difference means the
+ * downstream body/header inspection is comparing apples to oranges.
+ * Once those pass, header / body / exception can ALL fire and each
+ * gets reported.
+ */
+function classify(left: SideResult, right: SideResult): MismatchKind[] {
   const leftFailed = left.status === null;
   const rightFailed = right.status === null;
-  if (leftFailed !== rightFailed) return "failure";
-  if (leftFailed && rightFailed) {
-    // Both failed — not a parity mismatch per the feature request
-    // ("only one side fails"), so treat as a match. The caller can
-    // still see both error strings via the probe data if needed.
-    return null;
-  }
-  if (left.status !== right.status) return "status";
-  // Status matched. For 3xx, also check the redirect target.
+  if (leftFailed !== rightFailed) return ["failure"];
+  if (leftFailed && rightFailed) return []; // both failed → matched per spec
+  if (left.status !== right.status) return ["status"];
   if (
     typeof left.status === "number" &&
     left.status >= 300 &&
     left.status < 400 &&
     left.location !== right.location
   ) {
-    return "redirect";
+    return ["redirect"];
   }
-  // Header comparison is opt-in (gated by `checkHeaders` length) and
-  // checked BEFORE body — a header drift (e.g. `cache-control`
-  // changing TTL) usually causes downstream symptoms whose body
-  // signal is downstream noise, so we report the header difference
-  // as the primary cause.
+
+  const kinds: MismatchKind[] = [];
   if (left.headers && right.headers) {
     for (const name of Object.keys(left.headers)) {
-      if (left.headers[name] !== right.headers[name]) return "header";
+      if (left.headers[name] !== right.headers[name]) {
+        kinds.push("header");
+        break;
+      }
     }
   }
-  // Body comparison is opt-in (gated by `checkBody`) — both hashes
-  // are only populated when the caller asked for it, so a missing
-  // hash on either side disables this branch automatically.
   if (
     left.bodyHash !== undefined &&
     right.bodyHash !== undefined &&
     left.bodyHash !== right.bodyHash
   ) {
-    return "body";
+    kinds.push("body");
   }
-  // Exception comparison runs LAST — it's only meaningful when status
-  // / headers / body all matched (an HTTP-level difference already
-  // captures any browser symptoms it causes). Compare normalised
-  // error sets so source-location jitter doesn't false-positive.
   if (left.pageErrors && right.pageErrors) {
     const leftFp = new Set([
       ...left.pageErrors.map(fingerprintErrorMessage),
@@ -378,12 +385,18 @@ function classify(left: SideResult, right: SideResult): MismatchKind | null {
       ...right.pageErrors.map(fingerprintErrorMessage),
       ...(right.consoleErrors ?? []).map(fingerprintErrorMessage),
     ]);
-    if (leftFp.size !== rightFp.size) return "exception";
-    for (const fp of leftFp) {
-      if (!rightFp.has(fp)) return "exception";
+    let differs = leftFp.size !== rightFp.size;
+    if (!differs) {
+      for (const fp of leftFp) {
+        if (!rightFp.has(fp)) {
+          differs = true;
+          break;
+        }
+      }
     }
+    if (differs) kinds.push("exception");
   }
-  return null;
+  return kinds;
 }
 
 async function defaultBrowserLauncher(): Promise<BrowserLike> {
@@ -445,13 +458,14 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
       }
 
       const probe: ParityProbe = { path, left, right };
-      const kind = classify(left, right);
-      if (kind) {
-        const m: ParityMismatch = { ...probe, kind };
-        // Localise body drift to specific JSON paths when we have the
-        // bytes. Skipped for other kinds — a status mismatch's body
-        // delta is downstream noise the diff would just amplify.
-        if (kind === "body") {
+      const kinds = classify(left, right);
+      if (kinds.length > 0) {
+        const m: ParityMismatch = { ...probe, kinds };
+        // Localise body drift to specific JSON paths when both sides
+        // carry hashes and the kinds include "body". Other kinds
+        // (status / header / exception) don't need this — their
+        // primary signal is already actionable on its own.
+        if (kinds.includes("body")) {
           const diff = diffJsonBodies(leftProbe.bodyText, rightProbe.bodyText);
           if (diff) m.bodyDiff = diff;
         }

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -126,7 +126,19 @@ export interface ParityMismatch extends ParityProbe {
   bodyDiff?: BodyDiffResult;
 }
 
+/**
+ * Bumped when the report shape changes in a non-backwards-compatible
+ * way. Downstream consumers (dashboards, CI scripts, the agent loop)
+ * can reject reports of an unexpected version rather than silently
+ * mis-reading a renamed field. Additive changes (new optional fields,
+ * new `MismatchKind` values) do NOT bump this — they're behind
+ * opt-in flags.
+ */
+export const PARITY_REPORT_SCHEMA_VERSION = 1;
+
 export interface ParityReport {
+  /** Stable integer. See `PARITY_REPORT_SCHEMA_VERSION`. */
+  schemaVersion: number;
   left: string;
   right: string;
   pathsChecked: number;
@@ -558,6 +570,7 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   }
 
   return {
+    schemaVersion: PARITY_REPORT_SCHEMA_VERSION,
     left: opts.left,
     right: opts.right,
     pathsChecked: opts.paths.length,

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -40,7 +40,14 @@ export type MismatchKind =
    * mismatches. The bug class that's invisible to HTTP-layer probes.
    * Only fires when `checkExceptions` is enabled.
    */
-  | "exception";
+  | "exception"
+  /**
+   * Right was slower than left by more than the configured budget.
+   * Single-sample wall-clock — noisy by nature, so the threshold
+   * (`perfDeltaMs` and/or `perfRatio`) must be set explicitly. Pair
+   * with N-sample sweeping at the call site if you need percentiles.
+   */
+  | "perf";
 
 export interface SideResult {
   /** Final status. `null` when the fetch threw before getting a response. */
@@ -82,6 +89,13 @@ export interface SideResult {
    * deliberately ignored — chaosbringer's crawler does the same.
    */
   consoleErrors?: string[];
+  /**
+   * Wall-clock duration of the fetch, in milliseconds. Populated on
+   * every successful probe (free — we already have the start time
+   * before fetch). `undefined` when the probe failed before
+   * timing could be meaningful (DNS error, connection refused).
+   */
+  durationMs?: number;
 }
 
 export interface ParityProbe {
@@ -173,6 +187,23 @@ export interface RunParityOptions {
    * so consumers that don't opt in do not pay the install cost.
    */
   checkExceptions?: boolean;
+  /**
+   * Flag a `perf` mismatch when `right.durationMs - left.durationMs`
+   * exceeds this many milliseconds. Off when unset / 0. Single-sample
+   * wall-clock is noisy by nature — set the budget well above your
+   * jitter floor, or run multiple sweeps and check the percentile
+   * yourself. We don't ship N-sampling here because the right N is
+   * caller-specific.
+   */
+  perfDeltaMs?: number;
+  /**
+   * Flag a `perf` mismatch when `right.durationMs > left.durationMs * ratio`.
+   * Off when unset / 0 or when either side's duration is 0 (avoids
+   * divide-by-zero noise on instantly-cached responses). Composes with
+   * `perfDeltaMs` via OR — either threshold tripping fires the
+   * mismatch.
+   */
+  perfRatio?: number;
   /** Override fetch for testing. */
   fetcher?: typeof fetch;
   /**
@@ -291,6 +322,10 @@ async function probeSide(
   const url = joinBase(base, path);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  // Wall-clock timer wraps the full fetch including body read (when
+  // `checkBody` is on) — a slow-body side should NOT look faster than
+  // a fast-body one just because we stopped measuring at headers.
+  const startedAt = performance.now();
   try {
     const resp = await opts.fetcher(url, {
       redirect: opts.followRedirects ? "follow" : "manual",
@@ -319,6 +354,7 @@ async function probeSide(
       result.bodyHash = createHash("sha256").update(bytes).digest("hex");
       bodyText = new TextDecoder().decode(bytes);
     }
+    result.durationMs = performance.now() - startedAt;
     return { result, bodyText };
   } catch (err) {
     return {
@@ -333,6 +369,11 @@ async function probeSide(
   }
 }
 
+interface ClassifyOptions {
+  perfDeltaMs?: number;
+  perfRatio?: number;
+}
+
 /**
  * Detect every mismatch kind applicable to a (left, right) probe pair.
  * Returns the kinds in precedence order so `kinds[0]` is the primary
@@ -342,10 +383,14 @@ async function probeSide(
  * Failure / status / redirect are still exclusive at the top of the
  * chain: a connection-level or status-level difference means the
  * downstream body/header inspection is comparing apples to oranges.
- * Once those pass, header / body / exception can ALL fire and each
- * gets reported.
+ * Once those pass, header / body / exception / perf can ALL fire and
+ * each gets reported.
  */
-function classify(left: SideResult, right: SideResult): MismatchKind[] {
+function classify(
+  left: SideResult,
+  right: SideResult,
+  opts: ClassifyOptions = {},
+): MismatchKind[] {
   const leftFailed = left.status === null;
   const rightFailed = right.status === null;
   if (leftFailed !== rightFailed) return ["failure"];
@@ -395,6 +440,21 @@ function classify(left: SideResult, right: SideResult): MismatchKind[] {
       }
     }
     if (differs) kinds.push("exception");
+  }
+  // Perf comparison is OR-of-thresholds: either passing fires the
+  // mismatch. Skipped silently when either side has no duration
+  // (probe failed before timing was meaningful) or when no threshold
+  // is configured — leaves single-sample latency noise off by default.
+  if (
+    typeof left.durationMs === "number" &&
+    typeof right.durationMs === "number" &&
+    ((opts.perfDeltaMs && opts.perfDeltaMs > 0 && right.durationMs - left.durationMs > opts.perfDeltaMs) ||
+      (opts.perfRatio &&
+        opts.perfRatio > 0 &&
+        left.durationMs > 0 &&
+        right.durationMs > left.durationMs * opts.perfRatio))
+  ) {
+    kinds.push("perf");
   }
   return kinds;
 }
@@ -458,7 +518,10 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
       }
 
       const probe: ParityProbe = { path, left, right };
-      const kinds = classify(left, right);
+      const kinds = classify(left, right, {
+        perfDeltaMs: opts.perfDeltaMs,
+        perfRatio: opts.perfRatio,
+      });
       if (kinds.length > 0) {
         const m: ParityMismatch = { ...probe, kinds };
         // Localise body drift to specific JSON paths when both sides

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -31,7 +31,15 @@ export type MismatchKind =
    * Status agreed but one or more of the named response headers
    * differ. Only fires when `checkHeaders` is non-empty.
    */
-  | "header";
+  | "header"
+  /**
+   * Status / body / headers all agreed (or weren't checked) but a
+   * browser visit to one side surfaced JavaScript errors the other
+   * side did not — uncaught exceptions, console.error, hydration
+   * mismatches. The bug class that's invisible to HTTP-layer probes.
+   * Only fires when `checkExceptions` is enabled.
+   */
+  | "exception";
 
 export interface SideResult {
   /** Final status. `null` when the fetch threw before getting a response. */
@@ -61,6 +69,18 @@ export interface SideResult {
    * distinguish "missing" from "empty".
    */
   headers?: Record<string, string | null>;
+  /**
+   * Uncaught page errors (`window.onerror` / Playwright's `pageerror`
+   * event) captured during a browser visit. Populated only when
+   * `checkExceptions` is enabled.
+   */
+  pageErrors?: string[];
+  /**
+   * `console.error` lines captured during a browser visit. Populated
+   * only when `checkExceptions` is enabled. Console *warnings* are
+   * deliberately ignored — chaosbringer's crawler does the same.
+   */
+  consoleErrors?: string[];
 }
 
 export interface ParityProbe {
@@ -122,14 +142,113 @@ export interface RunParityOptions {
    * which headers actually matter to their app.
    */
   checkHeaders?: string[];
+  /**
+   * When `true`, each path is also visited in a real browser (Chromium)
+   * and uncaught page errors + `console.error` are recorded. The
+   * comparison fires "exception" when the captured error sets differ
+   * between sides — catches React hydration mismatches and other
+   * runtime-only failures where HTTP looks identical.
+   *
+   * Cost is dominant: one browser visit per side per path is orders
+   * of magnitude slower than the fetch probe. Browsers are reused
+   * across paths via a single launch; per-path isolation comes from
+   * a fresh `BrowserContext`.
+   *
+   * Playwright is loaded via dynamic import only when this is set,
+   * so consumers that don't opt in do not pay the install cost.
+   */
+  checkExceptions?: boolean;
   /** Override fetch for testing. */
   fetcher?: typeof fetch;
+  /**
+   * Override the browser launcher for testing. The default lazy-loads
+   * `playwright.chromium.launch()`. A test can pass a fake that
+   * produces canned `pageErrors` / `consoleErrors` per URL without
+   * actually starting Chromium.
+   */
+  browserLauncher?: () => Promise<BrowserLike>;
+}
+
+// ─── Browser abstraction (minimal subset of Playwright Page used here)
+//
+// The real `Browser` / `Page` types come from `playwright` and are huge.
+// We declare only the slice the parity probe actually touches, so test
+// doubles stay tiny and the integration boundary stays explicit.
+
+export interface PageLike {
+  on(event: "pageerror", handler: (err: Error) => void): void;
+  on(event: "console", handler: (msg: ConsoleMessageLike) => void): void;
+  goto(url: string, opts?: { timeout?: number; waitUntil?: string }): Promise<unknown>;
+  waitForLoadState?(
+    state: string,
+    opts?: { timeout?: number },
+  ): Promise<void>;
+}
+interface ConsoleMessageLike {
+  type(): string;
+  text(): string;
+}
+export interface ContextLike {
+  newPage(): Promise<PageLike>;
+  close(): Promise<void>;
+}
+export interface BrowserLike {
+  newContext(): Promise<ContextLike>;
+  close(): Promise<void>;
 }
 
 function joinBase(base: string, path: string): string {
   // Both `<base>/foo` and `<base>foo` are common in path files. Normalise
   // so we never double-slash or miss-slash. URL parses both cleanly.
   return new URL(path, base.endsWith("/") ? base : `${base}/`).toString();
+}
+
+/**
+ * Normalise an error message so two runs of the same bug collapse into
+ * the same string. Mirrors `clusterErrors`'s fingerprint logic but kept
+ * inline so parity stays free of a cross-module dependency on the
+ * crawler.
+ */
+function fingerprintErrorMessage(msg: string): string {
+  return msg
+    .replace(/https?:\/\/[^\s"'()<>]+/g, "<url>")
+    .replace(/:\d+:\d+/g, ":<loc>")
+    .replace(/\b\d{3,}\b/g, "<n>")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function probeBrowserSide(
+  browser: BrowserLike,
+  url: string,
+  timeoutMs: number,
+): Promise<{ pageErrors: string[]; consoleErrors: string[] }> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  try {
+    await page.goto(url, { timeout: timeoutMs, waitUntil: "load" });
+    // Best-effort idle wait so async errors (post-load fetch failures,
+    // micro-task throwers) surface before we tear the page down. The
+    // catch swallows the inevitable timeout on apps that never idle.
+    if (page.waitForLoadState) {
+      await page.waitForLoadState("networkidle", { timeout: 1000 }).catch(() => {
+        // ignored: networkidle didn't settle within 1s — fine, we have what we have
+      });
+    }
+  } catch {
+    // Navigation errors (DNS, connection refused, etc.) are already
+    // reported by the fetch probe via the "failure" kind. We don't
+    // double-report them here.
+  } finally {
+    await ctx.close();
+  }
+  return { pageErrors, consoleErrors };
 }
 
 async function probeSide(
@@ -223,7 +342,34 @@ function classify(left: SideResult, right: SideResult): MismatchKind | null {
   ) {
     return "body";
   }
+  // Exception comparison runs LAST — it's only meaningful when status
+  // / headers / body all matched (an HTTP-level difference already
+  // captures any browser symptoms it causes). Compare normalised
+  // error sets so source-location jitter doesn't false-positive.
+  if (left.pageErrors && right.pageErrors) {
+    const leftFp = new Set([
+      ...left.pageErrors.map(fingerprintErrorMessage),
+      ...(left.consoleErrors ?? []).map(fingerprintErrorMessage),
+    ]);
+    const rightFp = new Set([
+      ...right.pageErrors.map(fingerprintErrorMessage),
+      ...(right.consoleErrors ?? []).map(fingerprintErrorMessage),
+    ]);
+    if (leftFp.size !== rightFp.size) return "exception";
+    for (const fp of leftFp) {
+      if (!rightFp.has(fp)) return "exception";
+    }
+  }
   return null;
+}
+
+async function defaultBrowserLauncher(): Promise<BrowserLike> {
+  // Dynamic import keeps Playwright off the import graph for users
+  // who never enable `checkExceptions`. TS doesn't follow the dynamic
+  // string into the package, so we narrow to BrowserLike at runtime.
+  const pw = await import("playwright");
+  const browser = await pw.chromium.launch({ headless: true });
+  return browser as unknown as BrowserLike;
 }
 
 export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
@@ -235,22 +381,53 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   // can use `Headers.get()` (which is case-insensitive anyway) and
   // the result map is keyed predictably for downstream consumers.
   const checkHeaders = (opts.checkHeaders ?? []).map((h) => h.toLowerCase());
+  const checkExceptions = opts.checkExceptions ?? false;
+
+  // Browser launch is amortised across all paths — one Chromium for
+  // the whole run, fresh context per visit. Only fires when
+  // checkExceptions is enabled so non-browser runs stay zero-cost.
+  let browser: BrowserLike | null = null;
+  if (checkExceptions) {
+    const launcher = opts.browserLauncher ?? defaultBrowserLauncher;
+    browser = await launcher();
+  }
 
   const mismatches: ParityMismatch[] = [];
   const matches: ParityProbe[] = [];
 
-  for (const path of opts.paths) {
-    // Probe both sides in parallel — they're independent and the report
-    // is symmetric, so there's no reason to serialise.
-    const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody, checkHeaders };
-    const [left, right] = await Promise.all([
-      probeSide(opts.left, path, sideOpts),
-      probeSide(opts.right, path, sideOpts),
-    ]);
-    const probe: ParityProbe = { path, left, right };
-    const kind = classify(left, right);
-    if (kind) mismatches.push({ ...probe, kind });
-    else matches.push(probe);
+  try {
+    for (const path of opts.paths) {
+      // Probe both sides in parallel — they're independent and the report
+      // is symmetric, so there's no reason to serialise.
+      const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody, checkHeaders };
+      const [left, right] = await Promise.all([
+        probeSide(opts.left, path, sideOpts),
+        probeSide(opts.right, path, sideOpts),
+      ]);
+
+      if (browser) {
+        // Browser visits are slower (~1s+ per page) and must use real
+        // resolution against the live server. Serial per-side to avoid
+        // hammering one server; parallel across sides for symmetry.
+        const [bLeft, bRight] = await Promise.all([
+          probeBrowserSide(browser, joinBase(opts.left, path), timeoutMs),
+          probeBrowserSide(browser, joinBase(opts.right, path), timeoutMs),
+        ]);
+        left.pageErrors = bLeft.pageErrors;
+        left.consoleErrors = bLeft.consoleErrors;
+        right.pageErrors = bRight.pageErrors;
+        right.consoleErrors = bRight.consoleErrors;
+      }
+
+      const probe: ParityProbe = { path, left, right };
+      const kind = classify(left, right);
+      if (kind) mismatches.push({ ...probe, kind });
+      else matches.push(probe);
+    }
+  } finally {
+    // Always tear down — leaking a Chromium across CI runs is a
+    // multi-hundred-MB-each kind of leak.
+    if (browser) await browser.close();
   }
 
   return {

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -1,18 +1,19 @@
 /**
  * Non-random parity probe. For each path in a list, fetch the same path
  * against two base URLs and surface differences in status, redirect
- * target, and request failure. This is the routing-bug detection mode
- * — when random crawls find too much third-party noise, a deterministic
- * same-path probe across two runtimes pinpoints where the routes
- * actually disagree.
+ * target, request failure, and (opt-in) response-body content. This is
+ * the routing-bug detection mode — when random crawls find too much
+ * third-party noise, a deterministic same-path probe across two
+ * runtimes pinpoints where the routes actually disagree.
  *
- * Scope: HTTP request-level only (status codes, redirect locations,
- * fetch failures). JavaScript exceptions and body predicates from the
- * original feature request would need a Playwright session per probe
- * and are deferred — the fetch-based subset covers the three top-listed
- * comparisons (status mismatch / redirect mismatch / failed request
- * mismatch) without paying the browser-launch tax.
+ * Scope: HTTP request-level (status, Location, fetch failures) is
+ * always-on. Body-content drift is opt-in via `checkBody` because the
+ * body fetch doubles the work per probe and most consumers care first
+ * about status. JavaScript exceptions still need a Playwright session
+ * per probe and are deferred.
  */
+
+import { createHash } from "node:crypto";
 
 export type MismatchKind =
   /** HTTP status codes differ. */
@@ -20,7 +21,12 @@ export type MismatchKind =
   /** One side redirected to a different Location than the other. */
   | "redirect"
   /** fetch() threw on one side and succeeded on the other. */
-  | "failure";
+  | "failure"
+  /**
+   * Status agreed but the response body bytes differ. Only fires when
+   * `checkBody` is enabled in the run options.
+   */
+  | "body";
 
 export interface SideResult {
   /** Final status. `null` when the fetch threw before getting a response. */
@@ -29,6 +35,20 @@ export interface SideResult {
   location?: string | null;
   /** Captured fetch error message when the request threw. */
   error?: string;
+  /**
+   * Response body size in bytes. Populated only when `checkBody` is
+   * enabled. Lets a consumer of the JSON report see at a glance how
+   * different the two sides are without needing to refetch.
+   */
+  bodyLength?: number;
+  /**
+   * SHA-256 of the raw body bytes, lowercase hex. Populated only when
+   * `checkBody` is enabled. Used by `classify()` to detect drift; also
+   * carried in the JSON report so consumers can tell whether the
+   * mismatch reproduces across reruns (same pair of hashes → real
+   * drift, not flakiness).
+   */
+  bodyHash?: string;
 }
 
 export interface ParityProbe {
@@ -71,6 +91,13 @@ export interface RunParityOptions {
    * independently; one slow side does not stall the other.
    */
   timeoutMs?: number;
+  /**
+   * When `true`, the body of each response is read and compared by
+   * SHA-256 hash. Adds one full body read per side per path, so it's
+   * opt-in. Required to catch silent schema drift like a missing JSON
+   * field that doesn't move the status code.
+   */
+  checkBody?: boolean;
   /** Override fetch for testing. */
   fetcher?: typeof fetch;
 }
@@ -84,7 +111,12 @@ function joinBase(base: string, path: string): string {
 async function probeSide(
   base: string,
   path: string,
-  opts: { followRedirects: boolean; timeoutMs: number; fetcher: typeof fetch },
+  opts: {
+    followRedirects: boolean;
+    timeoutMs: number;
+    fetcher: typeof fetch;
+    checkBody: boolean;
+  },
 ): Promise<SideResult> {
   const url = joinBase(base, path);
   const controller = new AbortController();
@@ -94,10 +126,21 @@ async function probeSide(
       redirect: opts.followRedirects ? "follow" : "manual",
       signal: controller.signal,
     });
-    return {
+    const result: SideResult = {
       status: resp.status,
       location: resp.headers.get("location"),
     };
+    if (opts.checkBody) {
+      // Reading the body is part of the same timeout window — a slow
+      // body trickle counts against the per-request budget so one
+      // stuck side can't stall the report indefinitely. Hash on the
+      // raw bytes (not decoded text) so binary responses work without
+      // a content-type-aware decoder.
+      const bytes = new Uint8Array(await resp.arrayBuffer());
+      result.bodyLength = bytes.byteLength;
+      result.bodyHash = createHash("sha256").update(bytes).digest("hex");
+    }
+    return result;
   } catch (err) {
     return {
       status: null,
@@ -128,6 +171,16 @@ function classify(left: SideResult, right: SideResult): MismatchKind | null {
   ) {
     return "redirect";
   }
+  // Body comparison is opt-in (gated by `checkBody`) — both hashes
+  // are only populated when the caller asked for it, so a missing
+  // hash on either side disables this branch automatically.
+  if (
+    left.bodyHash !== undefined &&
+    right.bodyHash !== undefined &&
+    left.bodyHash !== right.bodyHash
+  ) {
+    return "body";
+  }
   return null;
 }
 
@@ -135,6 +188,7 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   const followRedirects = opts.followRedirects ?? false;
   const timeoutMs = opts.timeoutMs ?? 10_000;
   const fetcher = opts.fetcher ?? fetch;
+  const checkBody = opts.checkBody ?? false;
 
   const mismatches: ParityMismatch[] = [];
   const matches: ParityProbe[] = [];
@@ -142,9 +196,10 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   for (const path of opts.paths) {
     // Probe both sides in parallel — they're independent and the report
     // is symmetric, so there's no reason to serialise.
+    const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody };
     const [left, right] = await Promise.all([
-      probeSide(opts.left, path, { followRedirects, timeoutMs, fetcher }),
-      probeSide(opts.right, path, { followRedirects, timeoutMs, fetcher }),
+      probeSide(opts.left, path, sideOpts),
+      probeSide(opts.right, path, sideOpts),
     ]);
     const probe: ParityProbe = { path, left, right };
     const kind = classify(left, right);

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,4 @@
+reports/
+artifacts/
+node_modules/
+*.log

--- a/playground/README.md
+++ b/playground/README.md
@@ -32,10 +32,36 @@ pnpm loop chaos          # crawl v1 + v2 + diff only
 
 Outputs land in:
 
-- `reports/parity.json` — full parity report (status / redirect / failure mismatches)
+- `reports/parity.json` — full parity report (status / redirect / failure / header / body / exception / perf mismatches)
+- `reports/journey-*.json` — one per journey file (write-then-read, capture-by-id, tenant-isolation)
 - `reports/v1.json` / `reports/v2.json` — chaosbringer crawl reports
 - `artifacts/v1/` / `artifacts/v2/` — per-page failure bundles
 - `artifacts/{v1,v2}/clusters/` — one representative bundle per error cluster (via `--cluster-artifacts`)
+
+`pnpm loop` ends with a `=== summary ===` table tallying mismatches by kind across every report, so a CI gate has a single line to grep on.
+
+## Parity check kinds
+
+A single `chaosbringer parity` invocation can opt into any subset of:
+
+| Flag                                | Catches                                                  |
+| ----------------------------------- | -------------------------------------------------------- |
+| (always on)                         | status / redirect / one-sided failure                    |
+| `--check-body`                      | byte hash differs; JSON-aware diff names which field     |
+| `--check-headers <list>`            | named response headers differ (CORS / cache-control)     |
+| `--check-exceptions`                | uncaught JS errors + console.error from a browser visit  |
+| `--perf-delta-ms <n>`               | right slower than left by more than N ms (single-sample) |
+| `--perf-ratio <n>`                  | right > left × N (composes with `--perf-delta-ms` via OR) |
+
+Every detected kind for a probe fires — they don't shadow each other. A path with both a header drift and a body drift prints both lines (and the JSON carries `kinds: ["header","body"]`).
+
+## Journey: multi-step + per-actor
+
+`chaosbringer journey --steps file.json` replays a sequence with per-side cookie jars. Each step accepts:
+
+- `method`, `path`, `body`, `headers`, `label` — standard request shape.
+- `capture: [{ from: "body.id", as: "todoId" }]` — extract a value from the response and bind it as a variable on the side it ran on. `{{todoId}}` in later steps' path / body / headers is substituted before sending.
+- `actor: "alice"` — per-side, per-actor cookie jar + variable bag. Lets a journey verify tenant isolation: Alice creates a doc, Bob lists his docs, Bob must not see Alice's payload.
 
 ## Exercise individual fault kinds
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,79 @@
+# Dogfood playground
+
+Two variants of a small Hono app, served on different ports, with intentional divergences seeded for the recently-shipped chaosbringer tools to find. Designed to drive a sub-agent improvement loop: the agent runs the tools, reads the output, proposes (or applies) fixes, re-runs, and confirms.
+
+## Layout
+
+| File           | Role                                                                                   |
+| -------------- | -------------------------------------------------------------------------------------- |
+| `server.ts`    | The app. Same code path for v1/v2 — divergences gated on `VARIANT` env var.            |
+| `paths.txt`    | Path list for `chaosbringer parity`. Comments document each seeded divergence.         |
+| `loop.ts`      | Orchestrator: spawns both variants, runs the toolchain, tears down, reports exit code. |
+| `BUG_LEDGER`   | (Exported from `server.ts`) the grading rubric of seeded bugs.                         |
+
+The bug ledger is in source, not docs, because it has to stay in sync with the actual divergence branches.
+
+## Run the loop
+
+```bash
+pnpm install
+cd playground
+
+# Full pass — both server variants up, parity + crawls + diff
+pnpm loop
+
+# Or pieces
+pnpm loop parity         # parity probe only
+pnpm loop chaos          # crawl v1 + v2 + diff only
+
+# Exit code is non-zero when the loop detected something (parity
+# mismatch, new clusters on v2, etc.) — drop into reports/ to see.
+```
+
+Outputs land in:
+
+- `reports/parity.json` — full parity report (status / redirect / failure mismatches)
+- `reports/v1.json` / `reports/v2.json` — chaosbringer crawl reports
+- `artifacts/v1/` / `artifacts/v2/` — per-page failure bundles
+- `artifacts/{v1,v2}/clusters/` — one representative bundle per error cluster (via `--cluster-artifacts`)
+
+## Exercise individual fault kinds
+
+Every fault kind shipped on this PR is reachable via env vars passed to either variant. Examples:
+
+```bash
+# Probabilistic 5xx + abort
+CHAOS_5XX_RATE=0.1 CHAOS_ABORT_RATE=0.05 pnpm dev:v1
+
+# Windowed 5xx (5 sec sick / 25 sec healthy)
+CHAOS_FLAP_WINDOW=30000 CHAOS_FLAP_BAD=5000 pnpm dev:v1
+
+# Partial response (truncate body after 32 bytes for 20% of requests)
+CHAOS_PARTIAL_RATE=0.2 CHAOS_PARTIAL_AFTER=32 pnpm dev:v1
+
+# Slow streaming (100 ms between chunks, rechunk to 16-byte pieces)
+CHAOS_SLOW_RATE=0.3 CHAOS_SLOW_DELAY=100 CHAOS_SLOW_CHUNK=16 pnpm dev:v1
+```
+
+Health checks (`/health`) are always exempt — they'd flap the readiness signal otherwise. `x-chaos-bypass: 1` header bypasses chaos per request (useful for warm-up / fixture probes).
+
+## Sub-agent prompt template
+
+Hand this to an Agent invocation (general-purpose / claude). The agent should NOT read `server.ts` until after it has reported its findings — peeking at `BUG_LEDGER` defeats the dogfood point.
+
+> You have a chaosbringer playground at `playground/` with two variants of the same app (v1 reference, v2 with seeded divergences). Your job:
+>
+> 1. `cd playground && pnpm loop` — runs parity + chaos crawl + diff against both variants.
+> 2. Read `reports/parity.json` and the printed diff output. Identify each distinct divergence.
+> 3. For each divergence, write a one-sentence diagnosis (route bug? client-side error? schema drift?) and the evidence that backs it (the specific report field or artifact path).
+> 4. **Do not modify code.** Report your findings in a markdown table with columns `id | symptom | evidence | tool that caught it`.
+>
+> Cap your write-up at 300 words. After you submit, the user will reveal `BUG_LEDGER` and grade.
+
+## Closing the improvement loop
+
+The "improvement" half is a separate Agent invocation:
+
+> You found divergences X, Y, Z (passed in as a list with file:line evidence). Propose minimal code changes to `playground/server.ts` that close them. Run `pnpm loop` after each fix. Stop when the loop exits 0.
+
+Keeping investigation and fix as separate agent runs avoids context pollution and matches the human triage workflow.

--- a/playground/README.md
+++ b/playground/README.md
@@ -65,7 +65,25 @@ Every detected kind for a probe fires — they don't shadow each other. A path w
 
 ## Exercise individual fault kinds
 
-Every fault kind shipped on this PR is reachable via env vars passed to either variant. Examples:
+Every fault kind shipped by `@mizchi/server-faults` is reachable via env vars passed to either variant. Leave a var unset and that fault stays off.
+
+| Env var                 | Maps to                                       |
+| ----------------------- | --------------------------------------------- |
+| `CHAOS_5XX_RATE`        | `status5xxRate` (0..1)                        |
+| `CHAOS_5XX_CODE`        | `status5xxCode` (500 / 502 / 503 / 504)       |
+| `CHAOS_LATENCY_RATE`    | `latencyRate` (0..1)                          |
+| `CHAOS_LATENCY_MS`      | `latencyMs` (constant ms)                     |
+| `CHAOS_ABORT_RATE`      | `abortRate` (0..1)                            |
+| `CHAOS_ABORT_STYLE`     | `abortStyle` (`hangup` / `reset`)             |
+| `CHAOS_PARTIAL_RATE`    | `partialResponseRate` (0..1, Hono only)       |
+| `CHAOS_PARTIAL_AFTER`   | `partialResponseAfterBytes`                   |
+| `CHAOS_SLOW_RATE`       | `slowStreaming.rate` (0..1, Hono only)        |
+| `CHAOS_SLOW_DELAY`      | `slowStreaming.chunkDelayMs`                  |
+| `CHAOS_SLOW_CHUNK`      | `slowStreaming.chunkSize` (rechunk to N bytes) |
+| `CHAOS_FLAP_WINDOW`     | `statusFlapping.windowMs` (cycle length)      |
+| `CHAOS_FLAP_BAD`        | `statusFlapping.badMs` (sick slice per cycle) |
+
+Examples:
 
 ```bash
 # Probabilistic 5xx + abort

--- a/playground/journey-by-id.json
+++ b/playground/journey-by-id.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Demonstrates BUG-8: per-side capture/templating. Step 0 (POST) returns 201 + id; identical on both sides. Step 1 (GET /api/todos/{{todoId}}) resolves each side's own captured id, and v2 returns the title UPPERCASED. Single-shot parity could never hit /api/todos/<id> because <id> is server-assigned.",
+  "steps": [
+    {
+      "method": "POST",
+      "path": "/api/todos",
+      "body": { "title": "buy milk" },
+      "capture": [{ "from": "body.id", "as": "todoId" }],
+      "label": "create"
+    },
+    { "method": "GET", "path": "/api/todos/{{todoId}}", "label": "read-by-id" }
+  ]
+}

--- a/playground/journey-tenant-isolation.json
+++ b/playground/journey-tenant-isolation.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Demonstrates BUG-10: tenant isolation breach on v2. Alice and Bob each have their own session (driven by per-actor cookie jar). Alice creates a 'secret' doc. Bob lists his own docs. On v1 Bob sees nothing; on v2 Bob sees Alice's secret because v2 ignores the session cookie. The mismatch fires on the bob-lists step.",
+  "steps": [
+    { "method": "POST", "path": "/api/session", "body": { "user": "alice" }, "actor": "alice", "label": "alice-login" },
+    { "method": "POST", "path": "/api/docs", "body": { "title": "alice-secret" }, "actor": "alice", "label": "alice-creates" },
+    { "method": "POST", "path": "/api/session", "body": { "user": "bob" }, "actor": "bob", "label": "bob-login" },
+    { "method": "GET", "path": "/api/docs", "actor": "bob", "label": "bob-lists" }
+  ]
+}

--- a/playground/journey-todos.json
+++ b/playground/journey-todos.json
@@ -1,7 +1,7 @@
 {
-  "_comment": "Demonstrates BUG-7: silent write drop on v2. Step 0 (POST) matches on both sides — both return 201 with the created todo. Step 1 (GET) diverges because v2 didn't actually persist. Single-shot parity on either path alone would miss this; only the stateful sequence reveals it.",
+  "_comment": "Demonstrates BUG-7: silent write drop on v2 when the title is prefixed with 'drop:'. Step 0 (POST) returns 201 on both sides; Step 1 (GET list) diverges because v2 didn't persist. Single-shot parity on either path alone would miss this.",
   "steps": [
-    { "method": "POST", "path": "/api/todos", "body": { "title": "buy milk" }, "label": "create-todo" },
+    { "method": "POST", "path": "/api/todos", "body": { "title": "drop: groceries" }, "label": "create-todo" },
     { "method": "GET", "path": "/api/todos", "label": "list-after-create" }
   ]
 }

--- a/playground/journey-todos.json
+++ b/playground/journey-todos.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Demonstrates BUG-7: silent write drop on v2. Step 0 (POST) matches on both sides — both return 201 with the created todo. Step 1 (GET) diverges because v2 didn't actually persist. Single-shot parity on either path alone would miss this; only the stateful sequence reveals it.",
+  "steps": [
+    { "method": "POST", "path": "/api/todos", "body": { "title": "buy milk" }, "label": "create-todo" },
+    { "method": "GET", "path": "/api/todos", "label": "list-after-create" }
+  ]
+}

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -20,7 +20,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 
 const PORT_V1 = 5001;
@@ -166,7 +166,54 @@ async function main(): Promise<void> {
     // Give them a moment so the process group is gone before exit.
     await sleep(200);
   }
+  printSummary();
   process.exit(exitCode);
+}
+
+/**
+ * Read every JSON report under `reports/` and tally up mismatches by
+ * `MismatchKind`. Prints a table at the end of the loop so an
+ * operator (or sub-agent) sees the overall shape at a glance —
+ * useful as the CI gate's "did this run get worse" signal.
+ */
+function printSummary(): void {
+  if (!existsSync(REPORTS)) return;
+  type ReportShape = {
+    mismatches?: Array<{ kinds?: string[]; path?: string; label?: string }>;
+  };
+  const counts = new Map<string, number>();
+  const detail: Array<{ source: string; where: string; kinds: string[] }> = [];
+  const reports = ["parity.json", "journey-todos.json", "journey-by-id.json", "journey-tenant-isolation.json"];
+  for (const name of reports) {
+    const path = `${REPORTS}/${name}`;
+    if (!existsSync(path)) continue;
+    let parsed: ReportShape;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf-8")) as ReportShape;
+    } catch {
+      continue;
+    }
+    for (const m of parsed.mismatches ?? []) {
+      const where = m.path ?? m.label ?? "?";
+      const kinds = m.kinds ?? [];
+      detail.push({ source: name, where, kinds });
+      for (const k of kinds) counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+  }
+  if (counts.size === 0) {
+    console.log("\n=== summary === no mismatches");
+    return;
+  }
+  console.log("\n=== summary ===");
+  // Stable order: by precedence-ish then alphabetical.
+  const order = ["status", "failure", "redirect", "header", "body", "exception", "perf"];
+  const sortedKinds = Array.from(counts.keys()).sort(
+    (a, b) => order.indexOf(a) - order.indexOf(b),
+  );
+  for (const k of sortedKinds) {
+    console.log(`  ${k.padEnd(10)} ${counts.get(k)}`);
+  }
+  console.log(`  ${"TOTAL".padEnd(10)} ${detail.length} finding(s) across ${detail.length} kind-occurrences`);
 }
 
 main().catch((err) => {

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -96,6 +96,11 @@ async function main(): Promise<void> {
         "--check-headers",
         "content-type,cache-control",
         "--check-exceptions",
+        // Generous budget — single-sample wall-clock has jitter even
+        // for fast localhost loops. The seeded BUG-9 sleeps 120ms,
+        // well above this floor.
+        "--perf-delta-ms",
+        "50",
       ]);
       if (code !== 0) exitCode = 1;
     }

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -90,6 +90,9 @@ async function main(): Promise<void> {
         "paths.txt",
         "--output",
         `${REPORTS}/parity.json`,
+        // Opt into body comparison so JSON-shape drift surfaces as a
+        // first-class mismatch alongside status/redirect/failure.
+        "--check-body",
       ]);
       if (code !== 0) exitCode = 1;
     }

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -1,0 +1,142 @@
+/**
+ * One-shot dogfood loop orchestrator.
+ *
+ * Spawns both server variants on their fixed ports, waits for /health
+ * to come up on each, runs the suite of chaosbringer tools against
+ * them, prints a summary, and tears down. Designed for sub-agent
+ * invocation: a single `tsx loop.ts` produces the artefacts the agent
+ * inspects (reports/, artifacts/, parity output) without the agent
+ * having to manage processes.
+ *
+ * Usage:
+ *   tsx loop.ts             # full pass (parity + chaos:v1 + chaos:v2 + diff)
+ *   tsx loop.ts parity      # only parity
+ *   tsx loop.ts chaos       # only chaos crawls + diff
+ *
+ * Exit code:
+ *   0 — nothing the loop detected (no parity mismatches, no new clusters)
+ *   1 — at least one tool reported a deviation. Look in reports/ and
+ *       artifacts/clusters/ for evidence.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const PORT_V1 = 5001;
+const PORT_V2 = 5002;
+const REPORTS = "reports";
+const ARTIFACTS = "artifacts";
+
+const mode = (process.argv[2] ?? "all") as "all" | "parity" | "chaos";
+
+async function waitForHealth(port: number, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/health`);
+      if (r.ok) return;
+    } catch {
+      // not up yet
+    }
+    await sleep(150);
+  }
+  throw new Error(`server on :${port} never became healthy`);
+}
+
+function startVariant(variant: "v1" | "v2", port: number): ChildProcess {
+  const child = spawn("tsx", ["server.ts"], {
+    env: { ...process.env, VARIANT: variant, PORT: String(port) },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  child.on("error", (err) => {
+    console.error(`[${variant}] spawn error:`, err);
+  });
+  return child;
+}
+
+async function runCli(args: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn("pnpm", ["exec", "chaosbringer", ...args], {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    child.on("close", (code) => resolve(code ?? 0));
+  });
+}
+
+async function main(): Promise<void> {
+  // Fresh outputs every run so an agent looking at the directory sees
+  // only what THIS pass produced — no stale clusters from a previous fix.
+  rmSync(REPORTS, { recursive: true, force: true });
+  rmSync(ARTIFACTS, { recursive: true, force: true });
+  mkdirSync(REPORTS, { recursive: true });
+  mkdirSync(ARTIFACTS, { recursive: true });
+
+  const v1 = startVariant("v1", PORT_V1);
+  const v2 = startVariant("v2", PORT_V2);
+  let exitCode = 0;
+  try {
+    await Promise.all([waitForHealth(PORT_V1), waitForHealth(PORT_V2)]);
+
+    if (mode === "all" || mode === "parity") {
+      console.log("\n=== parity probe ===");
+      const code = await runCli([
+        "parity",
+        "--left",
+        `http://127.0.0.1:${PORT_V1}`,
+        "--right",
+        `http://127.0.0.1:${PORT_V2}`,
+        "--paths",
+        "paths.txt",
+        "--output",
+        `${REPORTS}/parity.json`,
+      ]);
+      if (code !== 0) exitCode = 1;
+    }
+
+    if (mode === "all" || mode === "chaos") {
+      for (const [variant, port] of [
+        ["v1", PORT_V1],
+        ["v2", PORT_V2],
+      ] as const) {
+        console.log(`\n=== chaos crawl: ${variant} ===`);
+        await runCli([
+          "--url",
+          `http://127.0.0.1:${port}`,
+          "--seed",
+          "42",
+          "--max-pages",
+          "8",
+          "--max-actions",
+          "2",
+          "--output",
+          `${REPORTS}/${variant}.json`,
+          "--failure-artifacts",
+          `${ARTIFACTS}/${variant}`,
+          "--cluster-artifacts",
+          "--ignore-preset",
+          "analytics",
+          "--compact",
+        ]);
+      }
+      console.log("\n=== chaos diff (v1 vs v2) ===");
+      const code = await runCli([
+        "diff",
+        `${REPORTS}/v1.json`,
+        `${REPORTS}/v2.json`,
+      ]);
+      if (code !== 0) exitCode = 1;
+    }
+  } finally {
+    v1.kill("SIGTERM");
+    v2.kill("SIGTERM");
+    // Give them a moment so the process group is gone before exit.
+    await sleep(200);
+  }
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error("loop failed:", err);
+  process.exit(2);
+});

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -101,19 +101,21 @@ async function main(): Promise<void> {
     }
 
     if (mode === "all" || mode === "parity" || mode === "journey") {
-      console.log("\n=== journey: write-then-read ===");
-      const code = await runCli([
-        "journey",
-        "--left",
-        `http://127.0.0.1:${PORT_V1}`,
-        "--right",
-        `http://127.0.0.1:${PORT_V2}`,
-        "--steps",
-        "journey-todos.json",
-        "--output",
-        `${REPORTS}/journey-todos.json`,
-      ]);
-      if (code !== 0) exitCode = 1;
+      for (const file of ["journey-todos.json", "journey-by-id.json"]) {
+        console.log(`\n=== journey: ${file} ===`);
+        const code = await runCli([
+          "journey",
+          "--left",
+          `http://127.0.0.1:${PORT_V1}`,
+          "--right",
+          `http://127.0.0.1:${PORT_V2}`,
+          "--steps",
+          file,
+          "--output",
+          `${REPORTS}/${file}`,
+        ]);
+        if (code !== 0) exitCode = 1;
+      }
     }
 
     if (mode === "all" || mode === "chaos") {

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -28,7 +28,7 @@ const PORT_V2 = 5002;
 const REPORTS = "reports";
 const ARTIFACTS = "artifacts";
 
-const mode = (process.argv[2] ?? "all") as "all" | "parity" | "chaos";
+const mode = (process.argv[2] ?? "all") as "all" | "parity" | "chaos" | "journey";
 
 async function waitForHealth(port: number, timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -96,6 +96,22 @@ async function main(): Promise<void> {
         "--check-headers",
         "content-type,cache-control",
         "--check-exceptions",
+      ]);
+      if (code !== 0) exitCode = 1;
+    }
+
+    if (mode === "all" || mode === "parity" || mode === "journey") {
+      console.log("\n=== journey: write-then-read ===");
+      const code = await runCli([
+        "journey",
+        "--left",
+        `http://127.0.0.1:${PORT_V1}`,
+        "--right",
+        `http://127.0.0.1:${PORT_V2}`,
+        "--steps",
+        "journey-todos.json",
+        "--output",
+        `${REPORTS}/journey-todos.json`,
       ]);
       if (code !== 0) exitCode = 1;
     }

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -106,7 +106,11 @@ async function main(): Promise<void> {
     }
 
     if (mode === "all" || mode === "parity" || mode === "journey") {
-      for (const file of ["journey-todos.json", "journey-by-id.json"]) {
+      for (const file of [
+        "journey-todos.json",
+        "journey-by-id.json",
+        "journey-tenant-isolation.json",
+      ]) {
         console.log(`\n=== journey: ${file} ===`);
         const code = await runCli([
           "journey",

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -90,9 +90,11 @@ async function main(): Promise<void> {
         "paths.txt",
         "--output",
         `${REPORTS}/parity.json`,
-        // Opt into body comparison so JSON-shape drift surfaces as a
-        // first-class mismatch alongside status/redirect/failure.
+        // Opt into body + header comparison so JSON-shape drift and
+        // header-policy drift both surface as first-class mismatches.
         "--check-body",
+        "--check-headers",
+        "content-type,cache-control",
       ]);
       if (code !== 0) exitCode = 1;
     }

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -90,11 +90,12 @@ async function main(): Promise<void> {
         "paths.txt",
         "--output",
         `${REPORTS}/parity.json`,
-        // Opt into body + header comparison so JSON-shape drift and
-        // header-policy drift both surface as first-class mismatches.
+        // Opt into body + header + browser comparison so the full
+        // spectrum of seeded bug classes surfaces in one pass.
         "--check-body",
         "--check-headers",
         "content-type,cache-control",
+        "--check-exceptions",
       ]);
       if (code !== 0) exitCode = 1;
     }

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@mizchi/chaosbringer-playground",
+  "private": true,
+  "type": "module",
+  "description": "Dogfooding playground: two Hono variants (v1/v2) with intentional divergences + server-faults wired for every fault kind. Drives the sub-agent improvement loop.",
+  "scripts": {
+    "dev:v1": "VARIANT=v1 PORT=5001 tsx server.ts",
+    "dev:v2": "VARIANT=v2 PORT=5002 tsx server.ts",
+    "dev:both": "concurrently -k -n v1,v2 -c blue,magenta 'pnpm dev:v1' 'pnpm dev:v2'",
+    "chaos:v1": "chaosbringer --url http://127.0.0.1:5001 --seed 42 --max-pages 8 --max-actions 2 --output reports/v1.json --failure-artifacts artifacts/v1 --cluster-artifacts --ignore-preset analytics --compact",
+    "chaos:v2": "chaosbringer --url http://127.0.0.1:5002 --seed 42 --max-pages 8 --max-actions 2 --output reports/v2.json --failure-artifacts artifacts/v2 --cluster-artifacts --ignore-preset analytics --compact",
+    "chaos:diff": "chaosbringer diff reports/v1.json reports/v2.json",
+    "chaos:parity": "chaosbringer parity --left http://127.0.0.1:5001 --right http://127.0.0.1:5002 --paths paths.txt --output reports/parity.json",
+    "loop": "tsx loop.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.0",
+    "@mizchi/server-faults": "workspace:*",
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "chaosbringer": "workspace:*",
+    "concurrently": "^9.0.0",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/playground/paths.txt
+++ b/playground/paths.txt
@@ -1,0 +1,13 @@
+# Paths fed to `chaosbringer parity`. The right-hand-side comments
+# document the seeded divergence (or its absence). Re-run after a fix
+# to confirm the bug class is resolved.
+/
+/users
+/users/1            # both 200
+/users/10           # both 200
+/users/11           # v1 404, v2 500 (BUG-1)
+/api/users
+/api/users/1
+/api/users/2        # v2 missing email (BUG-2)
+/admin
+/health             # exempt from chaos

--- a/playground/paths.txt
+++ b/playground/paths.txt
@@ -10,4 +10,5 @@
 /api/users/1        # v2 cache-control drift (BUG-5)
 /api/users/2        # v2 missing email + cache-control drift (BUG-2, BUG-5)
 /admin
+/dashboard          # HTML identical, v2 bundle.js throws (BUG-6 — needs --check-exceptions)
 /health             # exempt from chaos

--- a/playground/paths.txt
+++ b/playground/paths.txt
@@ -6,8 +6,8 @@
 /users/1            # both 200
 /users/10           # both 200
 /users/11           # v1 404, v2 500 (BUG-1)
-/api/users
-/api/users/1
-/api/users/2        # v2 missing email (BUG-2)
+/api/users          # v2 cache-control drift (BUG-5)
+/api/users/1        # v2 cache-control drift (BUG-5)
+/api/users/2        # v2 missing email + cache-control drift (BUG-2, BUG-5)
 /admin
 /health             # exempt from chaos

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -82,6 +82,13 @@ export const BUG_LEDGER = [
       "Both variants return matching 201 + id on POST. v1's GET by id returns the original title; v2's GET by id returns the title uppercased. Needs capture+template — single-shot parity can't hit the right id without knowing it in advance.",
     catcher: "chaosbringer journey (with capture: body.id → {{todoId}})",
   },
+  {
+    id: "BUG-9",
+    where: "GET /api/users",
+    symptom:
+      "v2 sleeps 120ms before responding (a regression that doesn't move status / body / headers — only latency). Invisible to every existing parity check.",
+    catcher: "chaosbringer parity --perf-delta-ms",
+  },
 ] as const;
 
 // ─── server-faults config from env ────────────────────────────────────────
@@ -206,7 +213,9 @@ function apiCache(): string {
   return VARIANT === "v2" ? "no-store" : "max-age=60";
 }
 
-app.get("/api/users", (c) => {
+app.get("/api/users", async (c) => {
+  // BUG-9: v2 adds latency that doesn't move any other dimension.
+  if (VARIANT === "v2") await new Promise((r) => setTimeout(r, 120));
   c.header("cache-control", apiCache());
   return c.json(USERS);
 });

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -68,6 +68,13 @@ export const BUG_LEDGER = [
       "v1 and v2 return byte-identical HTML; v2's bundle.js (served from /static/bundle.js) throws an uncaught ReferenceError on load. Invisible to status/body/header parity.",
     catcher: "chaosbringer parity --check-exceptions",
   },
+  {
+    id: "BUG-7",
+    where: "POST /api/todos then GET /api/todos",
+    symptom:
+      "v2's POST returns 201 with an identical-shaped JSON response, but silently no-ops the write. A subsequent GET shows an empty list on v2 / one item on v1. Single-shot probes (parity --check-body on either path alone) can't see it.",
+    catcher: "chaosbringer journey",
+  },
 ] as const;
 
 // ─── server-faults config from env ────────────────────────────────────────
@@ -195,6 +202,29 @@ function apiCache(): string {
 app.get("/api/users", (c) => {
   c.header("cache-control", apiCache());
   return c.json(USERS);
+});
+
+// BUG-7: v1's POST persists, v2's POST returns success and discards.
+// Status + body shape are identical on the write step — only the
+// follow-up read (different state) surfaces the divergence.
+interface Todo {
+  id: number;
+  title: string;
+}
+const TODOS: Todo[] = [];
+let nextTodoId = 1;
+
+app.post("/api/todos", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { title?: string };
+  const created: Todo = { id: nextTodoId++, title: body.title ?? "untitled" };
+  if (VARIANT !== "v2") TODOS.push(created);
+  c.header("cache-control", apiCache());
+  return c.json(created, 201);
+});
+
+app.get("/api/todos", (c) => {
+  c.header("cache-control", apiCache());
+  return c.json(TODOS);
 });
 
 app.get("/api/users/:id", (c) => {

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -75,6 +75,13 @@ export const BUG_LEDGER = [
       "v2's POST returns 201 with an identical-shaped JSON response, but silently no-ops the write. A subsequent GET shows an empty list on v2 / one item on v1. Single-shot probes (parity --check-body on either path alone) can't see it.",
     catcher: "chaosbringer journey",
   },
+  {
+    id: "BUG-8",
+    where: "POST /api/todos → GET /api/todos/<id>",
+    symptom:
+      "Both variants return matching 201 + id on POST. v1's GET by id returns the original title; v2's GET by id returns the title uppercased. Needs capture+template — single-shot parity can't hit the right id without knowing it in advance.",
+    catcher: "chaosbringer journey (with capture: body.id → {{todoId}})",
+  },
 ] as const;
 
 // ─── server-faults config from env ────────────────────────────────────────
@@ -217,7 +224,12 @@ let nextTodoId = 1;
 app.post("/api/todos", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { title?: string };
   const created: Todo = { id: nextTodoId++, title: body.title ?? "untitled" };
-  if (VARIANT !== "v2") TODOS.push(created);
+  // BUG-7 is gated on the title to avoid colliding with BUG-8 (which
+  // needs the write to actually persist so the GET-by-id can find it).
+  // Real-world equivalent: a tenant-specific flag that drops certain
+  // record classes silently.
+  const dropOnV2 = (body.title ?? "").startsWith("drop:");
+  if (!(VARIANT === "v2" && dropOnV2)) TODOS.push(created);
   c.header("cache-control", apiCache());
   return c.json(created, 201);
 });
@@ -225,6 +237,19 @@ app.post("/api/todos", async (c) => {
 app.get("/api/todos", (c) => {
   c.header("cache-control", apiCache());
   return c.json(TODOS);
+});
+
+// BUG-8: GET by id returns a mutated title on v2. The POST is identical
+// across variants and BUG-7 doesn't fire on v1 (which persists), so a
+// journey that captures the id and reads it back is the only way to
+// see this.
+app.get("/api/todos/:id", (c) => {
+  const id = Number.parseInt(c.req.param("id"), 10);
+  const todo = TODOS.find((t) => t.id === id);
+  c.header("cache-control", apiCache());
+  if (!todo) return c.notFound();
+  if (VARIANT === "v2") return c.json({ ...todo, title: todo.title.toUpperCase() });
+  return c.json(todo);
 });
 
 app.get("/api/users/:id", (c) => {

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -55,6 +55,12 @@ export const BUG_LEDGER = [
     symptom: "v2 home page has an extra <a href='/does-not-exist'> that 404s on click",
     catcher: "chaosbringer (crawler hits the link, both report 404 → ignore-preset must NOT swallow it)",
   },
+  {
+    id: "BUG-5",
+    where: "GET /api/users (and /api/users/:id)",
+    symptom: "v2 returns `cache-control: no-store` where v1 returns `max-age=60` (policy drift)",
+    catcher: "chaosbringer parity --check-headers cache-control",
+  },
 ] as const;
 
 // ─── server-faults config from env ────────────────────────────────────────
@@ -172,12 +178,23 @@ app.get("/users/:id", (c) => {
   return c.notFound();
 });
 
-app.get("/api/users", (c) => c.json(USERS));
+// BUG-5: v2's cache policy on /api/* is stricter (no-store vs max-age=60).
+// Either could be the "intended" policy — the point is the divergence,
+// which parity --check-headers must surface as a header mismatch.
+function apiCache(): string {
+  return VARIANT === "v2" ? "no-store" : "max-age=60";
+}
+
+app.get("/api/users", (c) => {
+  c.header("cache-control", apiCache());
+  return c.json(USERS);
+});
 
 app.get("/api/users/:id", (c) => {
   const id = Number.parseInt(c.req.param("id"), 10);
   const user = USERS.find((u) => u.id === id);
   if (!user) return c.notFound();
+  c.header("cache-control", apiCache());
   // BUG-2: v2 strips the `email` field on /api/users/2 specifically.
   if (VARIANT === "v2" && id === 2) {
     const { email: _drop, ...rest } = user;

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -61,6 +61,13 @@ export const BUG_LEDGER = [
     symptom: "v2 returns `cache-control: no-store` where v1 returns `max-age=60` (policy drift)",
     catcher: "chaosbringer parity --check-headers cache-control",
   },
+  {
+    id: "BUG-6",
+    where: "GET /dashboard",
+    symptom:
+      "v1 and v2 return byte-identical HTML; v2's bundle.js (served from /static/bundle.js) throws an uncaught ReferenceError on load. Invisible to status/body/header parity.",
+    catcher: "chaosbringer parity --check-exceptions",
+  },
 ] as const;
 
 // ─── server-faults config from env ────────────────────────────────────────
@@ -213,6 +220,28 @@ app.get("/admin", (c) => {
       : "";
   return c.html(`<!doctype html>
 <html><body><h1>Admin</h1>${bugScript}</body></html>`);
+});
+
+// BUG-6: byte-identical HTML on /dashboard for both variants — the only
+// difference lives in /static/bundle.js, which v2 ships with a broken
+// build (an undefined symbol). The HTTP-layer probes (status / headers
+// / body bytes) all match for /dashboard. The browser-level probe
+// catches it because the script throws on load.
+app.get("/dashboard", (c) =>
+  c.html(`<!doctype html>
+<html><body><h1>Dashboard</h1><script src="/static/bundle.js"></script></body></html>`),
+);
+
+app.get("/static/bundle.js", (c) => {
+  c.header("content-type", "application/javascript");
+  return c.body(
+    VARIANT === "v2"
+      ? // BUG-6 v2: uncaught ReferenceError on load. The HTML referencing
+        // bundle.js is identical on both sides, so this surfaces ONLY
+        // through a browser visit + page-error capture.
+        `(function(){ console.log('dashboard init:', undefinedDashboardSymbol); })();`
+      : `(function(){ /* dashboard ready */ })();`,
+  );
 });
 
 serve({ fetch: app.fetch, port: PORT }, (info) => {

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -89,6 +89,13 @@ export const BUG_LEDGER = [
       "v2 sleeps 120ms before responding (a regression that doesn't move status / body / headers — only latency). Invisible to every existing parity check.",
     catcher: "chaosbringer parity --perf-delta-ms",
   },
+  {
+    id: "BUG-10",
+    where: "Multi-actor journey: Alice creates a doc, Bob lists docs",
+    symptom:
+      "v1 isolates docs per user (Bob's list is empty). v2 ignores the session cookie and returns Alice's secret to Bob — a tenant-isolation breach invisible to any single-actor journey.",
+    catcher: "chaosbringer journey with actor=alice / actor=bob",
+  },
 ] as const;
 
 // ─── server-faults config from env ────────────────────────────────────────
@@ -246,6 +253,43 @@ app.post("/api/todos", async (c) => {
 app.get("/api/todos", (c) => {
   c.header("cache-control", apiCache());
   return c.json(TODOS);
+});
+
+// BUG-10: per-user document store. v1 keys by the `u=<user>` session
+// cookie. v2 has a bug where the listing endpoint ignores the cookie
+// and returns the global pile — a tenant-isolation breach.
+const DOCS_BY_USER = new Map<string, Array<{ title: string }>>();
+function currentUser(c: { req: { header: (name: string) => string | undefined } }): string {
+  const cookieHeader = c.req.header("cookie") ?? "";
+  const match = cookieHeader.match(/u=([^;]+)/);
+  return match ? match[1] : "anon";
+}
+
+app.post("/api/session", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { user?: string };
+  const user = body.user ?? "anon";
+  c.header("set-cookie", `u=${user}; Path=/; SameSite=Lax`);
+  return c.json({ user });
+});
+
+app.post("/api/docs", async (c) => {
+  const user = currentUser(c);
+  const body = (await c.req.json().catch(() => ({}))) as { title?: string };
+  const list = DOCS_BY_USER.get(user) ?? [];
+  list.push({ title: body.title ?? "untitled" });
+  DOCS_BY_USER.set(user, list);
+  return c.json({ ok: true }, 201);
+});
+
+app.get("/api/docs", (c) => {
+  const user = currentUser(c);
+  if (VARIANT === "v2") {
+    // Bug: ignore the user, return all docs across all users.
+    const all: Array<{ title: string }> = [];
+    for (const docs of DOCS_BY_USER.values()) all.push(...docs);
+    return c.json(all);
+  }
+  return c.json(DOCS_BY_USER.get(user) ?? []);
 });
 
 // BUG-8: GET by id returns a mutated title on v2. The POST is identical

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -1,0 +1,206 @@
+/**
+ * Dogfood playground server.
+ *
+ * Two variants of the same app, served on different ports, parameterised
+ * by the `VARIANT` env var. `v1` is the "correct" reference; `v2` has
+ * intentional divergences seeded for chaosbringer's diff / parity /
+ * cluster-artifacts tools to find. The bugs are NOT subtle in the code
+ * — they are subtle in their *symptoms* — so an agent reading reports
+ * (not source) has to do real work.
+ *
+ * server-faults is mounted on both variants, driven by `CHAOS_*` env
+ * vars. With everything unset it's a no-op; with rates / windows set
+ * each new fault kind from this PR can be exercised end-to-end.
+ *
+ * To keep this file the single source of truth for what an agent loop
+ * sees, the seeded bugs are listed in BUG_LEDGER below — useful as a
+ * grading rubric after a loop finishes ("did the agent find bug X?").
+ */
+
+import { serve } from "@hono/node-server";
+import type { ServerFaultConfig } from "@mizchi/server-faults";
+import { honoMiddleware } from "@mizchi/server-faults/hono";
+import { Hono } from "hono";
+
+const VARIANT = (process.env.VARIANT === "v2" ? "v2" : "v1") as "v1" | "v2";
+const PORT = Number.parseInt(process.env.PORT ?? "5001", 10);
+
+// ─── Seeded bugs ──────────────────────────────────────────────────────────
+// Each entry: where the divergence lives + what tool should catch it.
+// Agents shouldn't read this file before running the loop. After a loop
+// finishes, the seeded list can be cross-checked against what the agent
+// reported.
+export const BUG_LEDGER = [
+  {
+    id: "BUG-1",
+    where: "GET /users/11",
+    symptom: "v1 → 404, v2 → 500 (off-by-one in user-id bounds check)",
+    catcher: "chaosbringer parity",
+  },
+  {
+    id: "BUG-2",
+    where: "GET /api/users/2",
+    symptom: "v2 response is missing the `email` field that v1 includes",
+    catcher: "chaosbringer parity --follow-redirects + manual body inspection (or invariant)",
+  },
+  {
+    id: "BUG-3",
+    where: "GET /admin",
+    symptom: "v2 emits a console.error from an inline <script> referencing a missing var",
+    catcher: "chaosbringer (cluster shows up only on v2 report → diff surfaces it)",
+  },
+  {
+    id: "BUG-4",
+    where: "GET /broken-link page",
+    symptom: "v2 home page has an extra <a href='/does-not-exist'> that 404s on click",
+    catcher: "chaosbringer (crawler hits the link, both report 404 → ignore-preset must NOT swallow it)",
+  },
+] as const;
+
+// ─── server-faults config from env ────────────────────────────────────────
+// Every fault kind shipped on this PR is reachable from a single set of
+// env vars. Leaving them unset = no-op. The same config is applied to
+// both variants so chaos is symmetric and parity output still represents
+// real route differences, not fault-noise differences.
+function loadChaosConfig(): ServerFaultConfig {
+  const cfg: ServerFaultConfig = {
+    metadataHeader: true,
+    // Health checks should NEVER receive chaos — they'd flap the
+    // playground's own readiness signal. exemptPath wins over all raffles.
+    exemptPathPattern: /^\/health/,
+    bypassHeader: "x-chaos-bypass",
+  };
+  const num = (k: string) => {
+    const v = process.env[k];
+    return v === undefined ? undefined : Number.parseFloat(v);
+  };
+  const status5xxRate = num("CHAOS_5XX_RATE");
+  if (status5xxRate) cfg.status5xxRate = status5xxRate;
+  const latencyRate = num("CHAOS_LATENCY_RATE");
+  if (latencyRate) {
+    cfg.latencyRate = latencyRate;
+    cfg.latencyMs = num("CHAOS_LATENCY_MS") ?? 200;
+  }
+  const abortRate = num("CHAOS_ABORT_RATE");
+  if (abortRate) {
+    cfg.abortRate = abortRate;
+    if (process.env.CHAOS_ABORT_STYLE === "reset") cfg.abortStyle = "reset";
+  }
+  const partialRate = num("CHAOS_PARTIAL_RATE");
+  if (partialRate) {
+    cfg.partialResponseRate = partialRate;
+    cfg.partialResponseAfterBytes = num("CHAOS_PARTIAL_AFTER") ?? 32;
+  }
+  const slowRate = num("CHAOS_SLOW_RATE");
+  if (slowRate) {
+    cfg.slowStreaming = {
+      rate: slowRate,
+      chunkDelayMs: num("CHAOS_SLOW_DELAY") ?? 100,
+      ...(process.env.CHAOS_SLOW_CHUNK
+        ? { chunkSize: Number.parseInt(process.env.CHAOS_SLOW_CHUNK, 10) }
+        : {}),
+    };
+  }
+  const flapWindow = num("CHAOS_FLAP_WINDOW");
+  const flapBad = num("CHAOS_FLAP_BAD");
+  if (flapWindow && flapBad) {
+    cfg.statusFlapping = { windowMs: flapWindow, badMs: flapBad };
+  }
+  return cfg;
+}
+
+// ─── App data ─────────────────────────────────────────────────────────────
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+const USERS: User[] = Array.from({ length: 10 }, (_, i) => ({
+  id: i + 1,
+  name: `User ${i + 1}`,
+  email: `user${i + 1}@example.test`,
+}));
+
+// ─── Routes ───────────────────────────────────────────────────────────────
+const app = new Hono();
+app.use("*", honoMiddleware(loadChaosConfig()));
+
+app.get("/health", (c) => c.text("ok"));
+
+app.get("/", (c) => {
+  // BUG-4: v2 has an extra broken-link <a> that 404s on the next hop.
+  const extra =
+    VARIANT === "v2"
+      ? `<li><a href="/does-not-exist">does-not-exist (broken)</a></li>`
+      : "";
+  return c.html(`<!doctype html>
+<html><body>
+<h1>Playground (${VARIANT}) — port ${PORT}</h1>
+<ul>
+  <li><a href="/users">Users</a></li>
+  <li><a href="/users/1">User 1</a></li>
+  <li><a href="/users/11">User 11 (edge)</a></li>
+  <li><a href="/api/users">API: users</a></li>
+  <li><a href="/api/users/2">API: user 2</a></li>
+  <li><a href="/admin">Admin</a></li>
+  ${extra}
+</ul>
+</body></html>`);
+});
+
+app.get("/users", (c) => {
+  const items = USERS.map(
+    (u) => `<li><a href="/users/${u.id}">${u.name}</a></li>`,
+  ).join("");
+  return c.html(`<!doctype html>
+<html><body><h1>Users</h1><ul>${items}</ul></body></html>`);
+});
+
+app.get("/users/:id", (c) => {
+  const id = Number.parseInt(c.req.param("id"), 10);
+  if (!Number.isFinite(id)) return c.notFound();
+  const user = USERS.find((u) => u.id === id);
+  if (user) {
+    return c.html(`<!doctype html>
+<html><body><h1>${user.name}</h1><p>${user.email}</p></body></html>`);
+  }
+  // BUG-1: v2 has an off-by-one — IDs 11..15 hit a "still in range" branch
+  // that throws a 500 instead of returning the expected 404.
+  if (VARIANT === "v2" && id >= 11 && id <= 15) {
+    throw new Error("v2 off-by-one: id ${id} treated as in-range");
+  }
+  return c.notFound();
+});
+
+app.get("/api/users", (c) => c.json(USERS));
+
+app.get("/api/users/:id", (c) => {
+  const id = Number.parseInt(c.req.param("id"), 10);
+  const user = USERS.find((u) => u.id === id);
+  if (!user) return c.notFound();
+  // BUG-2: v2 strips the `email` field on /api/users/2 specifically.
+  if (VARIANT === "v2" && id === 2) {
+    const { email: _drop, ...rest } = user;
+    return c.json(rest);
+  }
+  return c.json(user);
+});
+
+app.get("/admin", (c) => {
+  // BUG-3: v2 inlines a script that references an undeclared variable.
+  // Browsers raise a ReferenceError → chaosbringer captures it as a
+  // console error → it forms a v2-only cluster the diff surfaces.
+  const bugScript =
+    VARIANT === "v2"
+      ? `<script>console.log("admin loaded:", missingGlobalVariable);</script>`
+      : "";
+  return c.html(`<!doctype html>
+<html><body><h1>Admin</h1>${bugScript}</body></html>`);
+});
+
+serve({ fetch: app.fetch, port: PORT }, (info) => {
+  console.log(
+    `[${VARIANT}] listening on http://127.0.0.1:${info.port} — chaos config:`,
+    Object.keys(loadChaosConfig()).join(", "),
+  );
+});

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,34 @@ importers:
         specifier: ^3.0.7
         version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
+  playground:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.0
+        version: 1.19.14(hono@4.12.17)
+      '@mizchi/server-faults':
+        specifier: workspace:*
+        version: link:../packages/server-faults
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.17
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      chaosbringer:
+        specifier: workspace:*
+        version: link:../packages/chaosbringer
+      concurrently:
+        specifier: ^9.0.0
+        version: 9.2.1
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
 packages:
 
   '@cloudflare/kv-asset-handler@0.3.4':
@@ -534,6 +562,12 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -971,6 +1005,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
 
@@ -1017,6 +1055,10 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -1032,6 +1074,10 @@ packages:
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1057,6 +1103,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -1124,6 +1175,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -1182,6 +1237,10 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
 
@@ -1202,6 +1261,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
@@ -1472,6 +1535,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1499,6 +1566,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1516,6 +1586,10 @@ packages:
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1585,6 +1659,14 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
@@ -1618,6 +1700,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1766,6 +1852,10 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -1781,12 +1871,24 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   youch@3.3.4:
     resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
@@ -1989,6 +2091,10 @@ snapshots:
   '@fastify/busboy@2.1.1': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@hono/node-server@1.19.14(hono@4.12.17)':
+    dependencies:
+      hono: 4.12.17
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -2349,6 +2455,10 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   aproba@2.1.0: {}
 
   are-we-there-yet@3.0.1:
@@ -2412,6 +2522,11 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   check-error@2.1.3: {}
 
   chownr@2.0.0: {}
@@ -2420,13 +2535,17 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-    optional: true
 
-  color-name@1.1.4:
-    optional: true
+  color-name@1.1.4: {}
 
   color-string@1.9.1:
     dependencies:
@@ -2445,6 +2564,15 @@ snapshots:
   commander@14.0.3: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   consola@3.4.2: {}
 
@@ -2543,6 +2671,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   estree-walker@0.6.1: {}
@@ -2588,6 +2718,8 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
+  get-caller-file@2.0.5: {}
+
   get-source@2.0.12:
     dependencies:
       data-uri-to-buffer: 2.0.2
@@ -2617,6 +2749,8 @@ snapshots:
       once: 1.4.0
 
   graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
 
   has-unicode@2.0.1: {}
 
@@ -2892,6 +3026,8 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  require-directory@2.1.1: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   retry@0.12.0: {}
@@ -2945,6 +3081,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2:
@@ -2980,6 +3120,8 @@ snapshots:
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
     optional: true
+
+  shell-quote@1.8.3: {}
 
   siginfo@2.0.0: {}
 
@@ -3046,6 +3188,14 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -3080,8 +3230,9 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  tslib@2.8.1:
-    optional: true
+  tree-kill@1.2.2: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -3243,13 +3394,33 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   youch@3.3.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "examples/*"
+  - "playground"


### PR DESCRIPTION
## Summary

Dogfooding the tools shipped in PR #99 produced a self-improving feedback loop: a sub-agent runs `chaosbringer parity` / `journey` against a playground with seeded divergences, identifies the next-most-pressing gap, and that gap drives the next implementation iteration. Eleven such iterations later, the parity-family tools catch a substantially wider class of cross-runtime regressions than what shipped in #99.

## What's in the branch

- **`playground/`** — two Hono variants (v1 reference, v2 with 10 seeded bugs spanning every shipped mismatch kind). `pnpm loop` is a single orchestrator that spawns both, runs the full chaosbringer tool suite against them, and exits non-zero on any deviation with a `=== summary ===` table at the end.

- **`parity`** gained four opt-in mismatch kinds (each driven by an agent-flagged gap):
  - `--check-body` — SHA-256 hash of the response, with JSON-aware path-level localization (`title: "buy milk" → "BUY MILK"`).
  - `--check-headers <list>` — named response-header comparison, lowercased, case-insensitive.
  - `--check-exceptions` — visits each path in headless Chromium and compares uncaught page errors + `console.error`. Lazy-imports Playwright; injectable `browserLauncher` for tests.
  - `--perf-delta-ms` / `--perf-ratio` — single-sample wall-clock thresholds.

- **`parity` returns ALL kinds** per probe (not first-wins). Status / failure / redirect still short-circuit at the top of the chain — but header + body + exception + perf now coexist on the same path, so an independent body drift no longer hides behind a header drift on `/api/users/2`.

- **`journey` subcommand** — replays a JSON-described step list with per-side cookie jars + per-side, per-actor isolation. Catches stateful bugs (silent write drops), capture-required flows (server-picked IDs, bearer tokens), and tenant-isolation breaches (Alice's session cookie must not be visible to Bob's GET).
  - `capture: [{ from: "body.id", as: "todoId" }]` + `{{var}}` substitution in path / headers / JSON body.
  - `actor: "alice"` — distinct cookie jars + var bags within the same side.

- **Body-diff localization** (`body-diff.ts`) — walks two JSON trees, returns path-level entries (`added` / `removed` / `changed` / `typed`). Renders as one-line summaries under `BODY` mismatches; falls back to byte-level when neither body is JSON. 50-entry cap with truncation flag so list-heavy diffs don't pollute the report.

- **Report `schemaVersion: 1` + `config: { ... }` echo** — both `ParityReport` and `JourneyReport` carry the thresholds that produced them, so an operator re-reading the JSON knows which check tripped without rerunning.

## Bug rubric

The playground seeds 10 bugs across every kind. One full `pnpm loop parity` run catches all of them:

| ID    | Where                                   | Caught by                                |
| ----- | --------------------------------------- | ---------------------------------------- |
| BUG-1 | `/users/11` (off-by-one)                | `parity` STATUS                          |
| BUG-2 | `/api/users/2` (missing `email`)        | `parity` BODY + JSON localization        |
| BUG-3 | `/admin` (console ReferenceError)       | `parity` BODY + EXCEPTION                |
| BUG-4 | `/` (broken inbound link)               | `parity` BODY                            |
| BUG-5 | `/api/users*` (cache-control drift)     | `parity` HEADER                          |
| BUG-6 | `/dashboard` (identical HTML, bad JS)   | `parity` EXCEPTION                       |
| BUG-7 | silent write drop                       | `journey` BODY                           |
| BUG-8 | mutated title on read-by-id             | `journey` BODY + capture/template        |
| BUG-9 | `/api/users` 120ms regression           | `parity` PERF                            |
| BUG-10| tenant isolation breach                 | `journey` BODY + per-actor jar           |

Loop tail:
```
=== summary ===
  status     1
  header     3
  body       6
  exception  2
  perf       1
  TOTAL      10 finding(s)
```

## What's NOT in scope here

- Resource-leak / race-condition detection (different tool category, not a parity probe)
- Multi-sample perf with percentile thresholds (single-sample documented; consumers can sweep via the JSON report)
- CI workflow YAML for the playground (maintainer's call)

## Tests

- `pnpm -F chaosbringer test src/` — 800+ assertions pass on the chaosbringer side, including 56 parity+journey + 20 body-diff
- `pnpm -F @mizchi/chaosbringer-playground typecheck` — clean
- `pnpm loop parity` against the playground — exits 1 with all 10 seeded bugs surfaced

## Test plan

- [x] All package builds clean
- [x] All unit tests pass
- [x] End-to-end playground loop catches every seeded bug
- [x] Report JSON shape stable (schemaVersion + config validated in tests)
- [ ] CI

The whole branch is sub-agent-driven: every feature has its driving "previous agent flagged X" justification documented in the commit message. Each commit closes one concrete gap and a fresh sub-agent verifies before the next iteration starts.

---
_Generated by [Claude Code](https://claude.ai/code/session_016akfbHeRMhsvBRxJW2HBFi)_