### PR TITLE
feat(crawler): detect shadowed fault rules at crawl start (closes last #129 item)

### DIFF
--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -201,7 +201,7 @@ faultInjection: [
 ],
 ```
 
-If you reverse the order, the catch-all swallows every request and `fulfill-api` will show `matched: 0` in the report (and trigger the unmatched-rule warning described above).
+If you reverse the order, the catch-all swallows every request and `fulfill-api` will show `matched: 0` in the report (and trigger the unmatched-rule warning described above). Chaosbringer also runs a best-effort static check at crawl start and emits one `fault_rule_shadowed` warning per shadowed pair — catching the common pathological case (broad regex before specific one) before the crawl has consumed a single request.
 
 ### Fault profiles
 
@@ -1232,6 +1232,10 @@ The logger emits one `fault_rule_unmatched` event per rule whose `matched` count
 - The `urlPattern` regex has a typo (escape mismatches and missing `^` / `$` anchors are common).
 - A broader catch-all earlier in the array is shadowing this rule — see [Rule order: first match wins](#rule-order-first-match-wins).
 - The crawl never visited a page that issues the matching request (raise `maxPages` or check `excludePatterns`).
+
+### `fault_rule_shadowed` warning at crawl start
+
+Emitted (best-effort) when a later rule's `urlPattern` looks fully shadowed by an earlier one — typically a `/^https?:\/\//`-style catch-all placed before a specific override. Each warning includes `earlierRule`, `laterRule`, and a `sampleUrl` derived from the later pattern that the earlier rule also matches. Reorder so specific rules come first, or narrow the catch-all's pattern. False negatives are accepted (the detector is heuristic, not a regex-superset prover), but false positives are designed to be rare — `probability < 1` and non-overlapping `methods` filters disable the check for that pair.
 
 ### Loopback (`127.0.0.1`) sub-resources blocked under Chromium 130+
 

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -727,6 +727,19 @@ export class ChaosCrawler {
       enableRecovery: this.options.enableRecovery,
     });
 
+    // Surface fault rules whose URL pattern is fully shadowed by an
+    // earlier rule (the unreachable-rule case from #129). Rules are
+    // evaluated top-to-bottom, first-match-wins, so a broad catch-all
+    // placed before a specific override will silently swallow every
+    // request the override expected.
+    for (const shadow of findFaultRuleShadows(this.compiledFaultRules)) {
+      this.logger.warn("fault_rule_shadowed", {
+        earlierRule: shadow.earlierName,
+        laterRule: shadow.laterName,
+        sampleUrl: shadow.sampleUrl,
+      });
+    }
+
     if (this.options.screenshots && !existsSync(this.options.screenshotDir)) {
       mkdirSync(this.options.screenshotDir, { recursive: true });
     }
@@ -3214,6 +3227,108 @@ function compileFaultRules(rules: FaultRule[] | undefined): Array<{
     });
   }
   return compiled;
+}
+
+/**
+ * Strip the regex-metacharacters from `re.source` to produce a candidate
+ * URL that the regex would (almost certainly) match. Used by
+ * `findFaultRuleShadows` to test whether a later rule is unreachable
+ * given an earlier rule's pattern.
+ *
+ * Best-effort: undecidable in general, but covers the catch-all-shadowing-
+ * specific-host case from issue #129.
+ */
+export function sampleUrlFromRegex(re: RegExp): string {
+  let s = re.source;
+  // Drop anchors — they're position constraints, not characters.
+  s = s.replace(/^\^/, "").replace(/\$$/, "");
+  // Drop non-capturing prefixes / lookahead / lookbehind so the literal
+  // tail still produces a useful sample.
+  s = s.replace(/\(\?[:=!<][^)]*\)/g, "");
+  // Drop the rest of unnested groups (`(...)`, `(?...)`, including any
+  // trailing quantifier).
+  s = s.replace(/\([^()]*\)[?*+]?/g, "");
+  // Backslash-escapes for literal characters like `\.` `\/` `\:` `\-`.
+  s = s.replace(/\\([./:?&=@#%-])/g, "$1");
+  // Common character-class shorthands → a plausible URL-safe letter.
+  s = s.replace(/\\[wd]/gi, "a");
+  s = s.replace(/\\s/gi, " ");
+  // Drop quantified character classes outright (`[^/]+` etc.) — keeping
+  // them tends to inject regex syntax into the sample.
+  s = s.replace(/\[[^\]]+\][?*+]?/g, "");
+  // Drop remaining regex metachars: `*`, `+`, `?`, `|`, `{N}`, `{N,M}`.
+  s = s.replace(/\{\d+(,\d*)?\}/g, "");
+  s = s.replace(/[*+?|]/g, "");
+  return s;
+}
+
+/**
+ * A later rule is shadowed by an earlier one when every request that would
+ * match the later rule also matches the earlier rule. Detection is
+ * undecidable for arbitrary regexes — we use `sampleUrlFromRegex` plus the
+ * `methods` / `probability` filters to catch the common pathological case
+ * called out in #129: catch-all (`/^https?:\/\//`) followed by a specific
+ * host (`/^https:\/\/api\.example\.com\//`).
+ *
+ * Returns one entry per shadowed pair, ordered from outermost loop. False
+ * negatives are accepted; false positives should be rare given the strict
+ * probability / methods checks.
+ */
+export function findFaultRuleShadows(
+  compiled: ReadonlyArray<{
+    rule: FaultRule;
+    pattern: RegExp;
+    methods?: string[];
+  }>,
+): Array<{
+  earlierIndex: number;
+  laterIndex: number;
+  earlierName: string;
+  laterName: string;
+  sampleUrl: string;
+}> {
+  const out: Array<{
+    earlierIndex: number;
+    laterIndex: number;
+    earlierName: string;
+    laterName: string;
+    sampleUrl: string;
+  }> = [];
+
+  const ruleLabel = (r: FaultRule, pattern: RegExp): string =>
+    r.name ?? pattern.toString();
+
+  for (let i = 0; i < compiled.length; i++) {
+    const earlier = compiled[i]!;
+    // A probability < 1 rule never reliably shadows — some requests fall
+    // through to the next rule. Skip to avoid false positives.
+    if ((earlier.rule.probability ?? 1) < 1) continue;
+
+    for (let j = i + 1; j < compiled.length; j++) {
+      const later = compiled[j]!;
+
+      // Method overlap. Earlier must accept every method the later one
+      // matches; otherwise some requests escape to `later`.
+      if (earlier.methods !== undefined) {
+        if (later.methods === undefined) continue; // later: all methods
+        const earlierSet = new Set(earlier.methods);
+        if (!later.methods.every((m) => earlierSet.has(m))) continue;
+      }
+
+      const sample = sampleUrlFromRegex(later.pattern);
+      if (sample.length === 0) continue;
+      if (!earlier.pattern.test(sample)) continue;
+
+      out.push({
+        earlierIndex: i,
+        laterIndex: j,
+        earlierName: ruleLabel(earlier.rule, earlier.pattern),
+        laterName: ruleLabel(later.rule, later.pattern),
+        sampleUrl: sample,
+      });
+    }
+  }
+  return out;
 }
 
 async function applyFault(route: Route, fault: Fault): Promise<void> {

--- a/packages/chaosbringer/src/fault-shadow.test.ts
+++ b/packages/chaosbringer/src/fault-shadow.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { findFaultRuleShadows, sampleUrlFromRegex } from "./crawler.js";
+import type { FaultRule } from "./types.js";
+
+function compiled(rules: Array<{
+  name?: string;
+  pattern: RegExp;
+  methods?: string[];
+  probability?: number;
+}>) {
+  return rules.map((r) => {
+    const rule: FaultRule = {
+      urlPattern: r.pattern,
+      fault: { kind: "abort" },
+    };
+    if (r.name !== undefined) rule.name = r.name;
+    if (r.methods !== undefined) rule.methods = r.methods;
+    if (r.probability !== undefined) rule.probability = r.probability;
+    return {
+      rule,
+      pattern: r.pattern,
+      methods: r.methods?.map((m) => m.toUpperCase()),
+    };
+  });
+}
+
+describe("sampleUrlFromRegex", () => {
+  it("strips ^/$ anchors so the literal body survives", () => {
+    expect(sampleUrlFromRegex(/^https:\/\/api\.example\.com\/p\//)).toBe(
+      "https://api.example.com/p/",
+    );
+  });
+
+  it("drops `(?...)` lookahead constructs (so negative lookahead in catch-alls doesn't poison the sample)", () => {
+    // The catch-all from #129: anything not on 127.0.0.1.
+    expect(sampleUrlFromRegex(/^https?:\/\/(?!127\.0\.0\.1)/)).toBe(
+      "https://",
+    );
+  });
+
+  it("drops quantified character classes so the sample stays URL-shaped", () => {
+    // `[^/]+` is dropped entirely; `\d` becomes a single letter. The
+    // important property is that no regex metachars leak into the sample
+    // (so `earlier.pattern.test(sample)` doesn't accidentally double-match).
+    const sample = sampleUrlFromRegex(
+      /^https:\/\/api\.example\.com\/[^/]+\/v\d+\//,
+    );
+    expect(sample).not.toMatch(/[\[\]+*?{}|]/);
+    expect(sample.startsWith("https://api.example.com/")).toBe(true);
+    expect(sample.endsWith("/")).toBe(true);
+  });
+
+  it("returns an empty / metachar-only string when there's no literal content to recover", () => {
+    // `[a-z]+` has no literals; the function returns "" so the caller skips
+    // the shadow check rather than emitting a spurious warning.
+    expect(sampleUrlFromRegex(/^[a-z]+$/)).toBe("");
+    // `.*` reduces to "." — a sample no realistic URL-shaped pattern will
+    // match, so no false positive in `findFaultRuleShadows`.
+    expect(sampleUrlFromRegex(/.*/)).toBe(".");
+  });
+});
+
+describe("findFaultRuleShadows", () => {
+  it("flags the canonical catch-all-before-specific case from #129", () => {
+    const rules = compiled([
+      // Block-external catch-all FIRST — wrong order.
+      {
+        name: "block-external",
+        pattern: /^https?:\/\/(?!127\.0\.0\.1)/,
+      },
+      {
+        name: "fulfill-api",
+        pattern: /^https:\/\/api\.example\.com\/p\//,
+      },
+    ]);
+
+    const shadows = findFaultRuleShadows(rules);
+    expect(shadows).toHaveLength(1);
+    expect(shadows[0]!.earlierName).toBe("block-external");
+    expect(shadows[0]!.laterName).toBe("fulfill-api");
+    expect(shadows[0]!.sampleUrl).toBe("https://api.example.com/p/");
+  });
+
+  it("does not flag a specific-first / catch-all-last config", () => {
+    const rules = compiled([
+      {
+        name: "fulfill-api",
+        pattern: /^https:\/\/api\.example\.com\/p\//,
+      },
+      {
+        name: "block-external",
+        pattern: /^https?:\/\//,
+      },
+    ]);
+
+    expect(findFaultRuleShadows(rules)).toEqual([]);
+  });
+
+  it("does not flag unrelated patterns", () => {
+    const rules = compiled([
+      { name: "block-tracking", pattern: /tracking/ },
+      { name: "api-500", pattern: /^https:\/\/api\.example\.com\/users/ },
+    ]);
+    expect(findFaultRuleShadows(rules)).toEqual([]);
+  });
+
+  it("skips earlier rules with probability < 1 (they don't reliably shadow)", () => {
+    const rules = compiled([
+      {
+        name: "flaky-block",
+        pattern: /^https?:\/\//,
+        probability: 0.3,
+      },
+      {
+        name: "fulfill-api",
+        pattern: /^https:\/\/api\.example\.com\/p\//,
+      },
+    ]);
+    expect(findFaultRuleShadows(rules)).toEqual([]);
+  });
+
+  it("respects method filters — earlier rule narrowed to POST does not shadow GET-default later rule", () => {
+    const rules = compiled([
+      {
+        name: "post-blocker",
+        pattern: /^https:\/\//,
+        methods: ["POST"],
+      },
+      {
+        name: "any-method-api",
+        pattern: /^https:\/\/api\.example\.com\/p\//,
+        // no methods = all methods
+      },
+    ]);
+    expect(findFaultRuleShadows(rules)).toEqual([]);
+  });
+
+  it("flags when earlier method-restricted rule covers every method the later rule names", () => {
+    const rules = compiled([
+      {
+        name: "post-blocker",
+        pattern: /^https:\/\//,
+        methods: ["POST", "PUT"],
+      },
+      {
+        name: "post-api",
+        pattern: /^https:\/\/api\.example\.com\/p\//,
+        methods: ["POST"],
+      },
+    ]);
+    const shadows = findFaultRuleShadows(rules);
+    expect(shadows).toHaveLength(1);
+    expect(shadows[0]!.earlierName).toBe("post-blocker");
+  });
+
+  it("derives a name from the pattern when the rule has no `name`", () => {
+    const rules = compiled([
+      { pattern: /^https?:\/\// },
+      { pattern: /^https:\/\/api\.example\.com\/p\// },
+    ]);
+    const shadows = findFaultRuleShadows(rules);
+    expect(shadows).toHaveLength(1);
+    expect(shadows[0]!.earlierName).toMatch(/^\//);
+    expect(shadows[0]!.laterName).toMatch(/^\//);
+  });
+
+  it("returns multiple shadows when the catch-all hides several later rules", () => {
+    const rules = compiled([
+      { name: "block-all", pattern: /^https?:\/\// },
+      { name: "api-a", pattern: /^https:\/\/a\.example\.com\// },
+      { name: "api-b", pattern: /^https:\/\/b\.example\.com\// },
+    ]);
+    const shadows = findFaultRuleShadows(rules);
+    expect(shadows).toHaveLength(2);
+    expect(shadows.map((s) => s.laterName)).toEqual(["api-a", "api-b"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last sub-item from #129 — option 1.2, the `validateOptions` warning for catch-all-shadows-specific patterns. The original DX fix-up (PR #131) only landed the README guidance for first-match-wins ordering; this adds the static detector that catches the misconfiguration before the crawl starts.

### Why now

Reviewer pushed back: "DX Issues は全部は終わってないのでは" — and they're right. The README change in #131 helps once you read it; the warning helps everyone whose config is already wrong.

### Detector

Two pure helpers, both exported from `crawler.ts` for testability:

- **`sampleUrlFromRegex(re)`** — strip anchors, drop lookahead/lookbehind constructs (so the `(?!127\.0\.0\.1)` in the issue's catch-all doesn't poison the result), unescape literal `\.` / `\/`, drop quantified character classes and remaining metachars. The output is a plausible URL the regex would match — used as the input for the shadow check.
- **`findFaultRuleShadows(compiled)`** — for each `(i, j)` with `i < j`, skip when:
  - earlier rule's `probability < 1` (it won't reliably shadow — some requests fall through), or
  - methods don't cover (earlier has narrower methods than later).

  Otherwise test the later rule's sample URL against the earlier rule's compiled pattern. A match → shadow.

Regex-superset is undecidable in general, so this is conservative on purpose: false negatives are accepted, false positives are minimized by the probability + methods filters.

### Wiring

`crawler.start()` runs the detector right after `logCrawlStart` and emits one `logger.warn("fault_rule_shadowed", { earlierRule, laterRule, sampleUrl })` per shadowed pair — *before* the crawl has consumed a single request, so users see config issues up front instead of grepping `matched: 0` from the report.

### Tests

12 new cases in `fault-shadow.test.ts`:

- Canonical catch-all-before-specific (the #129 example) — flagged.
- Specific-first / catch-all-last — clean.
- Unrelated patterns — clean.
- Earlier rule with `probability < 1` — skipped (no false positive).
- Earlier rule restricted to POST, later rule defaults to all methods — skipped (no shadow).
- Earlier rule covers `[POST, PUT]`, later rule says `[POST]` — flagged (full method coverage).
- Patterns without explicit `name` — derived label still works.
- One catch-all hiding multiple later rules — one warning per pair.

884 / 884 unit tests pass.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec vitest run` — 884 / 884 unit tests pass (chaos.test.ts `invokes setup before the crawl` is a pre-existing flake unrelated to this change).
- [ ] Verify the warning fires in a real crawl with the canonical bad config from #129 (manual smoke; the unit tests cover the same shape).

Refs #129

https://claude.ai/code/session_018t71eUNUYNqZs86fwLuCaf

---
_Generated by [Claude Code](https://claude.ai/code/session_018t71eUNUYNqZs86fwLuCaf)_