### PR TITLE
chore(hooks): install playwright chromium on Claude Code web session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Install Playwright Chromium so the chaosbringer test suite (chaos.test.ts
+# and fixture-driven e2e tests) can launch a browser. Chromium is not part
+# of the pnpm-managed dependency graph — it lives in /opt/pw-browsers — so
+# `pnpm install` does not fetch it. CI does this explicitly via
+# `npx playwright install --with-deps chromium` in .github/workflows/ci.yml.
+# This hook mirrors that for Claude Code on the web sessions.
+#
+# Only run inside the remote container — locally, the developer can decide
+# when to install browsers themselves.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Idempotent: playwright install detects existing browsers and skips
+# the download when the binary is already present.
+pnpm exec playwright install chromium

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 flake.json
 heatmap.json
 failure-artifacts/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook so Claude Code on the web sessions install Playwright Chromium before running tests. Previously, a fresh session would land in a container with pnpm-managed deps installed but no browser binary — `pnpm install` doesn't fetch `/opt/pw-browsers` content. Browser-dependent vitest cases (chaos.test.ts and the fixtures e2e suite) would then fail with the misleading "expected setup to be called 1 times, but got 0 times" — the actual cause is `chromium.launch()` throwing on the missing binary.

CI already does this via `npx playwright install --with-deps chromium` in `.github/workflows/ci.yml`. This hook mirrors that for the remote-execution environment so the local test suite reaches parity with CI without manual intervention.

(Revises an earlier attempt on this branch that skipped the browser-dependent tests with `it.skipIf(...)`. Per @mizchi's feedback, installing the browser is the right fix — silently skipping just hides the missing dependency.)

### Hook design

```bash
if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
  exit 0
fi
cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
pnpm exec playwright install chromium
```

- Runs only when `CLAUDE_CODE_REMOTE=true` (no-op for local developer checkouts — the developer chooses when to install browsers).
- Idempotent — `playwright install` skips the download when the binary is already present.
- Synchronous (not async) — tests / linters invoked early in the session see a ready environment with no race.

Also gitignores `.claude/settings.local.json` (machine-specific tool permissions emitted by the CLI).

## Test plan
- [x] Hook executes cleanly: `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` → exit 0, Chromium present at `/opt/pw-browsers/chromium_headless_shell-1217/...`.
- [x] After hook runs, `pnpm exec vitest run src/chaos.test.ts` passes 3/3 (was 1/3 before).
- [ ] On a fresh web session, the hook runs automatically and the test suite is green from the first invocation.

https://claude.ai/code/session_018t71eUNUYNqZs86fwLuCaf