### PR TITLE
docs+fix(chaosbringer): address DX gaps from #129

### DIFF
--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -182,7 +182,26 @@ await chaos({
 
 `probability` is evaluated against the seeded RNG — same seed, same pattern of injections.
 
-Per-rule `matched` / `injected` counters end up in `report.faultInjections`.
+Per-rule `matched` / `injected` counters end up in `report.faultInjections`. When a rule's `matched` is `0` at the end of a run, chaosbringer emits a `fault_rule_unmatched` warning on the logger — useful for catching typo'd `urlPattern` regexes and rules that are shadowed by an earlier catch-all.
+
+### Rule order: first match wins
+
+Rules are evaluated **top-to-bottom** in the order you pass them, and the **first** match wins. This is the opposite of Playwright's raw `page.route(...)` API, where later registrations override earlier ones (LIFO). Put **specific rules first** and broad catch-alls last:
+
+```ts
+faultInjection: [
+  // ✅ specific overrides first
+  faults.status(200, {
+    urlPattern: /^https:\/\/api\.example\.com\/p\//,
+    body: '{"foo":"bar"}',
+    name: "fulfill-api",
+  }),
+  // ✅ catch-all last
+  faults.abort({ urlPattern: /^https?:\/\/(?!127\.0\.0\.1)/, name: "block-external" }),
+],
+```
+
+If you reverse the order, the catch-all swallows every request and `fulfill-api` will show `matched: 0` in the report (and trigger the unmatched-rule warning described above).
 
 ### Fault profiles
 
@@ -612,6 +631,14 @@ await chaos({
 - `notFound: "abort"` fails them — useful when you want to prove a run is fully deterministic.
 - Fault injection rules still apply in replay mode and take precedence over HAR responses.
 
+> **Heads up — `notFound: "abort"` with `traceparent` injection:** when
+> `traceparent` is enabled, every outgoing request carries a freshly-generated
+> `traceparent` header that wasn't in the recorded HAR. Depending on your
+> Playwright version and HAR matcher, this can cause `notFound: "abort"` to
+> fail on every request during replay. If you hit this, either record the HAR
+> with `traceparent` also enabled (so the matcher sees consistent headers),
+> set `traceparent: false` for replay-mode runs, or use `notFound: "fallback"`.
+
 ## Accessibility (axe-core)
 
 Install `axe-core` as a peer and opt in with either the `invariants.axe()` preset or the `--axe` flag. Each visited page is scanned; violations are reported as invariant failures (name: `a11y-axe`), which always fail the run.
@@ -938,6 +965,19 @@ chaosbringer flake --url http://localhost:3000 --runs 5 --seed 42
 
 With a fixed `--seed`, RNG-driven variance is impossible, so any flake points at non-determinism outside chaosbringer (server, network, timers, or observable ordering). Pair with `--har-replay` or `--trace-replay` to narrow further. Exits 1 when any cluster / page flaked, so CI can gate on it. `--output <path>` also writes the analysis as JSON.
 
+Programmatic equivalent — `chaos()` does **not** throw when `strict: true` triggers a failure; it returns `{ report, passed: false, exitCode: 1 }`. That means you can collect reports across runs even with `strict: true` and pass them to `flakeReport()`:
+
+```ts
+import { chaos, flakeReport } from "chaosbringer";
+
+const reports = [];
+for (const seed of [1, 2, 3, 4, 5]) {
+  const { report } = await chaos({ ...sharedOpts, seed, strict: true });
+  reports.push(report);
+}
+const analysis = flakeReport(reports);
+```
+
 ### `shard`
 
 Split a crawl across N processes and merge the reports. Each worker is spawned with `--shard i/N` and hashes discovered URLs (FNV-1a) mod N; it only processes URLs whose hash matches its index, so shards do disjoint work. `baseUrl` is always processed by every shard so each has a seed for BFS.
@@ -1128,6 +1168,36 @@ new ChaosCrawler({
   "faultInjections": [{ "rule": "api-500", "matched": 4, "injected": 4 }]
 }
 ```
+
+## Troubleshooting
+
+### `fault_rule_unmatched` warning at end of run
+
+The logger emits one `fault_rule_unmatched` event per rule whose `matched` counter is `0` at the end of a crawl. Usually one of:
+
+- The `urlPattern` regex has a typo (escape mismatches and missing `^` / `$` anchors are common).
+- A broader catch-all earlier in the array is shadowing this rule — see [Rule order: first match wins](#rule-order-first-match-wins).
+- The crawl never visited a page that issues the matching request (raise `maxPages` or check `excludePatterns`).
+
+### Loopback (`127.0.0.1`) sub-resources blocked under Chromium 130+
+
+If the page you're testing loads sub-resources from `127.0.0.1` (or any loopback address) while the page itself is served from a non-loopback origin, Chromium's Private Network Access classifier may block the sub-resource with:
+
+```
+Permission was denied for this request to access the `loopback` address space.
+```
+
+Switching the page origin to `*.localhost` or to a `127.0.0.1:PORT` URL does not help when the response is intercepted (Playwright `page.route`), because Chromium doesn't classify the intercepted response as loopback. The reliable workaround is to launch Chromium with `--disable-web-security`:
+
+```ts
+await chaos({
+  baseUrl,
+  launchOptions: { args: ["--disable-web-security"] },
+  // ...
+});
+```
+
+This is a test-only flag — never ship it to real users. The PNA-specific flags (`--disable-features=BlockInsecurePrivateNetworkRequests,...`) are not sufficient on their own for intercepted responses.
 
 ## License
 

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -839,6 +839,18 @@ export class ChaosCrawler {
     const endTime = Date.now();
     const report = this.generateReport(endTime);
 
+    // Surface fault rules that never matched a request — typically a typo'd
+    // urlPattern, or a rule shadowed by an earlier catch-all (rules are
+    // first-match-wins). Without this, the only signal is matched:0 buried
+    // inside report.faultInjections, which is easy to miss.
+    for (const compiled of this.compiledFaultRules) {
+      if (compiled.matched === 0) {
+        this.logger.warn("fault_rule_unmatched", {
+          rule: compiled.rule.name ?? compiled.pattern.toString(),
+        });
+      }
+    }
+
     // Log crawl end
     this.logger.logCrawlEnd({
       duration: report.duration,

--- a/packages/chaosbringer/src/types.ts
+++ b/packages/chaosbringer/src/types.ts
@@ -24,7 +24,15 @@ export interface CrawlerOptions {
   screenshotDir?: string;
   /** URL patterns to exclude (regex strings) */
   excludePatterns?: string[];
-  /** Error message patterns to ignore (regex strings) */
+  /**
+   * Error message patterns to ignore (regex strings).
+   *
+   * Matched (case-insensitively) against `PageError.message` for **every**
+   * error type — `console`, `network`, `js-exception`, `unhandled-rejection`,
+   * and `invariant-violation`. There is no separate
+   * `ignoreNetworkErrorPatterns`; use this single allowlist for both
+   * console noise and network noise.
+   */
   ignoreErrorPatterns?: string[];
   /** URL patterns to treat as SPA (regex strings) - errors from these are categorized separately */
   spaPatterns?: string[];


### PR DESCRIPTION
## Summary

Addresses the documentation + small-code items from #129 (DX umbrella). 5 of the 6 sub-items; deliberately skipped the heuristic-based `validateOptions` warning for catch-all-shadows-specific patterns (item 1.2) since that's brittle to design correctly and warrants a separate discussion.

### Doc changes (README)
- **Rule ordering** — explicit "first match wins, opposite of Playwright `page.route` LIFO" note in the Fault injection section, with a specific-first / catch-all-last example. (item 1.1)
- **HAR + traceparent** — heads-up under HAR section that `notFound: "abort"` replay can fail when traceparent injection adds a fresh per-request header that wasn't recorded. (item 2.2)
- **`flakeReport` with strict** — added a programmatic example to the `flake` subcommand section showing that `chaos()` does **not** throw on strict failures, so reports can be aggregated across runs even with `strict: true`. (item 3)
- **PNA troubleshooting** — new Troubleshooting section covering Chromium 130+ blocking intercepted loopback sub-resources and the `--disable-web-security` workaround. (item 4)

### Code changes
- **`fault_rule_unmatched` warning** — `crawler.ts` now emits a `logger.warn("fault_rule_unmatched", { rule })` at end of run for every fault rule whose `matched` counter is `0`. Catches typo'd `urlPattern` regexes and rules shadowed by an earlier catch-all without forcing users to grep `report.faultInjections`. (item 5)
- **`ignoreErrorPatterns` JSDoc** — expanded the JSDoc in `types.ts` to make explicit that the allowlist applies to every `PageError.type` (console / network / js-exception / unhandled-rejection / invariant-violation), since the original comment didn't clarify scope. (item 6)

## Test plan
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec vitest run` — 866 / 866 unit tests pass (chaos.test.ts `invokes setup before the crawl` is a pre-existing failure on main, unrelated to this change).
- [ ] Verify the new `fault_rule_unmatched` warning fires in a real run (manual smoke).

Closes none of #129 alone — please pick any items to merge and split the rest off as needed.

https://claude.ai/code/session_018t71eUNUYNqZs86fwLuCaf

---
_Generated by [Claude Code](https://claude.ai/code/session_018t71eUNUYNqZs86fwLuCaf)_