### PR TITLE
parity N-sample perf + playground CI gate + sibling --output mkdir fixes

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,76 @@
+name: playground-dogfood
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Spawns both v1/v2 server variants, runs the full parity + journey
+# + chaos sweep against them, and asserts the mismatch count matches
+# the seeded baseline (BUG_LEDGER). A regression that breaks any of
+# the detectors fails this gate even when the other test suite stays
+# green — those tests can't see end-to-end signal drift between two
+# live runtimes.
+
+env:
+  # Total mismatch probes the loop should detect across the seeded
+  # BUG_LEDGER. Adjust when adding or removing seeded bugs, OR when a
+  # new detector starts catching a bug that was previously
+  # out-of-scope. A CI failure here means either:
+  #   (a) detection regressed — investigate before merging, or
+  #   (b) the BUG_LEDGER changed — update this number.
+  EXPECTED_MISMATCHES: 10
+
+jobs:
+  loop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build chaosbringer
+        run: pnpm -F chaosbringer build
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit path)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Run dogfood loop with seeded-baseline assertion
+        working-directory: playground
+        run: pnpm exec tsx loop.ts --expect-mismatches ${{ env.EXPECTED_MISMATCHES }}
+
+      - name: Upload loop reports + artifacts
+        # `if: always()` so the artifacts are available even when the
+        # assertion fails — the reports/ + artifacts/ trees are what
+        # the maintainer (or a follow-up agent) needs to diagnose the
+        # regression. Without this, a CI failure leaves nothing to
+        # debug from.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-reports
+          path: |
+            playground/reports/
+            playground/artifacts/
+          if-no-files-found: ignore

--- a/packages/chaosbringer/src/cli.ts
+++ b/packages/chaosbringer/src/cli.ts
@@ -31,7 +31,8 @@ import { axe } from "./invariants.js";
 import { printReport, saveReport, getExitCode } from "./reporter.js";
 import { buildActionHeatmap, formatHeatmap } from "./heatmap.js";
 import { buildJunitXml } from "./junit.js";
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { parseShardArg } from "./shard.js";
 import type { CrawlerOptions, Invariant } from "./types.js";
 import { visualRegression } from "./visual.js";
@@ -478,6 +479,7 @@ async function main() {
       }
       const heatmapOut = values["heatmap-out"];
       if (heatmapOut) {
+        mkdirSync(dirname(heatmapOut), { recursive: true });
         writeFileSync(heatmapOut, JSON.stringify(entries, null, 2));
         if (!isQuiet) console.log(`\nHeatmap saved to: ${heatmapOut}`);
       }
@@ -510,6 +512,7 @@ async function main() {
     }
 
     if (values.junit) {
+      mkdirSync(dirname(values.junit), { recursive: true });
       writeFileSync(values.junit, buildJunitXml(report));
       if (!isQuiet) console.log(`JUnit XML saved to: ${values.junit}`);
     }

--- a/packages/chaosbringer/src/parity-cli.test.ts
+++ b/packages/chaosbringer/src/parity-cli.test.ts
@@ -142,4 +142,83 @@ describe("runParityCli", () => {
     await runParityCli(["--help"]);
     expect(logged()).toContain("Usage: chaosbringer parity");
   });
+
+  describe("perf N-sample flags", () => {
+    it("--perf-samples and --perf-percentile flow through to the report config", async () => {
+      stubFetch({
+        "http://l/foo": () => new Response("", { status: 200 }),
+        "http://r/foo": () => new Response("", { status: 200 }),
+      });
+      const pathsFile = writePaths("paths.txt", ["/foo"]);
+      const outPath = join(dir, "parity.json");
+      await runParityCli([
+        "--left", "http://l",
+        "--right", "http://r",
+        "--paths", pathsFile,
+        "--perf-samples", "3",
+        "--perf-percentile", "median",
+        "--output", outPath,
+      ]);
+      const parsed = JSON.parse(readFileSync(outPath, "utf-8"));
+      expect(parsed.config.perfSamples).toBe(3);
+      expect(parsed.config.perfPercentile).toBe("median");
+      // First sample populates durationMs; perfStats carries the
+      // distribution from all 3.
+      expect(parsed.matches[0].left.perfStats.samples).toBe(3);
+    });
+
+    it("rejects --perf-percentile values not in the allow-list", async () => {
+      const pathsFile = writePaths("paths.txt", ["/foo"]);
+      await runParityCli([
+        "--left", "http://l",
+        "--right", "http://r",
+        "--paths", pathsFile,
+        "--perf-percentile", "p50", // not in the allow-list (we expose median, not p50)
+      ]);
+      expect(process.exitCode).toBe(1);
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("--perf-percentile must be one of"),
+      );
+    });
+
+    it("rejects --perf-samples that aren't positive integers", async () => {
+      const pathsFile = writePaths("paths.txt", ["/foo"]);
+      await runParityCli([
+        "--left", "http://l",
+        "--right", "http://r",
+        "--paths", pathsFile,
+        "--perf-samples", "0",
+      ]);
+      expect(process.exitCode).toBe(1);
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("--perf-samples must be a positive integer"),
+      );
+    });
+
+    it("PERF line in CLI output shows the percentile + sample count when N>1", async () => {
+      // Right side: four fast samples + one outlier. With p95 of 5
+      // the outlier wins; PERF line should annotate "p95 of 5/5".
+      const counters: Record<string, number> = {};
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const idx = counters[url] ?? 0;
+        counters[url] = idx + 1;
+        if (url.startsWith("http://r/") && idx === 4) {
+          await new Promise((r) => setTimeout(r, 80));
+        }
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+      const pathsFile = writePaths("paths.txt", ["/foo"]);
+      await runParityCli([
+        "--left", "http://l",
+        "--right", "http://r",
+        "--paths", pathsFile,
+        "--perf-samples", "5",
+        "--perf-percentile", "p95",
+        "--perf-delta-ms", "30",
+      ]);
+      expect(process.exitCode).toBe(1);
+      expect(logged()).toMatch(/PERF.*p95 of 5\/5/);
+    });
+  });
 });

--- a/packages/chaosbringer/src/parity-cli.ts
+++ b/packages/chaosbringer/src/parity-cli.ts
@@ -7,7 +7,9 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { parseArgs } from "node:util";
 import { summariseBodyDiff } from "./body-diff.js";
-import { runParity } from "./parity.js";
+import { type PerfPercentile, runParity } from "./parity.js";
+
+const PERF_PERCENTILES: readonly PerfPercentile[] = ["min", "median", "p95", "p99"];
 
 const HELP = `Usage: chaosbringer parity --left <url> --right <url> --paths <file> [options]
 
@@ -49,10 +51,23 @@ Options:
                      browser binary available.
   --perf-delta-ms <n>  Flag a "perf" mismatch when right is more than
                      N ms slower than left. Single-sample wall clock —
-                     noisy; set well above your jitter floor.
+                     noisy; set well above your jitter floor (or pair
+                     with --perf-samples for percentile-based gating).
   --perf-ratio <n>   Flag a "perf" mismatch when right > left * N.
                      Composes with --perf-delta-ms via OR.
-  --timeout <ms>     Per-request timeout. Default 10000.
+  --perf-samples <n> Number of serial fetches per side per path. Default
+                     1 (single-sample). With N>1 the perf threshold runs
+                     against the configured percentile of N samples
+                     instead of a single noisy wall-clock reading. Each
+                     sample is timed independently; the first captures
+                     status/headers/body and later samples contribute
+                     timing only. Worst-case wall-clock per side per
+                     path is N * --timeout.
+  --perf-percentile <p>
+                     Which percentile to compare when --perf-samples>1.
+                     One of min, median, p95, p99. Default p95 (SLO
+                     standard). Ignored when --perf-samples=1.
+  --timeout <ms>     Per-request timeout, applied per sample. Default 10000.
   --help             Show this help
 
 Exit code is 1 when any mismatch is found, 0 when both sides agree on
@@ -93,6 +108,8 @@ export async function runParityCli(argv: string[]): Promise<void> {
       "check-exceptions": { type: "boolean", default: false },
       "perf-delta-ms": { type: "string" },
       "perf-ratio": { type: "string" },
+      "perf-samples": { type: "string" },
+      "perf-percentile": { type: "string" },
       timeout: { type: "string" },
       help: { type: "boolean", default: false },
     },
@@ -120,6 +137,29 @@ export async function runParityCli(argv: string[]): Promise<void> {
     .map((h) => h.trim())
     .filter((h) => h.length > 0);
 
+  let perfSamples: number | undefined;
+  if (values["perf-samples"] !== undefined) {
+    const n = parseInt(values["perf-samples"], 10);
+    if (!Number.isFinite(n) || n < 1) {
+      console.error(`parity: --perf-samples must be a positive integer (got ${values["perf-samples"]})`);
+      process.exitCode = 1;
+      return;
+    }
+    perfSamples = n;
+  }
+  let perfPercentile: PerfPercentile | undefined;
+  if (values["perf-percentile"] !== undefined) {
+    const p = values["perf-percentile"];
+    if (!(PERF_PERCENTILES as readonly string[]).includes(p)) {
+      console.error(
+        `parity: --perf-percentile must be one of ${PERF_PERCENTILES.join(", ")} (got ${p})`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    perfPercentile = p as PerfPercentile;
+  }
+
   const report = await runParity({
     left: values.left,
     right: values.right,
@@ -130,6 +170,8 @@ export async function runParityCli(argv: string[]): Promise<void> {
     checkExceptions: values["check-exceptions"],
     perfDeltaMs: values["perf-delta-ms"] ? parseFloat(values["perf-delta-ms"]) : undefined,
     perfRatio: values["perf-ratio"] ? parseFloat(values["perf-ratio"]) : undefined,
+    perfSamples,
+    perfPercentile,
     timeoutMs,
   });
 
@@ -171,12 +213,20 @@ export async function runParityCli(argv: string[]): Promise<void> {
           `  EXC    ${m.path}  left=${leftCount} err  right=${rightCount} err  e.g. "${sample ?? "(none)"}"`,
         );
       } else if (kind === "perf") {
-        const l = m.left.durationMs ?? 0;
-        const r = m.right.durationMs ?? 0;
+        // When N-sample mode is on, show the configured percentile
+        // (the value the threshold actually compared) — otherwise the
+        // printed numbers wouldn't explain why the mismatch fired.
+        // Fall back to first-sample `durationMs` for single-sample mode.
+        const pct = report.config.perfPercentile;
+        const lStats = m.left.perfStats;
+        const rStats = m.right.perfStats;
+        const l = pct && lStats ? lStats[pct] : (m.left.durationMs ?? 0);
+        const r = pct && rStats ? rStats[pct] : (m.right.durationMs ?? 0);
         const delta = r - l;
         const ratio = l > 0 ? r / l : 0;
+        const tag = pct && lStats && rStats ? ` ${pct} of ${lStats.samples}/${rStats.samples}` : "";
         console.log(
-          `  PERF   ${m.path}  left=${l.toFixed(0)}ms  right=${r.toFixed(0)}ms  Δ=${delta.toFixed(0)}ms (×${ratio.toFixed(2)})`,
+          `  PERF   ${m.path}  left=${l.toFixed(0)}ms  right=${r.toFixed(0)}ms  Δ=${delta.toFixed(0)}ms (×${ratio.toFixed(2)})${tag}`,
         );
       } else if (kind === "failure") {
         const leftMsg = m.left.error ?? `status ${m.left.status}`;

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -582,15 +582,20 @@ describe("runParity", () => {
     }
 
     it("flags a perf mismatch when right is slower than left by more than the delta budget", async () => {
+      // Margins sized for contended CI runners: 0ms baseline can
+      // measure as 50ms+ under event-loop contention, so the right
+      // wait and threshold both need generous headroom above that
+      // floor. 200ms vs 0ms with an 80ms threshold survives even when
+      // the runner adds ~80ms of jitter to either side.
       const fetcher = makeTimedFetcher({
-        "http://left/x": 5,
-        "http://right/x": 80,
+        "http://left/x": 0,
+        "http://right/x": 200,
       });
       const report = await runParity({
         left: "http://left",
         right: "http://right",
         paths: ["x"],
-        perfDeltaMs: 30,
+        perfDeltaMs: 80,
         fetcher,
       });
       expect(report.mismatches).toHaveLength(1);
@@ -601,30 +606,38 @@ describe("runParity", () => {
     });
 
     it("does not flag perf when the delta is below the budget", async () => {
+      // Both sides 0ms so the asymmetric wait can't trip the
+      // threshold; budget set well above any plausible jitter delta
+      // between two same-event-loop awaits on a busy CI runner.
       const fetcher = makeTimedFetcher({
-        "http://left/x": 5,
-        "http://right/x": 10,
+        "http://left/x": 0,
+        "http://right/x": 0,
       });
       const report = await runParity({
         left: "http://left",
         right: "http://right",
         paths: ["x"],
-        perfDeltaMs: 50,
+        perfDeltaMs: 150,
         fetcher,
       });
       expect(report.mismatches).toHaveLength(0);
     });
 
     it("perfRatio fires independently of perfDeltaMs", async () => {
+      // Use a wide left/right spread so a few-ms of measurement jitter
+      // on `left` can't drag the ratio below the threshold. With
+      // left=10ms (so the ratio path doesn't skip on 0) and right=300ms
+      // and a 2x threshold, even a +50ms CI jitter on left (60ms
+      // measured) keeps ratio at 5+ — well clear of 2x.
       const fetcher = makeTimedFetcher({
-        "http://left/x": 30,
-        "http://right/x": 120,
+        "http://left/x": 10,
+        "http://right/x": 300,
       });
       const report = await runParity({
         left: "http://left",
         right: "http://right",
         paths: ["x"],
-        perfRatio: 3.0,
+        perfRatio: 2.0,
         fetcher,
       });
       expect(report.mismatches[0]?.kinds).toContain("perf");
@@ -804,9 +817,13 @@ describe("runParity", () => {
       // one side would false-positive a 30ms-budget single-sample
       // perf check. Median sees through it; p95 still raises the
       // alarm so we're not blind to genuine tail-latency regressions.
+      // Outlier sized for CI: a 300ms spike against a 0ms baseline
+      // and a 100ms threshold survives ~80ms of per-sample jitter on
+      // either side. With perfSamples=5, p95 = max sample; median = 3rd
+      // sample (untouched by the single outlier).
       const timings = {
         "http://l/x": [0, 0, 0, 0, 0],
-        "http://r/x": [0, 0, 0, 0, 100],
+        "http://r/x": [0, 0, 0, 0, 300],
       };
 
       const medianReport = await runParity({
@@ -815,7 +832,7 @@ describe("runParity", () => {
         paths: ["x"],
         perfSamples: 5,
         perfPercentile: "median",
-        perfDeltaMs: 30,
+        perfDeltaMs: 100,
         fetcher: makeQueuedTimedFetcher(timings),
       });
       expect(medianReport.mismatches).toHaveLength(0);
@@ -826,7 +843,7 @@ describe("runParity", () => {
         paths: ["x"],
         perfSamples: 5,
         perfPercentile: "p95",
-        perfDeltaMs: 30,
+        perfDeltaMs: 100,
         fetcher: makeQueuedTimedFetcher(timings),
       });
       expect(p95Report.mismatches).toHaveLength(1);
@@ -836,16 +853,17 @@ describe("runParity", () => {
     it("defaults to p95 when perfPercentile is omitted and perfSamples > 1", async () => {
       // Same outlier scenario as above. With no explicit percentile
       // the classifier must pick p95 (SLO-standard default) — so the
-      // outlier trips a 30ms budget.
+      // outlier trips the budget. Sized for CI jitter (see sibling
+      // test).
       const report = await runParity({
         left: "http://l",
         right: "http://r",
         paths: ["x"],
         perfSamples: 5,
-        perfDeltaMs: 30,
+        perfDeltaMs: 100,
         fetcher: makeQueuedTimedFetcher({
           "http://l/x": [0, 0, 0, 0, 0],
-          "http://r/x": [0, 0, 0, 0, 100],
+          "http://r/x": [0, 0, 0, 0, 300],
         }),
       });
       expect(report.mismatches[0]?.kinds).toContain("perf");
@@ -925,8 +943,8 @@ describe("runParity", () => {
         paths: ["x"],
         perfSamples: 1,
         perfPercentile: "p99",
-        perfDeltaMs: 30,
-        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [80] }),
+        perfDeltaMs: 80,
+        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [200] }),
       });
       expect(report.mismatches[0]?.kinds).toContain("perf");
     });

--- a/packages/chaosbringer/src/parity.test.ts
+++ b/packages/chaosbringer/src/parity.test.ts
@@ -744,6 +744,194 @@ describe("runParity", () => {
     });
   });
 
+  describe("perf N-sample mode", () => {
+    /**
+     * Fetcher that returns a fixed delay per (URL, call-index) so we
+     * can mix fast samples with deliberate outliers. Each URL has a
+     * queue; subsequent calls walk the queue and the last entry
+     * repeats once exhausted (so a single-entry array works as a
+     * fixed-time stub).
+     */
+    function makeQueuedTimedFetcher(timings: Record<string, number[]>): typeof fetch {
+      const counters: Record<string, number> = {};
+      return (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const arr = timings[url] ?? [0];
+        const idx = counters[url] ?? 0;
+        counters[url] = idx + 1;
+        const ms = arr[Math.min(idx, arr.length - 1)];
+        if (ms > 0) await new Promise((r) => setTimeout(r, ms));
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+    }
+
+    it("populates perfStats with one entry per sample on both sides", async () => {
+      const report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 5,
+        fetcher: makeQueuedTimedFetcher({
+          "http://l/x": [0, 0, 0, 0, 0],
+          "http://r/x": [0, 0, 0, 0, 0],
+        }),
+      });
+      const probe = report.matches[0];
+      expect(probe.left.perfStats?.samples).toBe(5);
+      expect(probe.right.perfStats?.samples).toBe(5);
+      // p95 / p99 must be >= median by construction; serves as a
+      // sanity check on the percentile math rather than a stub-tied
+      // exact-millisecond comparison (which would be flaky).
+      expect(probe.left.perfStats!.p95).toBeGreaterThanOrEqual(probe.left.perfStats!.median);
+      expect(probe.left.perfStats!.p99).toBeGreaterThanOrEqual(probe.left.perfStats!.p95);
+      // First-sample durationMs is preserved as the legacy timing.
+      expect(typeof probe.left.durationMs).toBe("number");
+    });
+
+    it("leaves perfStats undefined in default (single-sample) mode", async () => {
+      const report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [0] }),
+      });
+      expect(report.matches[0].left.perfStats).toBeUndefined();
+      expect(report.matches[0].right.perfStats).toBeUndefined();
+    });
+
+    it("median percentile is immune to a single high outlier; p95 catches it", async () => {
+      // The whole point of N-sample: a cold-cache 100ms outlier on
+      // one side would false-positive a 30ms-budget single-sample
+      // perf check. Median sees through it; p95 still raises the
+      // alarm so we're not blind to genuine tail-latency regressions.
+      const timings = {
+        "http://l/x": [0, 0, 0, 0, 0],
+        "http://r/x": [0, 0, 0, 0, 100],
+      };
+
+      const medianReport = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 5,
+        perfPercentile: "median",
+        perfDeltaMs: 30,
+        fetcher: makeQueuedTimedFetcher(timings),
+      });
+      expect(medianReport.mismatches).toHaveLength(0);
+
+      const p95Report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 5,
+        perfPercentile: "p95",
+        perfDeltaMs: 30,
+        fetcher: makeQueuedTimedFetcher(timings),
+      });
+      expect(p95Report.mismatches).toHaveLength(1);
+      expect(p95Report.mismatches[0].kinds).toContain("perf");
+    });
+
+    it("defaults to p95 when perfPercentile is omitted and perfSamples > 1", async () => {
+      // Same outlier scenario as above. With no explicit percentile
+      // the classifier must pick p95 (SLO-standard default) — so the
+      // outlier trips a 30ms budget.
+      const report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 5,
+        perfDeltaMs: 30,
+        fetcher: makeQueuedTimedFetcher({
+          "http://l/x": [0, 0, 0, 0, 0],
+          "http://r/x": [0, 0, 0, 0, 100],
+        }),
+      });
+      expect(report.mismatches[0]?.kinds).toContain("perf");
+    });
+
+    it("config echoes perfSamples and perfPercentile when N>1, omits them otherwise", async () => {
+      const sampled = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 3,
+        perfPercentile: "median",
+        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [0] }),
+      });
+      expect(sampled.config.perfSamples).toBe(3);
+      expect(sampled.config.perfPercentile).toBe("median");
+
+      const single = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [0] }),
+      });
+      // Single-sample mode keeps the legacy config shape — no
+      // surprise fields on consumers who don't opt in.
+      expect(single.config.perfSamples).toBeUndefined();
+      expect(single.config.perfPercentile).toBeUndefined();
+    });
+
+    it("short-circuits N-sample loop when the first sample fails (no N×timeout cost on dead hosts)", async () => {
+      let rightCalls = 0;
+      const fetcher = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("right")) {
+          rightCalls++;
+          throw new Error("ECONNREFUSED");
+        }
+        return new Response("ok", { status: 200 });
+      }) as typeof fetch;
+
+      const report = await runParity({
+        left: "http://left",
+        right: "http://right",
+        paths: ["x"],
+        perfSamples: 5,
+        fetcher,
+      });
+      // Right side reports the failure kind from the single attempt.
+      expect(report.mismatches[0].kinds).toContain("failure");
+      expect(report.mismatches[0].right.perfStats).toBeUndefined();
+      // The whole point of short-circuit: we did NOT make 5 calls
+      // against a server we already know is down.
+      expect(rightCalls).toBe(1);
+    });
+
+    it("clamps perfSamples=0 to the single-sample default", async () => {
+      const report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 0,
+        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [0] }),
+      });
+      // 0 silently disabling all probes would be a footgun; we treat
+      // it as the default (=1) and report cleanly.
+      expect(report.matches[0].left.perfStats).toBeUndefined();
+      expect(report.matches[0].left.durationMs).toBeDefined();
+    });
+
+    it("falls back to durationMs when perfStats absent (single-sample with percentile set)", async () => {
+      // Setting perfPercentile without perfSamples>1 shouldn't break
+      // anything — the classifier just falls back to the single-sample
+      // durationMs. Validates the contract robustness.
+      const report = await runParity({
+        left: "http://l",
+        right: "http://r",
+        paths: ["x"],
+        perfSamples: 1,
+        perfPercentile: "p99",
+        perfDeltaMs: 30,
+        fetcher: makeQueuedTimedFetcher({ "http://l/x": [0], "http://r/x": [80] }),
+      });
+      expect(report.mismatches[0]?.kinds).toContain("perf");
+    });
+  });
+
   it("flags 3xx → 200 status mismatch (not redirect mismatch)", async () => {
     // Same status family check guards against false-positive redirects:
     // 301 vs 200 should be reported as a status mismatch, not a redirect mismatch.

--- a/packages/chaosbringer/src/parity.ts
+++ b/packages/chaosbringer/src/parity.ts
@@ -43,11 +43,42 @@ export type MismatchKind =
   | "exception"
   /**
    * Right was slower than left by more than the configured budget.
-   * Single-sample wall-clock — noisy by nature, so the threshold
-   * (`perfDeltaMs` and/or `perfRatio`) must be set explicitly. Pair
-   * with N-sample sweeping at the call site if you need percentiles.
+   * Single-sample wall-clock is noisy by nature, so the threshold
+   * (`perfDeltaMs` and/or `perfRatio`) must be set explicitly. When
+   * `perfSamples > 1` the comparison runs against the configured
+   * percentile of N serial samples (`perfStats[percentile]`) instead
+   * of the single first-sample `durationMs` — same threshold flags,
+   * fewer false positives.
    */
   | "perf";
+
+/**
+ * Percentile of N-sample timings used for the perf comparison when
+ * `perfSamples > 1`. `p95` is the SLO-standard default; `median`
+ * smooths harder for noisy backends; `min` is best-case (closest to
+ * a warm-cache lower bound); `p99` reserves jitter headroom for
+ * cold-start outliers.
+ */
+export type PerfPercentile = "min" | "median" | "p95" | "p99";
+
+/**
+ * Distribution of N serial-sample timings for one side of a probe.
+ * Populated by `runParity` when `perfSamples > 1`; `undefined` for
+ * the default single-sample mode (in that case `durationMs` is the
+ * only timing available).
+ *
+ * `samples` is the count of samples that actually completed — a
+ * sample that errored after the first one doesn't contribute a
+ * duration and is excluded. So a `perfSamples: 10` run with one
+ * mid-run failure yields `samples: 9` here.
+ */
+export interface PerfStats {
+  samples: number;
+  min: number;
+  median: number;
+  p95: number;
+  p99: number;
+}
 
 export interface SideResult {
   /** Final status. `null` when the fetch threw before getting a response. */
@@ -94,8 +125,18 @@ export interface SideResult {
    * every successful probe (free — we already have the start time
    * before fetch). `undefined` when the probe failed before
    * timing could be meaningful (DNS error, connection refused).
+   * When `perfSamples > 1` this is the FIRST sample's timing —
+   * `perfStats` carries the distribution across all samples.
    */
   durationMs?: number;
+  /**
+   * N-sample timing distribution. Set only when the run was
+   * configured with `perfSamples > 1` and at least one sample beyond
+   * the first completed successfully. The classifier uses
+   * `perfStats[perfPercentile]` for the perf comparison when this is
+   * present; otherwise it falls back to `durationMs`.
+   */
+  perfStats?: PerfStats;
 }
 
 export interface ParityProbe {
@@ -161,6 +202,8 @@ export interface ParityReport {
     timeoutMs: number;
     perfDeltaMs?: number;
     perfRatio?: number;
+    perfSamples?: number;
+    perfPercentile?: PerfPercentile;
   };
 }
 
@@ -232,6 +275,27 @@ export interface RunParityOptions {
    * mismatch.
    */
   perfRatio?: number;
+  /**
+   * Number of serial fetch samples per side per path. Defaults to 1
+   * (single-sample, the original behaviour). Set to >1 to defeat
+   * wall-clock jitter — `perfStats` is populated with the distribution
+   * and the perf threshold compares the configured `perfPercentile`
+   * instead of `durationMs`.
+   *
+   * Samples run serially (single connection — concurrent samples would
+   * change the timing model). The per-sample timeout is `timeoutMs`,
+   * so worst-case wall-clock per probe is `perfSamples * timeoutMs`
+   * per side. The first sample captures status/headers/body as
+   * before; later samples contribute timing only.
+   */
+  perfSamples?: number;
+  /**
+   * Which percentile of `perfStats` to compare against `perfDeltaMs` /
+   * `perfRatio` when `perfSamples > 1`. Defaults to `"p95"` — the
+   * SLO-standard target. Ignored when `perfSamples <= 1` because there
+   * is no distribution to take a percentile of.
+   */
+  perfPercentile?: PerfPercentile;
   /** Override fetch for testing. */
   fetcher?: typeof fetch;
   /**
@@ -336,18 +400,15 @@ interface ProbedSide {
   bodyText: string | null;
 }
 
-async function probeSide(
-  base: string,
-  path: string,
-  opts: {
-    followRedirects: boolean;
-    timeoutMs: number;
-    fetcher: typeof fetch;
-    checkBody: boolean;
-    checkHeaders: string[];
-  },
-): Promise<ProbedSide> {
-  const url = joinBase(base, path);
+interface SampleOpts {
+  followRedirects: boolean;
+  timeoutMs: number;
+  fetcher: typeof fetch;
+  checkBody: boolean;
+  checkHeaders: string[];
+}
+
+async function probeOneSample(url: string, opts: SampleOpts): Promise<ProbedSide> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
   // Wall-clock timer wraps the full fetch including body read (when
@@ -381,6 +442,19 @@ async function probeSide(
       result.bodyLength = bytes.byteLength;
       result.bodyHash = createHash("sha256").update(bytes).digest("hex");
       bodyText = new TextDecoder().decode(bytes);
+    } else {
+      // Drain the body so each sample's timing reflects a comparable
+      // transaction. Without this, a server that streams a large
+      // response would look artificially fast (we'd return as soon as
+      // headers landed). The drain is best-effort — some response
+      // bodies aren't readable twice or at all in test doubles, so a
+      // failure here is silently swallowed.
+      try {
+        await resp.arrayBuffer();
+      } catch {
+        // Body drain failed (test double, already-consumed stream).
+        // Timing already captured pre-catch; carry on.
+      }
     }
     result.durationMs = performance.now() - startedAt;
     return { result, bodyText };
@@ -397,9 +471,79 @@ async function probeSide(
   }
 }
 
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  // Nearest-rank with ceiling: matches the conventional "p95 of 10
+  // samples is the 10th element" reading. Clamped to the array so the
+  // worst sample is always reachable.
+  const idx = Math.min(
+    sortedAsc.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sortedAsc.length) - 1),
+  );
+  return sortedAsc[idx];
+}
+
+function computePerfStats(durations: number[]): PerfStats {
+  const sorted = [...durations].sort((a, b) => a - b);
+  return {
+    samples: sorted.length,
+    min: sorted[0],
+    median: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+  };
+}
+
+async function probeSide(
+  base: string,
+  path: string,
+  opts: SampleOpts & { perfSamples: number },
+): Promise<ProbedSide> {
+  const url = joinBase(base, path);
+  const first = await probeOneSample(url, opts);
+  // First-sample failure short-circuits: extra samples wouldn't change
+  // the classification (status=null wins over any timing) and would
+  // just pay N × timeoutMs in wall-clock for nothing.
+  if (first.result.status === null || opts.perfSamples <= 1) {
+    return first;
+  }
+  const durations: number[] = [];
+  if (typeof first.result.durationMs === "number") {
+    durations.push(first.result.durationMs);
+  }
+  for (let i = 1; i < opts.perfSamples; i++) {
+    const next = await probeOneSample(url, opts);
+    if (typeof next.result.durationMs === "number") {
+      durations.push(next.result.durationMs);
+    }
+    // We deliberately do NOT replace `first` even if a later sample
+    // produced a different status / body — the first sample is the
+    // canonical record. Mixed status across samples is a bug worth
+    // catching, but that's the job of a flakiness probe, not parity.
+  }
+  if (durations.length >= 2) {
+    first.result.perfStats = computePerfStats(durations);
+  }
+  return first;
+}
+
 interface ClassifyOptions {
   perfDeltaMs?: number;
   perfRatio?: number;
+  perfPercentile?: PerfPercentile;
+}
+
+/**
+ * Pick the timing value the perf threshold should compare. When the
+ * side carries `perfStats` (N-sample mode) we use the configured
+ * percentile so wall-clock jitter on a single sample can't trip the
+ * threshold. Otherwise the legacy single-sample `durationMs` is the
+ * only thing we have.
+ */
+function pickPerfValue(side: SideResult, percentile: PerfPercentile): number | undefined {
+  if (side.perfStats) return side.perfStats[percentile];
+  return side.durationMs;
 }
 
 /**
@@ -473,14 +617,20 @@ function classify(
   // mismatch. Skipped silently when either side has no duration
   // (probe failed before timing was meaningful) or when no threshold
   // is configured — leaves single-sample latency noise off by default.
+  // `pickPerfValue` switches to `perfStats[percentile]` when N-sample
+  // mode is on, so the OR-of-thresholds runs against the chosen
+  // percentile rather than a noisy single sample.
+  const percentile = opts.perfPercentile ?? "p95";
+  const lPerf = pickPerfValue(left, percentile);
+  const rPerf = pickPerfValue(right, percentile);
   if (
-    typeof left.durationMs === "number" &&
-    typeof right.durationMs === "number" &&
-    ((opts.perfDeltaMs && opts.perfDeltaMs > 0 && right.durationMs - left.durationMs > opts.perfDeltaMs) ||
+    typeof lPerf === "number" &&
+    typeof rPerf === "number" &&
+    ((opts.perfDeltaMs && opts.perfDeltaMs > 0 && rPerf - lPerf > opts.perfDeltaMs) ||
       (opts.perfRatio &&
         opts.perfRatio > 0 &&
-        left.durationMs > 0 &&
-        right.durationMs > left.durationMs * opts.perfRatio))
+        lPerf > 0 &&
+        rPerf > lPerf * opts.perfRatio))
   ) {
     kinds.push("perf");
   }
@@ -506,6 +656,11 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   // the result map is keyed predictably for downstream consumers.
   const checkHeaders = (opts.checkHeaders ?? []).map((h) => h.toLowerCase());
   const checkExceptions = opts.checkExceptions ?? false;
+  // perfSamples normalised to >=1; 0/negative would silently disable
+  // probing entirely otherwise. Default 1 keeps single-sample as the
+  // base behaviour.
+  const perfSamples = Math.max(1, Math.floor(opts.perfSamples ?? 1));
+  const perfPercentile: PerfPercentile = opts.perfPercentile ?? "p95";
 
   // Browser launch is amortised across all paths — one Chromium for
   // the whole run, fresh context per visit. Only fires when
@@ -522,8 +677,10 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
   try {
     for (const path of opts.paths) {
       // Probe both sides in parallel — they're independent and the report
-      // is symmetric, so there's no reason to serialise.
-      const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody, checkHeaders };
+      // is symmetric, so there's no reason to serialise. Inside each
+      // side the N samples run serially (single-connection timing
+      // model); only the left/right pairing is concurrent.
+      const sideOpts = { followRedirects, timeoutMs, fetcher, checkBody, checkHeaders, perfSamples };
       const [leftProbe, rightProbe] = await Promise.all([
         probeSide(opts.left, path, sideOpts),
         probeSide(opts.right, path, sideOpts),
@@ -549,6 +706,7 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
       const kinds = classify(left, right, {
         perfDeltaMs: opts.perfDeltaMs,
         perfRatio: opts.perfRatio,
+        perfPercentile,
       });
       if (kinds.length > 0) {
         const m: ParityMismatch = { ...probe, kinds };
@@ -584,6 +742,10 @@ export async function runParity(opts: RunParityOptions): Promise<ParityReport> {
       timeoutMs,
       ...(opts.perfDeltaMs !== undefined ? { perfDeltaMs: opts.perfDeltaMs } : {}),
       ...(opts.perfRatio !== undefined ? { perfRatio: opts.perfRatio } : {}),
+      // Echo the resolved sampling config only when N-sample mode is
+      // actually on, so the legacy single-sample report shape stays
+      // unchanged for existing consumers.
+      ...(perfSamples > 1 ? { perfSamples, perfPercentile } : {}),
     },
   };
 }

--- a/packages/chaosbringer/src/recipes/load-cli.ts
+++ b/packages/chaosbringer/src/recipes/load-cli.ts
@@ -6,7 +6,8 @@
  * or invariants; the CLI is the "I just want N workers replaying my
  * verified recipes for K minutes" path.
  */
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { parseArgs } from "node:util";
 import { formatLoadReport, parseDurationMs, type DurationInput } from "../load/index.js";
 import {
@@ -79,6 +80,7 @@ export async function runLoadCli(argv: string[]): Promise<void> {
     thinkTime: parsed.thinkTime,
   });
   if (parsed.output) {
+    mkdirSync(dirname(parsed.output), { recursive: true });
     writeFileSync(parsed.output, JSON.stringify(result, null, 2));
   }
   if (parsed.json) {

--- a/playground/README.md
+++ b/playground/README.md
@@ -28,6 +28,12 @@ pnpm loop chaos          # crawl v1 + v2 + diff only
 
 # Exit code is non-zero when the loop detected something (parity
 # mismatch, new clusters on v2, etc.) — drop into reports/ to see.
+
+# CI-gate mode: flip the exit code semantics. Success means the loop
+# caught EXACTLY the expected number of seeded mismatches; less is a
+# regression in detection, more is a false positive. Used by the
+# `playground-dogfood` workflow.
+pnpm loop --expect-mismatches 10
 ```
 
 Outputs land in:

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -128,18 +128,20 @@ async function main(): Promise<void> {
         "content-type,cache-control",
         "--check-exceptions",
         // Single-sample wall-clock on a loaded CI runner is too noisy
-        // for a hard-pass gate: a cold-start blip on v1 alone can hide
-        // BUG-9 (v2 sleeps 120ms), and noise on an unrelated path can
-        // trip a false-positive. Use the N-sample percentile mode the
-        // sibling parity feature in this same package adds — 5 samples
-        // at p95 reduces both directions of flake to negligible while
-        // BUG-9's 120ms floor still trips the 50ms threshold.
+        // for a hard-pass gate. Use N-sample median: p95 of 5 samples
+        // is just the max (nearest-rank: ceil(0.95*5)-1 = 4), which on
+        // a contended runner is the noisiest possible choice. Median
+        // of 5 takes the 3rd-fastest sample — trims a cold-start blip
+        // on either end. BUG-9's v2-side 120ms sleep is consistent
+        // across samples so its median is still well above the 50ms
+        // threshold, while a one-off jitter spike on an unrelated path
+        // can no longer trip a false positive.
         "--perf-delta-ms",
         "50",
         "--perf-samples",
         "5",
         "--perf-percentile",
-        "p95",
+        "median",
       ]);
       if (code !== 0) exitCode = 1;
     }

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -9,26 +9,57 @@
  * having to manage processes.
  *
  * Usage:
- *   tsx loop.ts             # full pass (parity + chaos:v1 + chaos:v2 + diff)
- *   tsx loop.ts parity      # only parity
- *   tsx loop.ts chaos       # only chaos crawls + diff
+ *   tsx loop.ts                          # full pass
+ *   tsx loop.ts parity                   # only parity
+ *   tsx loop.ts chaos                    # only chaos crawls + diff
+ *   tsx loop.ts --expect-mismatches 10   # CI gate: exit 0 iff count==10
  *
  * Exit code:
- *   0 — nothing the loop detected (no parity mismatches, no new clusters)
- *   1 — at least one tool reported a deviation. Look in reports/ and
- *       artifacts/clusters/ for evidence.
+ *   0 — nothing the loop detected (no parity mismatches, no new
+ *       clusters); OR `--expect-mismatches N` was supplied and the
+ *       observed mismatch count matched N exactly (the CI baseline
+ *       upheld).
+ *   1 — at least one tool reported a deviation (default mode) OR
+ *       the observed mismatch count did not match `--expect-mismatches`.
+ *       Look in reports/ and artifacts/clusters/ for evidence.
+ *   2 — bad CLI usage (invalid flag value).
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
+import { parseArgs } from "node:util";
 
 const PORT_V1 = 5001;
 const PORT_V2 = 5002;
 const REPORTS = "reports";
 const ARTIFACTS = "artifacts";
 
-const mode = (process.argv[2] ?? "all") as "all" | "parity" | "chaos" | "journey";
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    "expect-mismatches": { type: "string" },
+  },
+  allowPositionals: true,
+});
+
+const mode = (positionals[0] ?? "all") as "all" | "parity" | "chaos" | "journey";
+// `--expect-mismatches N` flips the exit-code semantics: a successful
+// CI run is one where the playground catches *exactly* N mismatches
+// (the seeded baseline), not zero. Without the flag the loop behaves
+// as before — exit 1 on any deviation, useful for local "did I break
+// detection" runs.
+let expectMismatches: number | null = null;
+if (values["expect-mismatches"] !== undefined) {
+  const n = parseInt(values["expect-mismatches"], 10);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(
+      `loop: --expect-mismatches must be a non-negative integer (got ${values["expect-mismatches"]})`,
+    );
+    process.exit(2);
+  }
+  expectMismatches = n;
+}
 
 async function waitForHealth(port: number, timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -166,18 +197,44 @@ async function main(): Promise<void> {
     // Give them a moment so the process group is gone before exit.
     await sleep(200);
   }
-  printSummary();
+  const summary = printSummary();
+  // `--expect-mismatches` mode flips the exit code: success means the
+  // playground caught exactly the expected number of seeded bugs. A
+  // regression that drops detection (count too low) or one that adds
+  // false positives (count too high) both fail the gate.
+  if (expectMismatches !== null) {
+    if (summary.mismatches === expectMismatches) {
+      console.log(
+        `\n[OK] expected ${expectMismatches} mismatch(es), got ${summary.mismatches}`,
+      );
+      process.exit(0);
+    } else {
+      console.log(
+        `\n[FAIL] expected ${expectMismatches} mismatch(es), got ${summary.mismatches}`,
+      );
+      process.exit(1);
+    }
+  }
   process.exit(exitCode);
+}
+
+interface SummaryCounts {
+  /** Number of distinct mismatch probes (one entry per path/step pair). */
+  mismatches: number;
+  /** Sum of all `kinds[]` firings across all probes — strictly >= mismatches. */
+  kindOccurrences: number;
 }
 
 /**
  * Read every JSON report under `reports/` and tally up mismatches by
  * `MismatchKind`. Prints a table at the end of the loop so an
  * operator (or sub-agent) sees the overall shape at a glance —
- * useful as the CI gate's "did this run get worse" signal.
+ * useful as the CI gate's "did this run get worse" signal. Returns
+ * the count so `--expect-mismatches` can gate on it without re-reading
+ * the files.
  */
-function printSummary(): void {
-  if (!existsSync(REPORTS)) return;
+function printSummary(): SummaryCounts {
+  if (!existsSync(REPORTS)) return { mismatches: 0, kindOccurrences: 0 };
   type ReportShape = {
     mismatches?: Array<{ kinds?: string[]; path?: string; label?: string }>;
   };
@@ -200,9 +257,11 @@ function printSummary(): void {
       for (const k of kinds) counts.set(k, (counts.get(k) ?? 0) + 1);
     }
   }
+  let kindOccurrences = 0;
+  for (const n of counts.values()) kindOccurrences += n;
   if (counts.size === 0) {
     console.log("\n=== summary === no mismatches");
-    return;
+    return { mismatches: 0, kindOccurrences: 0 };
   }
   console.log("\n=== summary ===");
   // Stable order: by precedence-ish then alphabetical.
@@ -213,7 +272,13 @@ function printSummary(): void {
   for (const k of sortedKinds) {
     console.log(`  ${k.padEnd(10)} ${counts.get(k)}`);
   }
-  console.log(`  ${"TOTAL".padEnd(10)} ${detail.length} finding(s) across ${detail.length} kind-occurrences`);
+  // Two numbers, not one: a header+body bug on the same path is 1
+  // mismatch but 2 kind-occurrences. The original printout used
+  // detail.length for both — wrong, and hid that distinction.
+  console.log(
+    `  ${"TOTAL".padEnd(10)} ${detail.length} mismatch(es) across ${kindOccurrences} kind-occurrence(s)`,
+  );
+  return { mismatches: detail.length, kindOccurrences };
 }
 
 main().catch((err) => {

--- a/playground/loop.ts
+++ b/playground/loop.ts
@@ -127,11 +127,19 @@ async function main(): Promise<void> {
         "--check-headers",
         "content-type,cache-control",
         "--check-exceptions",
-        // Generous budget — single-sample wall-clock has jitter even
-        // for fast localhost loops. The seeded BUG-9 sleeps 120ms,
-        // well above this floor.
+        // Single-sample wall-clock on a loaded CI runner is too noisy
+        // for a hard-pass gate: a cold-start blip on v1 alone can hide
+        // BUG-9 (v2 sleeps 120ms), and noise on an unrelated path can
+        // trip a false-positive. Use the N-sample percentile mode the
+        // sibling parity feature in this same package adds — 5 samples
+        // at p95 reduces both directions of flake to negligible while
+        // BUG-9's 120ms floor still trips the 50ms threshold.
         "--perf-delta-ms",
         "50",
+        "--perf-samples",
+        "5",
+        "--perf-percentile",
+        "p95",
       ]);
       if (code !== 0) exitCode = 1;
     }


### PR DESCRIPTION
## Summary

Closes #102, #103, #87.

Two commits picking up the next-gap items the iter-11 dogfood verifier flagged from #101, plus a drive-by fix for the sibling `--output` mkdir cases that #87 missed.

### `df6c1ed` — parity N-sample perf (#102)

`--perf-delta-ms` / `--perf-ratio` on a single wall-clock sample is too noisy for CI gating — two consecutive verifier agents called this out. Now:

- `--perf-samples N` (default 1): N serial fetches per side per path. Sample 1 captures status / headers / body; samples 2..N contribute timing only.
- `--perf-percentile {min|median|p95|p99}` (default p95): which percentile of `perfStats` the threshold compares.
- `SideResult.perfStats: { samples, min, median, p95, p99 }` populated when N > 1.
- First-sample failure short-circuits — N retries against a dead host wastes N × timeout.
- Body drain on every sample so timing reflects a comparable transaction even when `--check-body` is off.
- `ParityReport.config` echoes `perfSamples` / `perfPercentile` only when N > 1, keeping the single-sample report shape unchanged.
- CLI rejects out-of-range `--perf-samples` and unknown `--perf-percentile` with an explicit message rather than silently disabling.

Journey side is deliberately out of scope — re-running a whole journey N times is a different cost model and nobody's asked for it yet.

13 new tests (8 parity, 4 CLI, 1 fetcher-bug regression).

### `f726d5b` — playground CI gate (#103) + sibling mkdir fixes (#87)

**CI gate.** New `.github/workflows/playground.yml` spawns both server variants, runs the full `pnpm loop`, and asserts the mismatch count matches `EXPECTED_MISMATCHES` (default 10, the seeded BUG_LEDGER size). Regressions that break a detector, or that seed new divergence without updating the count, fail this gate. Reports and per-page artifact bundles upload on every run so the evidence trail is always available.

`loop.ts` learned `--expect-mismatches N`: without the flag the legacy "exit 1 on any deviation" behaviour stays; with the flag it exits 0 iff the count matches exactly. Both detection-regression (count too low) and false-positive (count too high) fail.

Drive-by fix in `printSummary` — the original `${detail.length} findings across ${detail.length} kind-occurrences` used the same variable twice, hiding the distinction between "one path with header+body drift" (1 mismatch, 2 kind-firings) and "two paths with one kind each".

**`--output` mkdir.** #87 was originally fixed for `saveReport` in a38a7fc, but the same `writeFileSync` shape recurs in three siblings the original fix missed: `--junit` and `--heatmap-out` on the main crawler, and `--output` on the recipes load CLI. All three now `mkdirSync(dirname(...), { recursive: true })` before writing.

## Test plan

- [x] `pnpm -F chaosbringer test src/parity` — 55 tests pass (43 existing + 12 new)
- [x] `pnpm -F chaosbringer test src/journey` — 21 tests pass (SideResult type extension is additive)
- [x] `pnpm -F chaosbringer build` — clean tsc
- [x] `pnpm -F @mizchi/chaosbringer-playground typecheck` — clean tsc
- [x] `pnpm exec tsx loop.ts --expect-mismatches abc` rejects with explicit message
- [ ] CI run on this PR will exercise the new `playground-dogfood` workflow against the seeded baseline — if `EXPECTED_MISMATCHES=10` is wrong the gate will fail and surface the correct number for adjustment

The 21 pre-existing E2E failures across the rest of the test suite are all Playwright-Chromium-not-installed in the cloud environment, unrelated to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGScReR8AWUzBYhAm2sFqV)_