### PR TITLE
fix: checks that reported nothing instead of reporting they could not check

### DIFF
--- a/.claude/skills/chaosbringer/SKILL.md
+++ b/.claude/skills/chaosbringer/SKILL.md
@@ -187,9 +187,9 @@ button enabled*. Check what the label promises about the page.
 
 **Forgetting what escaped.** "The spinner stopped" and "the spinner stopped and
 nothing escaped" are different findings, and the second is usually the bug.
-`watchUnhandledRejections(page)` before you navigate, then `drain()` at each
-read — it claims the rejections via `preventDefault`, so they do not also
-arrive as `pageerror` and get counted twice.
+`watchUnhandledRejections(page)` at any point, then `drain()` at each read — it
+claims the rejections via `preventDefault`, so they do not also arrive as
+`pageerror` and get counted twice.
 
 **One instant.** A probe fires once. A backend that acknowledges now and
 commits 450ms later, a retry scheduled on the error path, a revalidation

--- a/.claude/skills/chaosbringer/references/api.md
+++ b/.claude/skills/chaosbringer/references/api.md
@@ -252,17 +252,20 @@ belong to `chaos()`.
 ```ts
 import { watchUnhandledRejections } from "chaosbringer";
 
-const rejections = await watchUnhandledRejections(page);  // BEFORE page.goto
+const rejections = await watchUnhandledRejections(page);  // before or after goto
 await page.goto(url);
 await page.click("#save");
 // …wait settleMs…
 const escaped = await rejections.drain();     // [] if the app handled everything
 ```
 
-Installed as an init script, so it must precede the navigation, and it survives
-navigation — one call covers a whole test. `drain()` empties as it reads, so a
-second probe after a quiescence window reports only what is new, and it returns
-`[]` rather than throwing once the page is closed.
+Installed both as an init script and against the document already open, so the
+order does not matter and it survives navigation — one call covers a whole test.
+(It used to be the init script only, which meant installing after `goto` left
+nothing listening and `drain()` returned `[]` — the same answer a clean page
+gives.) `drain()` empties as it reads, so a second probe after a quiescence
+window reports only what is new, and it returns `[]` rather than throwing once
+the page is closed — which is a read that could not happen, not a clean page.
 
 It claims each rejection with `preventDefault()`, which matters: without that,
 Chromium reports the same rejection a second time through

--- a/.claude/skills/chaosbringer/references/api.md
+++ b/.claude/skills/chaosbringer/references/api.md
@@ -205,7 +205,7 @@ It cannot take runtime faults.
 |---|---|
 | `stats()` | network rules: `{ rule, matched, injected, suppressed? }[]`, live |
 | `runtimeStats()` | runtime faults: `Promise<{ rule, matched, fired, suppressed? }[]>`, read out of the page |
-| `firings()` | `Promise<Firing[]>` — both layers in one shape: `{ name, layer, matched, fired, suppressed, errored }`. `layer` is `"network" \| "runtime" \| "lifecycle" \| "iframe"` |
+| `firings()` | `Promise<Firing[]>` — both layers in one shape: `{ name, layer, matched, fired, suppressed, errored, counted }`. `layer` is `"network" \| "runtime" \| "lifecycle" \| "iframe"`; `counted` is false when the source row carried no usable counters, which is how you tell "nothing happened" from "nothing was measured" |
 | `heldRequests()` | requests currently parked by an unbounded `hang` |
 | `release()` | abort the parked ones, so the app's `catch` runs |
 | `dispose()` | release, then remove the route — page talks to the real origin again |

--- a/.claude/skills/chaosbringer/references/api.md
+++ b/.claude/skills/chaosbringer/references/api.md
@@ -58,9 +58,18 @@ const crawler = new ChaosCrawler({
   faultInjection: [ … ],            // network layer: FaultRule[]
   runtimeFaults: [ … ],             // in-page fetch patching: RuntimeFault[]
   lifecycleFaults: [ … ],           // visibility, offline, CPU: LifecycleFault[]
+  initScripts: [ "…js…" ],          // raw JS run before the page's own scripts
   invariants: [ … ],                // what must hold; see below
 });
 ```
+
+`initScripts` is for anything that has to be in place *before* the app runs —
+patching an API you want to observe, seeding a global, stubbing a clock. An
+observer installed later reports zero for everything that happened during load,
+and zero is indistinguishable from "nothing happened", so if the thing you are
+measuring can occur during load, it belongs here rather than in an `afterLoad`
+invariant. Each string is evaluated verbatim on every navigation: wrap it in an
+IIFE and guard against a second install.
 
 ### Reading whether a fault fired
 

--- a/.claude/skills/chaosbringer/references/model-driven.md
+++ b/.claude/skills/chaosbringer/references/model-driven.md
@@ -157,6 +157,12 @@ faster than guessing.
 | `state` | `stateProbe`, read after the run settled |
 | `calls` | requests the fault layers counted, page-load calls included |
 
+An expectation whose probe the bridge does not supply is reported, not skipped:
+`expect.ui` against a bridge with no `uiProbe` fails the plan as `undecided`,
+and `expect.state` without a `stateProbe` fails as `state`. A probe-less bridge
+is fine — stating an expectation it cannot read is what is not, because a check
+that reads nothing passes for the wrong reason.
+
 `calls` is the only one that can say what must **not** happen: the schedule pins
 the outcome of call 0 and call 1 and has no way to state that call 2 does not
 exist. It also states calls no fault can target — the extra read an app owes you

--- a/.claude/skills/chaosbringer/references/timing.md
+++ b/.claude/skills/chaosbringer/references/timing.md
@@ -87,7 +87,13 @@ returns a union: `status: "sat"` carries `settleMs`, `slowMs`, `fastMs`,
 `quiescenceMs`, `pageTimeoutMs`, `wallClockMs` and the resolved `profile`;
 `status: "unsat"` carries `core` (which constraints could not be met) and a
 readable `explanation`. Check the status — the fields do not exist on the unsat
-branch. If the app has its own retry ladder, pass
+branch.
+
+`checkTiming(profile, request, proposed)` validates numbers you picked
+yourself, and returns `{ ok, checked, rows, violations }`. Omitting a field
+skips its constraint, but omitting *everything* is not a pass: `ok` is false
+when `checked` is 0, because "I checked nothing" is not a verdict. If you build
+`proposed` conditionally, decide at the call site what an empty one means. If the app has its own retry ladder, pass
 `ladder: { attempts, backoffsMs }` and the window covers all of it, not one
 round.
 

--- a/.github/workflows/chaos-flake.yml
+++ b/.github/workflows/chaos-flake.yml
@@ -69,7 +69,7 @@ jobs:
             --url http://127.0.0.1:4455 \
             --runs ${{ github.event.inputs.runs || '10' }} \
             --max-pages 30 \
-            --max-actions-per-page 5 \
+            --max-actions 5 \
             --output flake.json \
           || true   # exit 1 means flakes were found; we want to process them
 

--- a/.github/workflows/chaos-flake.yml
+++ b/.github/workflows/chaos-flake.yml
@@ -65,13 +65,23 @@ jobs:
 
       - name: chaosbringer flake
         run: |
+          # Exit 1 means flakes were found and the next step should process
+          # them. Anything else means the command did not run, and a bare
+          # `|| true` swallowed both alike: this step spent weeks dying on an
+          # unknown-option error while looking like a step with nothing to say.
+          set +e
           pnpm exec chaosbringer flake \
             --url http://127.0.0.1:4455 \
             --runs ${{ github.event.inputs.runs || '10' }} \
             --max-pages 30 \
             --max-actions 5 \
-            --output flake.json \
-          || true   # exit 1 means flakes were found; we want to process them
+            --output flake.json
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then
+            echo "flake command failed with exit $status — this is not a flake result" >&2
+            exit "$status"
+          fi
 
       - name: Stop fixture server
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check the chaosbringer skill's docs against the real exports
         run: pnpm check:skill-docs
 
-      - name: Check workflow run: blocks parse as shell
+      - name: Check that workflow shell blocks parse
         run: pnpm check:workflow-shell
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Check the chaosbringer skill's docs against the real exports
         run: pnpm check:skill-docs
 
+      - name: Check workflow run: blocks parse as shell
+        run: pnpm check:workflow-shell
+
       - name: Build
         run: pnpm -F chaosbringer build
 

--- a/.github/workflows/flaker-confirm.yml
+++ b/.github/workflows/flaker-confirm.yml
@@ -27,12 +27,14 @@ jobs:
 
       - name: Run confirmation tests
         run: |
-          for i in \$(seq 1 ${{ inputs.repeat }}); do
-            echo "--- Run \$i/${{ inputs.repeat }} ---"
-            pnpm exec vitest run "${{ inputs.suite }}" \\
-              -t "${{ inputs.test_name }}" \\
-              --reporter json \\
-              --outputFile "result-\$i.json" || true
+          for i in $(seq 1 ${{ inputs.repeat }}); do
+            echo "--- Run $i/${{ inputs.repeat }} ---"
+            # `|| true` is deliberate here and only here: a failing run is the
+            # data this workflow collects, not an error.
+            pnpm exec vitest run "${{ inputs.suite }}" \
+              -t "${{ inputs.test_name }}" \
+              --reporter json \
+              --outputFile "result-$i.json" || true
           done
 
       - uses: actions/upload-artifact@v4

--- a/docs/recipes/model-driven-faults.md
+++ b/docs/recipes/model-driven-faults.md
@@ -349,13 +349,22 @@ action ──── settleMs ────▶ probe: ui, uiInvariants, state
                            late-rejection classification
 ```
 
-- The runner instruments `setTimeout` / `setInterval` **before** firing the
-  action, so it knows whether the page has work due in the future and how far
-  out, and waits for it (default cap `asyncDrainCapMs: 3000`). A `void retry()`
-  inside a 900ms backoff escapes every handler; a run that stopped at 400ms
-  reported `unhandledRejection: false` and was neither wrong nor right — it had
-  not looked. Recurring timers are *reported*, never waited on: an uncleared
-  `setInterval` is a fact about the app, not a reason to hang.
+- The runner instruments `setTimeout` / `setInterval` **before the page's own
+  scripts run**, so it knows whether the page has work due in the future and how
+  far out, and waits for it (default cap `asyncDrainCapMs: 3000`). A `void
+  retry()` inside a 900ms backoff escapes every handler; a run that stopped at
+  400ms reported `unhandledRejection: false` and was neither wrong nor right —
+  it had not looked. Recurring timers are *reported*, never waited on: an
+  uncleared `setInterval` is a fact about the app, not a reason to hang.
+
+  It used to be installed from the `afterLoad` hook, i.e. after load and before
+  the action. That left a plan with **no `action`** — operations issued by page
+  load itself — with nothing instrumented, and the report then said
+  `pendingAsync: { timers: 0 }`, which reads as a fact about the page rather
+  than as the absence of a measurement. `pendingAsync.measured` now separates
+  the two, and a run that asked for a drain and could not read the
+  instrumentation reports `undecided` instead of a clean `unhandledRejection:
+  false`.
 - `expect.state` is compared against a **second** read, taken after
   `quiescenceMs`. The window is spent by any plan the second look could change
   its mind about — one naming `expect.state`, or a `ui` label, or a bridge with
@@ -405,8 +414,10 @@ guarantee.
   from one is caught — but it cannot make one fail, so a bug reachable only by
   perturbing local scheduling has nothing to write a plan against.
 - **Work past the observation window.** `quiescenceMs` bounds one further round
-  of app-deadline-length work, and the timer drain follows at most four rounds
-  of chained timers within `asyncDrainCapMs`. A duplicate write that commits
+  of app-deadline-length work, and the timer drain follows chained timers for as
+  long as `asyncDrainCapMs` lasts — each round waits for the latest pending
+  timer that still fits in the remaining budget, so the bound is the budget and
+  not a round count. A duplicate write that commits
   five seconds later, or a retry ladder with a 30-second backoff, is outside
   it. The window is a derived heuristic, not a proof of quiescence: what is
   still pending when the run ends is reported in

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
     "lint:nul": "pnpm -r lint:nul",
-    "check:skill-docs": "pnpm -F chaosbringer exec tsx ../../scripts/check-skill-docs.mjs"
+    "check:skill-docs": "pnpm -F chaosbringer exec tsx ../../scripts/check-skill-docs.mjs",
+    "check:workflow-shell": "node scripts/check-workflow-shell.mjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
       "duckdb",
       "esbuild"
     ]
+  },
+  "devDependencies": {
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/chaosbringer/README.md
+++ b/packages/chaosbringer/README.md
@@ -223,7 +223,7 @@ faultInjection: [
 - `afterEnd` decides what happens past the table: `"pass"` (default — spent), `"inject"` (keep firing), `"repeat"` (cycle it).
 - Available on all four layers (`faultInjection`, `lifecycleFaults`, `runtimeFaults`, `iframeFaults`). `probability` + `schedule` together is a validation error.
 - A schedule consumes no RNG, so adding one leaves the seed sequence — and therefore chaos action selection — untouched.
-- Faults watching the same URL share occurrence numbering on the layers that evaluate every matching rule — the network layer, the runtime `fetch` layer and the lifecycle layer — so occurrence 0 can get one fault kind and occurrence 2 another. The **iframe layer and the load path are single-pass**: the first fault to claim an assignment returns, and a scheduled fault sitting behind it does not advance. Numbering there is per-rule, so don't write a two-fault occurrence split on those layers. Don't split one endpoint across the network and runtime layers either: a client-side rejection issues no request, so the network counter never advances.
+- Faults watching the same URL (or the same iframe) share occurrence numbering on **every** layer: each evaluates every matching rule, so occurrence 0 can get one fault kind and occurrence 2 another, and a rule that decided `inject` and lost the race is counted in `suppressed` rather than dropped. Don't split one endpoint across the network and runtime layers, though: a client-side rejection issues no request, so the network counter never advances.
 
 To enumerate *every* combination rather than the ones you thought of, see [model-driven faults](https://github.com/mizchi/chaosbringer/blob/main/docs/recipes/model-driven-faults.md).
 

--- a/packages/chaosbringer/scripts/chaos-flake-issues.ts
+++ b/packages/chaosbringer/scripts/chaos-flake-issues.ts
@@ -26,6 +26,13 @@ interface ClusterOccurrence {
 
 interface FlakeAnalysis {
   runs: number;
+  /**
+   * Set by `flakeReport`. False means the run count could not decide
+   * flakiness, in which case `flakyClusters` is empty because of the sample
+   * size and not because the app is clean — see the guard in `main`.
+   * Optional so a `flake.json` written before the field existed still parses.
+   */
+  decidable?: boolean;
   stableClusters: ClusterOccurrence[];
   flakyClusters: ClusterOccurrence[];
   flakyPages: { url: string; failedInRuns: number; visitedInRuns: number }[];
@@ -101,6 +108,26 @@ function findExisting(issues: ReturnType<typeof listOpenFlakeIssues>, key: strin
 
 function main() {
   const analysis = JSON.parse(readFileSync(inputPath!, "utf8")) as FlakeAnalysis;
+
+  // The loop below closes every open issue whose cluster is absent from this
+  // report. An undecidable report has an empty `flakyClusters` *by
+  // construction* — with one run nothing can differ between runs — so acting
+  // on it would close every open flake issue with the comment "Cluster no
+  // longer appears in the latest flake report". Deleting real bug reports
+  // because nothing was measured is the worst thing this script can do, so it
+  // refuses rather than reconciling against a report that decided nothing.
+  //
+  // `decidable === undefined` is a report written before the field existed;
+  // fall back to the run count, which is the same rule `flakeReport` applies.
+  const decidable = analysis.decidable ?? analysis.runs >= 2;
+  if (!decidable) {
+    console.error(
+      `refusing to reconcile: ${analysis.runs} run(s) cannot decide flakiness, so an empty ` +
+        `flakyClusters here would close every open issue. Re-run with --runs 2 or more.`,
+    );
+    process.exit(1);
+  }
+
   const flaky = analysis.flakyClusters.filter((c) => c.runsWithCluster >= MIN_RUNS_WITH_CLUSTER);
   const seenKeys = new Set(flaky.map((c) => c.key));
 

--- a/packages/chaosbringer/scripts/chaos-flake-issues.ts
+++ b/packages/chaosbringer/scripts/chaos-flake-issues.ts
@@ -16,28 +16,24 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
-interface ClusterOccurrence {
-  key: string;
-  type: string;
-  fingerprint: string;
-  perRunCounts: number[];
-  runsWithCluster: number;
-}
+// The shapes come from the library rather than being restated here. This file
+// used to declare its own `ClusterOccurrence` / `FlakeAnalysis`, and when
+// `decidable` was added to the real one I hand-copied it into the duplicate —
+// which is the "one rule in two places, and the copy nobody looked at is the
+// stale one" shape the whole branch this landed in is about. `decidable` is
+// read through a `?? runs >= 2` fallback below, so a `flake.json` written
+// before the field existed still reconciles.
+import type { ClusterOccurrence, FlakeAnalysis } from "../src/flake.js";
 
-interface FlakeAnalysis {
-  runs: number;
-  /**
-   * Set by `flakeReport`. False means the run count could not decide
-   * flakiness, in which case `flakyClusters` is empty because of the sample
-   * size and not because the app is clean — see the guard in `main`.
-   * Optional so a `flake.json` written before the field existed still parses.
-   */
-  decidable?: boolean;
-  stableClusters: ClusterOccurrence[];
-  flakyClusters: ClusterOccurrence[];
-  flakyPages: { url: string; failedInRuns: number; visitedInRuns: number }[];
-  durations: number[];
-}
+/**
+ * What a `flake.json` on disk may actually contain, as opposed to what
+ * `flakeReport` returns today. `decidable` is required on `FlakeAnalysis`, so
+ * importing that type verbatim would tell the checker the field is always
+ * present and make the fallback below look like dead code — while a report
+ * written before the field existed still lacks it at runtime. Stating the one
+ * difference keeps the shape shared and the fallback honest.
+ */
+type ParsedAnalysis = Omit<FlakeAnalysis, "decidable"> & { decidable?: boolean };
 
 const LABEL = "chaos-flake";
 const MIN_RUNS_WITH_CLUSTER = 2;
@@ -107,7 +103,7 @@ function findExisting(issues: ReturnType<typeof listOpenFlakeIssues>, key: strin
 }
 
 function main() {
-  const analysis = JSON.parse(readFileSync(inputPath!, "utf8")) as FlakeAnalysis;
+  const analysis = JSON.parse(readFileSync(inputPath!, "utf8")) as ParsedAnalysis;
 
   // The loop below closes every open issue whose cluster is absent from this
   // report. An undecidable report has an empty `flakyClusters` *by

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -3073,9 +3073,16 @@ export function validateOptions(options: CrawlerOptions): void {
   for (const [ruleIndex, rule] of (options.faultInjection ?? []).entries()) {
     // The index when there is no name: "faultInjection rule" alone, in a
     // config with twenty of them, does not tell you which one to fix.
+    //
+    // …and the pattern alongside it, because the two halves of this library
+    // label the same unnamed rule differently: errors here said "rule #3"
+    // while `getFaultStats` reports it as `pattern.toString()`. Each is the
+    // right handle for its own context — the index finds it in your array, the
+    // pattern finds it in the report — and carrying both is what lets a reader
+    // connect an error to the row it is about.
     const label = rule.name
       ? `faultInjection rule "${rule.name}"`
-      : `faultInjection rule #${ruleIndex}`;
+      : `faultInjection rule #${ruleIndex} (${String(rule.urlPattern)})`;
     assertMatcher(`${label} urlPattern`, rule.urlPattern);
     validateFaultSchedule(label, rule, "chaosbringer");
     if (rule.probability !== undefined) {

--- a/packages/chaosbringer/src/crawler.ts
+++ b/packages/chaosbringer/src/crawler.ts
@@ -171,6 +171,7 @@ const DEFAULT_OPTIONS: Required<
   lifecycleFaults: [],
   runtimeFaults: [],
   iframeFaults: [],
+  initScripts: [],
 };
 
 const DEFAULT_ACTION_WEIGHTS: Required<ActionWeights> = {
@@ -779,6 +780,13 @@ export class ChaosCrawler {
         this.compiledRuntimeFaults.map((c) => c.fault),
         this.rng.seed,
       );
+      await this.context.addInitScript({ content: script });
+    }
+
+    // Caller-supplied init scripts, after the fault layers so a script can
+    // observe the patched APIs. Installed even when empty-checked away, so a
+    // caller that passes `[]` costs nothing.
+    for (const script of this.options.initScripts ?? []) {
       await this.context.addInitScript({ content: script });
     }
 
@@ -2909,7 +2917,7 @@ export class ChaosCrawler {
  * because breaking those to catch typos would trade one silent failure for a
  * loud one somebody did not ask for.
  */
-const KNOWN_OPTION_NAMES = [
+export const KNOWN_OPTION_NAMES = [
   "baseUrl", "maxPages", "maxActionsPerPage", "timeout", "headless", "screenshots",
   "screenshotDir", "excludePatterns", "ignoreErrorPatterns", "spaPatterns", "viewport",
   "userAgent", "traceparent", "actionWeights", "logFile", "logLevel", "logToConsole",
@@ -2918,6 +2926,7 @@ const KNOWN_OPTION_NAMES = [
   "storageState", "performanceBudget", "traceOut", "traceReplay", "device", "network",
   "seedFromSitemap", "advisor", "driver", "driverGoal", "coverageFeedback",
   "shardIndex", "shardCount", "blockExternalNavigation", "failureArtifacts", "server",
+  "initScripts",
 ] as const;
 
 /**

--- a/packages/chaosbringer/src/drivers/auth-attack/payloads.test.ts
+++ b/packages/chaosbringer/src/drivers/auth-attack/payloads.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   freshTestEmail,
   NONEXISTENT_USERNAME,
@@ -39,9 +39,39 @@ describe("auth-attack payloads", () => {
   });
 
   it("freshTestEmail produces unique addresses across calls", () => {
+    // 20000, not 50. The old implementation leaned on 16 bits of randomness
+    // inside a constant millisecond, so 50 calls collided in 1.68% of trials —
+    // a test that failed once every sixty CI runs and passed the rest, which
+    // reads as a flake rather than as the bug it was. At this scale the old
+    // implementation loses ~200 addresses every time, so the test either
+    // catches the defect or it is not there.
+    //
+    // The addresses are what the auth-attack probes sign up with: a collision
+    // makes a probe register an address that already exists and report the
+    // app's duplicate-signup behaviour as its answer about a fresh signup.
     const seen = new Set<string>();
-    for (let i = 0; i < 50; i++) seen.add(freshTestEmail());
-    expect(seen.size).toBe(50);
+    for (let i = 0; i < 20000; i++) seen.add(freshTestEmail());
+    expect(seen.size).toBe(20000);
+  });
+
+  it("is unique by construction, not by having enough random bits", () => {
+    // Freeze *both* sources of entropy. Any implementation whose uniqueness
+    // comes from a timestamp or from randomness produces 1 distinct address
+    // here; only a counter produces 200. That is the difference between a
+    // guarantee and a wide-enough coincidence, and a statistical test cannot
+    // tell them apart — widening `Math.random()` to 32 bits passes a
+    // 20000-draw uniqueness check ~95% of the time while still being able to
+    // collide.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const randSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      const seen = new Set<string>();
+      for (let i = 0; i < 200; i++) seen.add(freshTestEmail());
+      expect(seen.size).toBe(200);
+    } finally {
+      nowSpy.mockRestore();
+      randSpy.mockRestore();
+    }
   });
 
   it("freshTestEmail with a salt embeds it as a plus-tag", () => {

--- a/packages/chaosbringer/src/drivers/auth-attack/payloads.ts
+++ b/packages/chaosbringer/src/drivers/auth-attack/payloads.ts
@@ -32,12 +32,32 @@ export const WEAK_PASSWORDS: ReadonlyArray<string> = [
  */
 export const NONEXISTENT_USERNAME = "chaosbringer-noexist-9f3c@example.invalid";
 
+/**
+ * A counter, because "never collide" has to be a guarantee and not a
+ * probability. This used to be `Date.now()` plus 16 bits of `Math.random()`:
+ * within one millisecond the timestamp is constant, so uniqueness rested on
+ * those 16 bits alone. Measured over 4000 trials of 50 calls, 1.68% of trials
+ * produced a duplicate, and 20000 calls lost 215 addresses to collisions.
+ *
+ * What that costs is not a flaky test. These addresses are what the
+ * auth-attack probes sign up with, so a collision means a probe registers an
+ * address that already exists and reads the app's *duplicate signup* response
+ * as its answer about a *fresh* signup — a finding about a path the probe never
+ * took.
+ */
+let freshEmailSeq = 0;
+
 /** Generate a one-shot test email so repeated signups never collide. */
 export function freshTestEmail(salt?: string): string {
   const ts = Date.now().toString(36);
-  const rand = Math.floor(Math.random() * 0xffff).toString(16);
+  // The counter carries uniqueness within the process, which is the scope that
+  // matters: every signup in one run comes from one process. Timestamp and
+  // randomness are what keep two concurrent runs (a sharded crawl, two
+  // developers) apart, and 32 bits there is cheap.
+  const seq = (freshEmailSeq++).toString(36);
+  const rand = Math.floor(Math.random() * 0xffffffff).toString(16);
   const tag = salt ? `+${salt}` : "";
-  return `chaosbringer-test${tag}-${ts}-${rand}@example.invalid`;
+  return `chaosbringer-test${tag}-${ts}-${seq}-${rand}@example.invalid`;
 }
 
 /**

--- a/packages/chaosbringer/src/fault-router.test.ts
+++ b/packages/chaosbringer/src/fault-router.test.ts
@@ -365,7 +365,15 @@ describe("applyFaultRules on a page you drive yourself", () => {
       // layer says `fired` where the other says `injected`.
       const firings = await session.firings();
       expect(firings).toEqual([
-        { name: "save-body-unreadable", layer: "runtime", matched: 1, fired: 1, suppressed: 0, errored: 0 },
+        {
+          name: "save-body-unreadable",
+          layer: "runtime",
+          matched: 1,
+          fired: 1,
+          suppressed: 0,
+          errored: 0,
+          counted: true,
+        },
       ]);
       await session.dispose();
     } finally {

--- a/packages/chaosbringer/src/fault-router.test.ts
+++ b/packages/chaosbringer/src/fault-router.test.ts
@@ -477,3 +477,49 @@ describe("a fault kind the library does not know", () => {
     expect(calls).toEqual(["abort", "fulfill", "fallback", "held"]);
   });
 });
+
+describe("a urlPattern that is not a valid regex", () => {
+  it("refuses the rule instead of dropping it", async () => {
+    // Measured before this threw: `applyFaultRules` with `"/api/(cart"`
+    // installed nothing, the page got its real 200, `stats()` was `[]` and
+    // `firings()` was `{}` — the rule was not even listed as having matched
+    // nothing. `compileFaultRules` skipped it on the premise that
+    // `validateOptions` had already raised, which is true for `ChaosCrawler`
+    // and false for this entry point.
+    const page = { route: async () => {}, unroute: async () => {} } as unknown as import("playwright").Page;
+    await expect(
+      applyFaultRules(page, [
+        { urlPattern: "/api/(cart", fault: { kind: "status", status: 500 } },
+      ]),
+    ).rejects.toThrow(/invalid urlPattern/);
+  });
+
+  it("names the rule so a config with twenty of them is actionable", async () => {
+    const page = { route: async () => {}, unroute: async () => {} } as unknown as import("playwright").Page;
+    // By name when there is one…
+    await expect(
+      applyFaultRules(page, [
+        { name: "cart-500", urlPattern: "(", fault: { kind: "status", status: 500 } },
+      ]),
+    ).rejects.toThrow(/rule "cart-500"/);
+    // …and by index when there is not, which is what locates it in the array.
+    await expect(
+      applyFaultRules(page, [
+        { urlPattern: /\/api\/ok/, fault: { kind: "abort" } },
+        { urlPattern: "(", fault: { kind: "abort" } },
+      ]),
+    ).rejects.toThrow(/rule #1/);
+  });
+
+  it("still accepts every pattern that does compile", async () => {
+    // The guard must not be satisfiable by refusing everything: a string, a
+    // regex, and a string with regex metacharacters that are legal.
+    const page = { route: async () => {}, unroute: async () => {} } as unknown as import("playwright").Page;
+    const session = await applyFaultRules(page, [
+      { urlPattern: "/api/cart", fault: { kind: "abort" } },
+      { urlPattern: /\/api\/checkout\?.*$/, fault: { kind: "abort" } },
+      { urlPattern: "\\/api\\/(cart|checkout)", fault: { kind: "abort" } },
+    ]);
+    expect(session.stats()).toHaveLength(3);
+  });
+});

--- a/packages/chaosbringer/src/fault-router.ts
+++ b/packages/chaosbringer/src/fault-router.ts
@@ -75,11 +75,30 @@ export type CompiledFaultRule = {
 export function compileFaultRules(rules: FaultRule[] | undefined): CompiledFaultRule[] {
   if (!rules || rules.length === 0) return [];
   const compiled: CompiledFaultRule[] = [];
-  for (const rule of rules) {
+  for (const [i, rule] of rules.entries()) {
     const pattern = toRegExp(rule.urlPattern);
     if (!pattern) {
-      // Skip invalid regex silently; validateOptions will have already raised.
-      continue;
+      // This used to `continue`, on the premise that "validateOptions will have
+      // already raised". True for `ChaosCrawler`, and false for `applyFaults` /
+      // `applyFaultRules`, which have no options object and validate schedules
+      // and layer confusion here but never the pattern. Measured on
+      // `applyFaultRules(page, [{ urlPattern: "/api/(cart", … }])`: no error,
+      // the page saw 200, `stats()` was `[]` and `firings()` was `{}` — the
+      // rule was not even listed as having matched nothing. That presents as
+      // "my fault never fired", which this codebase repeatedly calls the
+      // hardest thing in it to debug.
+      //
+      // Thrown here rather than fixed in the second caller, so one rule lives
+      // in one place. `validateOptions` still runs first on the crawler path
+      // and still produces its more specific message, so nothing changes
+      // there.
+      const label = rule.name ? `"${rule.name}"` : `#${i}`;
+      throw new Error(
+        `chaosbringer: faultInjection rule ${label} has an invalid urlPattern ` +
+          `(${JSON.stringify(String(rule.urlPattern))}) — it is not a valid regular expression, ` +
+          `so the rule cannot be installed. Skipping it silently would present as "my fault ` +
+          `never fired" with an empty stats table.`,
+      );
     }
     compiled.push({
       rule,

--- a/packages/chaosbringer/src/fault-router.ts
+++ b/packages/chaosbringer/src/fault-router.ts
@@ -197,13 +197,17 @@ export async function applyFault(
  * Mutates `matched`, `suppressed` and (for the winner) `injected`, and returns
  * the winner or null.
  */
-export function pickFaultRule(
-  rules: ReadonlyArray<CompiledFaultRule>,
+export function pickFaultRule<T extends CompiledFaultRule>(
+  rules: ReadonlyArray<T>,
   url: string,
   method: string,
-  rng: Rng,
-): CompiledFaultRule | null {
-  let winner: CompiledFaultRule | null = null;
+  // Only `next` is used. Typed as the minimum rather than the whole `Rng` so
+  // the load path — which is unseeded by design, because its workers run
+  // concurrently — can pass `{ next: Math.random }` and still share this
+  // function instead of keeping a second copy of the decision.
+  rng: Pick<Rng, "next">,
+): T | null {
+  let winner: T | null = null;
   for (const compiled of rules) {
     if (!compiled.pattern.test(url)) continue;
     if (compiled.methods && !compiled.methods.includes(method)) continue;

--- a/packages/chaosbringer/src/firings.test.ts
+++ b/packages/chaosbringer/src/firings.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { faultFirings, unfiredFaults } from "./firings.js";
+import type { CrawlReport } from "./types.js";
+
+const report = (partial: Partial<CrawlReport>) => partial as CrawlReport;
+
+describe("faultFirings", () => {
+  it("reads all four layers into one shape", () => {
+    // The point of the function: the network layer says `injected`, the other
+    // three say `fired`, and lifecycle labels its row `name` where the rest say
+    // `rule`. A caller should never have to know that.
+    expect(
+      faultFirings(
+        report({
+          faultInjections: [{ rule: "n", matched: 3, injected: 2, suppressed: 1 }],
+          runtimeFaults: [{ rule: "r", matched: 2, fired: 1 }],
+          lifecycleFaults: [{ name: "l", matched: 1, fired: 1, errored: 1 }],
+          iframeFaults: [
+            { rule: "i", selector: "iframe", action: "never-load", matched: 4, fired: 0 },
+          ],
+        }),
+      ),
+    ).toEqual([
+      { name: "n", layer: "network", matched: 3, fired: 2, suppressed: 1, errored: 0, counted: true },
+      { name: "r", layer: "runtime", matched: 2, fired: 1, suppressed: 0, errored: 0, counted: true },
+      { name: "l", layer: "lifecycle", matched: 1, fired: 1, suppressed: 0, errored: 1, counted: true },
+      { name: "i", layer: "iframe", matched: 4, fired: 0, suppressed: 0, errored: 0, counted: true },
+    ]);
+  });
+
+  it("returns nothing for a report that configured nothing", () => {
+    expect(faultFirings(report({}))).toEqual([]);
+    expect(unfiredFaults(report({}))).toEqual([]);
+  });
+
+  it("never emits an undefined counter, whatever the row looked like", () => {
+    // A row missing `matched` used to come back with `matched: undefined`, and
+    // the diagnosis below then read "matched undefinedx and never fired".
+    const [row] = faultFirings(report({ faultInjections: [{ rule: "r" } as never] }));
+    expect(row).toEqual({
+      name: "r",
+      layer: "network",
+      matched: 0,
+      fired: 0,
+      suppressed: 0,
+      errored: 0,
+      counted: false,
+    });
+  });
+
+  it("labels a nameless row rather than leaving it blank", () => {
+    const [row] = faultFirings(report({ runtimeFaults: [{ matched: 1, fired: 1 } as never] }));
+    expect(row?.name).toBe("(unnamed)");
+  });
+});
+
+describe("unfiredFaults", () => {
+  it("separates the two ordinary failures", () => {
+    expect(
+      unfiredFaults(
+        report({
+          faultInjections: [{ rule: "wrong-pattern", matched: 0, injected: 0 }],
+          runtimeFaults: [{ rule: "declined", matched: 3, fired: 0 }],
+        }),
+      ),
+    ).toEqual([
+      expect.stringContaining('network fault "wrong-pattern" never matched anything'),
+      expect.stringMatching(/runtime fault "declined" matched 3x and never fired/),
+    ]);
+  });
+
+  it("says a rule ahead of it answered, when that is what happened", () => {
+    const [problem] = unfiredFaults(
+      report({ faultInjections: [{ rule: "loser", matched: 3, injected: 0, suppressed: 2 }] }),
+    );
+    expect(problem).toContain("2 decision(s) lost to a rule ahead of it");
+  });
+
+  it("reports an unmeasured row as undecided, not as didn't-fire", () => {
+    // The third case, and it used to be folded into the second with an
+    // `undefined` in the sentence. "Nothing measured it" and "the policy said
+    // no" are different findings and lead to different fixes.
+    const problems = unfiredFaults(report({ faultInjections: [{ rule: "r" } as never] }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("no usable counters");
+    expect(problems[0]).not.toContain("undefined");
+    expect(problems[0]).not.toContain("firing policy");
+  });
+
+  it("stays quiet about faults that fired", () => {
+    expect(
+      unfiredFaults(report({ faultInjections: [{ rule: "ok", matched: 1, injected: 1 }] })),
+    ).toEqual([]);
+  });
+
+  it("restricts to the names asked for, and flags one it never saw", () => {
+    const r = report({
+      faultInjections: [{ rule: "ignored", matched: 0, injected: 0 }],
+      runtimeFaults: [{ rule: "watched", matched: 0, fired: 0 }],
+    });
+    expect(unfiredFaults(r, ["watched"])).toEqual([
+      expect.stringContaining('runtime fault "watched" never matched anything'),
+    ]);
+    expect(unfiredFaults(r, ["typo"])).toEqual([
+      expect.stringContaining('no layer reported stats for a fault named "typo"'),
+    ]);
+  });
+});

--- a/packages/chaosbringer/src/firings.ts
+++ b/packages/chaosbringer/src/firings.ts
@@ -32,6 +32,14 @@ export interface Firing {
    */
   fired: number;
   /**
+   * False when the source row carried no usable counters — a report from an
+   * older version, a hand-built one, a run that died before the stats arrays
+   * were written. `matched` and `fired` read 0 in that case, which is the only
+   * safe default, and this flag is how a caller tells "nothing happened" from
+   * "nothing was measured". They are very different findings.
+   */
+  counted: boolean;
+  /**
    * Times the fault decided to fire and something else answered first.
    * Network and runtime layers only; 0 elsewhere.
    */
@@ -48,46 +56,40 @@ export interface Firing {
  * crawl died before the routes went on.
  */
 export function faultFirings(report: CrawlReport): Firing[] {
+  // One builder, four layers. The counters are coerced rather than trusted:
+  // a row missing `matched` produced `matched: undefined`, and
+  // `unfiredFaults` then reported `matched undefinedx and never fired` — a
+  // diagnosis with `undefined` in it, from the function whose whole job is to
+  // give a usable one, asserting a firing policy that had not been consulted.
+  const row = (
+    name: unknown,
+    layer: FaultLayer,
+    matched: unknown,
+    fired: unknown,
+    suppressed: unknown,
+    errored: unknown,
+  ): Firing => ({
+    name: typeof name === "string" && name.length > 0 ? name : "(unnamed)",
+    layer,
+    matched: typeof matched === "number" && Number.isFinite(matched) ? matched : 0,
+    fired: typeof fired === "number" && Number.isFinite(fired) ? fired : 0,
+    suppressed: typeof suppressed === "number" && Number.isFinite(suppressed) ? suppressed : 0,
+    errored: typeof errored === "number" && Number.isFinite(errored) ? errored : 0,
+    counted: typeof matched === "number" && Number.isFinite(matched),
+  });
+
   const out: Firing[] = [];
   for (const s of report.faultInjections ?? []) {
-    out.push({
-      name: s.rule,
-      layer: "network",
-      matched: s.matched,
-      fired: s.injected,
-      suppressed: s.suppressed ?? 0,
-      errored: 0,
-    });
+    out.push(row(s.rule, "network", s.matched, s.injected, s.suppressed, 0));
   }
   for (const s of report.runtimeFaults ?? []) {
-    out.push({
-      name: s.rule,
-      layer: "runtime",
-      matched: s.matched,
-      fired: s.fired,
-      suppressed: s.suppressed ?? 0,
-      errored: 0,
-    });
+    out.push(row(s.rule, "runtime", s.matched, s.fired, s.suppressed, 0));
   }
   for (const s of report.lifecycleFaults ?? []) {
-    out.push({
-      name: s.name,
-      layer: "lifecycle",
-      matched: s.matched,
-      fired: s.fired,
-      suppressed: 0,
-      errored: s.errored,
-    });
+    out.push(row(s.name, "lifecycle", s.matched, s.fired, 0, s.errored));
   }
   for (const s of report.iframeFaults ?? []) {
-    out.push({
-      name: s.rule,
-      layer: "iframe",
-      matched: s.matched,
-      fired: s.fired,
-      suppressed: 0,
-      errored: 0,
-    });
+    out.push(row(s.rule, "iframe", s.matched, s.fired, 0, 0));
   }
   return out;
 }
@@ -115,6 +117,16 @@ export function unfiredFaults(report: CrawlReport, only?: readonly string[]): st
   for (const f of faultFirings(report)) {
     if (wanted && !wanted.has(f.name)) continue;
     if (f.fired > 0) continue;
+    if (!f.counted) {
+      // A third case, and it used to be reported as the second: the row
+      // carries no usable counters, so the firing policy was never consulted.
+      // Unmeasured is not the same as didn't-fire.
+      problems.push(
+        `${f.layer} fault "${f.name}" reported no usable counters — nothing measured whether ` +
+          `it fired, so this run decides nothing about it`,
+      );
+      continue;
+    }
     if (f.matched === 0) {
       problems.push(
         `${f.layer} fault "${f.name}" never matched anything — the pattern did not see the ` +

--- a/packages/chaosbringer/src/flake.test.ts
+++ b/packages/chaosbringer/src/flake.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ErrorCluster } from "./clusters.js";
-import { flakeReport, formatFlakeReport } from "./flake.js";
+import { flakeReport, formatFlakeReport, parseFlakeArgs } from "./flake.js";
 import type { CrawlReport, CrawlSummary, PageError, PageResult } from "./types.js";
 
 function summary(over: Partial<CrawlSummary> = {}): CrawlSummary {
@@ -166,6 +166,28 @@ describe("flakeReport", () => {
   it("preserves input order for durations", () => {
     const reports = [makeReport({ duration: 100 }), makeReport({ duration: 50 }), makeReport({ duration: 200 })];
     expect(flakeReport(reports).durations).toEqual([100, 50, 200]);
+  });
+});
+
+describe("flake CLI arguments", () => {
+  // Not a parser unit test for its own sake: the weekly workflow that runs
+  // this passed the *root* command's spelling of a shared option, strict
+  // `parseArgs` refused it, and `|| true` hid the failure.
+  const base = ["--url", "http://x", "--runs", "2"];
+
+  it("accepts either spelling of the per-page action cap", () => {
+    expect(parseFlakeArgs([...base, "--max-actions", "5"]).maxActions).toBe(5);
+    expect(parseFlakeArgs([...base, "--max-actions-per-page", "5"]).maxActions).toBe(5);
+  });
+
+  it("leaves it unset when neither is given", () => {
+    expect(parseFlakeArgs(base).maxActions).toBeUndefined();
+  });
+
+  it("still refuses a flag no spelling covers", () => {
+    // The alias must not become "accept anything": an unknown flag has to stay
+    // an error, because being refused is what makes a typo visible at all.
+    expect(() => parseFlakeArgs([...base, "--max-action", "5"])).toThrow();
   });
 });
 

--- a/packages/chaosbringer/src/flake.test.ts
+++ b/packages/chaosbringer/src/flake.test.ts
@@ -108,14 +108,59 @@ describe("flakeReport", () => {
     expect(flakeReport(reports).flakyPages).toEqual([]);
   });
 
-  it("returns an empty analysis for zero runs", () => {
+  it("returns an empty analysis for zero runs, marked undecidable", () => {
+    // The empty lists are the same shape a clean result has, and the CLI turns
+    // `flakyClusters.length === 0` into a green gate. `decidable` is what keeps
+    // "nothing flaked" apart from "nothing was measured".
     expect(flakeReport([])).toEqual({
       runs: 0,
+      decidable: false,
       stableClusters: [],
       flakyClusters: [],
       flakyPages: [],
       durations: [],
     });
+  });
+
+  it("refuses to call anything stable or flaky from a single run", () => {
+    const err = { type: "console" as const, message: "boom", url: "http://x/a" };
+    const one = flakeReport([
+      makeReport({
+        errorClusters: [cluster("seen-once", 1)],
+        pages: [page({ url: "http://x/a", errors: [err] })],
+      }),
+    ]);
+    expect(one.decidable).toBe(false);
+    // The cluster is still listed — one run is enough to say what happened —
+    // but `flakyClusters` being empty here is arithmetic, not evidence: with
+    // one run every cluster fired in "every" run.
+    expect(one.stableClusters).toHaveLength(1);
+    expect(one.flakyClusters).toEqual([]);
+  });
+
+  it("becomes decidable at two runs", () => {
+    const two = flakeReport([makeReport({}), makeReport({})]);
+    expect(two.decidable).toBe(true);
+  });
+
+  it("says so in the formatted report instead of printing a verdict", () => {
+    const text = formatFlakeReport(flakeReport([makeReport({ errorClusters: [cluster("c", 1)] })]));
+    expect(text).toContain("UNDECIDABLE");
+    expect(text).toContain("at least 2 runs");
+    // And it must not print the line that claims stability.
+    expect(text).not.toContain("Stable clusters (fire every run)");
+    expect(text).toContain("stability undecidable");
+  });
+
+  it("prints the ordinary verdict once there are enough runs", () => {
+    const text = formatFlakeReport(
+      flakeReport([
+        makeReport({ errorClusters: [cluster("c", 1)] }),
+        makeReport({ errorClusters: [cluster("c", 1)] }),
+      ]),
+    );
+    expect(text).not.toContain("UNDECIDABLE");
+    expect(text).toContain("Stable clusters (fire every run)");
   });
 
   it("preserves input order for durations", () => {

--- a/packages/chaosbringer/src/flake.ts
+++ b/packages/chaosbringer/src/flake.ts
@@ -32,7 +32,22 @@ export interface PageOccurrence {
 
 export interface FlakeAnalysis {
   runs: number;
-  /** Clusters that fired in every run. */
+  /**
+   * Whether `runs` was enough to decide anything about flakiness at all. Two
+   * is the minimum, and below it every field lies in the reassuring direction:
+   * with one run each cluster fired in "every" run, so `flakyClusters` is
+   * empty *by construction* and `stableClusters` calls a cluster seen exactly
+   * once stable. With zero runs everything is empty.
+   *
+   * Both read identically to a clean result, which is why this flag exists
+   * rather than a comment: the CLI turns `flakyClusters.length === 0` into a
+   * green CI gate, and a gate that passes because nothing was measured is the
+   * one outcome this tool must never produce. (`flakyPages` already required
+   * `visitedInRuns >= 2` for the same reason — the guard existed on the
+   * quieter half of the report and not on the headline.)
+   */
+  decidable: boolean;
+  /** Clusters that fired in every run. Stability is only a claim when `decidable`. */
   stableClusters: ClusterOccurrence[];
   /** Clusters that fired in some runs but not others. */
   flakyClusters: ClusterOccurrence[];
@@ -49,8 +64,19 @@ export interface FlakeAnalysis {
  */
 export function flakeReport(reports: readonly CrawlReport[]): FlakeAnalysis {
   const runs = reports.length;
+  // One run is enough to *list* what happened and never enough to call any of
+  // it stable or flaky, so the verdict is marked undecidable rather than
+  // returned as a clean bill of health.
+  const decidable = runs >= 2;
   if (runs === 0) {
-    return { runs: 0, stableClusters: [], flakyClusters: [], flakyPages: [], durations: [] };
+    return {
+      runs: 0,
+      decidable,
+      stableClusters: [],
+      flakyClusters: [],
+      flakyPages: [],
+      durations: [],
+    };
   }
 
   const keyMap = new Map<string, ClusterOccurrence>();
@@ -112,6 +138,7 @@ export function flakeReport(reports: readonly CrawlReport[]): FlakeAnalysis {
 
   return {
     runs,
+    decidable,
     stableClusters,
     flakyClusters,
     flakyPages,
@@ -131,7 +158,22 @@ export function formatFlakeReport(analysis: FlakeAnalysis): string {
     lines.push(`Duration (ms): avg=${avg.toFixed(0)} min=${min} max=${max}`);
   }
   lines.push("");
-  lines.push(`Stable clusters (fire every run): ${analysis.stableClusters.length}`);
+  if (!analysis.decidable) {
+    lines.push(
+      `UNDECIDABLE — flakiness needs at least 2 runs of the same configuration; ` +
+        `this analysis has ${analysis.runs}.`,
+    );
+    lines.push(
+      `  With one run nothing can differ between runs, so "0 flaky clusters" below is a ` +
+        `property of the sample size and not of the app. Re-run with --runs 2 or more.`,
+    );
+    lines.push("");
+  }
+  lines.push(
+    analysis.decidable
+      ? `Stable clusters (fire every run): ${analysis.stableClusters.length}`
+      : `Clusters seen (stability undecidable): ${analysis.stableClusters.length}`,
+  );
   for (const c of analysis.stableClusters) {
     lines.push(`  [${c.type}] ${truncate(c.fingerprint, 70)}  counts=${c.perRunCounts.join(",")}`);
   }
@@ -286,7 +328,16 @@ export async function runFlakeCli(argv: string[]): Promise<void> {
     writeFileSync(args.output, JSON.stringify(analysis, null, 2));
     if (!args.quiet) console.log(`Analysis saved to: ${args.output}`);
   }
-  // Exit 1 if anything flaked — CI uses this to fail a gate.
+  // Exit 1 if anything flaked — CI uses this to fail a gate. An undecidable
+  // analysis fails it too: `--runs` is validated at parse time so this should
+  // be unreachable, but the alternative to failing is a green gate that
+  // measured nothing, and that is the failure mode worth being paranoid about.
+  if (!analysis.decidable) {
+    console.error(
+      `flake: ${analysis.runs} run(s) cannot decide flakiness — nothing above is a verdict.`,
+    );
+    process.exit(1);
+  }
   if (analysis.flakyClusters.length > 0 || analysis.flakyPages.length > 0) {
     process.exit(1);
   }

--- a/packages/chaosbringer/src/flake.ts
+++ b/packages/chaosbringer/src/flake.ts
@@ -212,7 +212,14 @@ interface FlakeCliArgs {
   quiet: boolean;
 }
 
-function parseFlakeArgs(argv: string[]): FlakeCliArgs {
+/**
+ * Exported for tests. The parser is where the workflow bug lived — a real flag
+ * of the root command that this subcommand refused — and it is not reachable
+ * from `runFlakeCli` without launching browsers. Note that invalid *values*
+ * exit the process via `fail()` rather than throwing, so only the
+ * unknown-flag path (thrown by `parseArgs` itself) is assertable in-process.
+ */
+export function parseFlakeArgs(argv: string[]): FlakeCliArgs {
   const { values } = parseArgs({
     args: argv,
     options: {
@@ -221,6 +228,14 @@ function parseFlakeArgs(argv: string[]): FlakeCliArgs {
       seed: { type: "string" },
       "max-pages": { type: "string" },
       "max-actions": { type: "string" },
+      // The root CLI accepts both spellings for the same crawl option
+      // (`values["max-actions"] ?? values["max-actions-per-page"]`), so a
+      // caller who learned the long one there passed it here and `parseArgs`,
+      // being strict, killed the command on its first line. That is what
+      // happened to `.github/workflows/chaos-flake.yml`: a weekly job whose
+      // flake step had never once run. Accepting both here removes the trap
+      // rather than fixing the one call site that hit it.
+      "max-actions-per-page": { type: "string" },
       timeout: { type: "string" },
       "ignore-analytics": { type: "boolean", default: false },
       "har-replay": { type: "string" },
@@ -244,6 +259,8 @@ function parseFlakeArgs(argv: string[]): FlakeCliArgs {
     fail(`--runs must be an integer >= 2 (got ${JSON.stringify(values.runs)})`);
   }
 
+  const maxActionsRaw = values["max-actions"] ?? values["max-actions-per-page"];
+
   let seed: number | undefined;
   if (values.seed !== undefined) {
     const parsed = Number(values.seed);
@@ -258,7 +275,7 @@ function parseFlakeArgs(argv: string[]): FlakeCliArgs {
     runs,
     seed,
     maxPages: values["max-pages"] ? Number(values["max-pages"]) : undefined,
-    maxActions: values["max-actions"] ? Number(values["max-actions"]) : undefined,
+    maxActions: maxActionsRaw !== undefined ? Number(maxActionsRaw) : undefined,
     timeout: values.timeout ? Number(values.timeout) : undefined,
     ignoreAnalytics: values["ignore-analytics"] ?? false,
     harReplay: values["har-replay"],
@@ -283,7 +300,7 @@ OPTIONS:
                         so any flake points at non-determinism outside
                         chaosbringer (server, network, timers).
   --max-pages <n>       Forward to each crawl
-  --max-actions <n>     Forward to each crawl
+  --max-actions <n>     Forward to each crawl (--max-actions-per-page also accepted)
   --timeout <ms>        Forward to each crawl
   --ignore-analytics    Forward to each crawl
   --har-replay <path>   Forward to each crawl

--- a/packages/chaosbringer/src/init-scripts.test.ts
+++ b/packages/chaosbringer/src/init-scripts.test.ts
@@ -1,0 +1,96 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chaos } from "./chaos.js";
+import { validateOptions } from "./crawler.js";
+
+/**
+ * `initScripts` exists because "before the page's own scripts" is not a nicety
+ * — it is the difference between an observer that measures and one that reports
+ * zero. The model runner's timer watch used to be installed from an `afterLoad`
+ * invariant, and every timer the page scheduled while loading was invisible to
+ * it; the run then said `pendingAsync: { timers: 0 }`, which reads as a fact
+ * about the page rather than as the absence of a measurement.
+ *
+ * So what has to be pinned is the ordering, not merely that the script ran.
+ */
+describe("initScripts run before the page's own scripts", () => {
+  let server: http.Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+      // The page reads the flag the init script sets and records the answer
+      // where an invariant can see it. If the init script ran second, `saw` is
+      // false and the flag is still set by the time anyone looks — which is why
+      // asserting the flag alone would pass either way.
+      res.end(`<!doctype html><title>i</title><body><script>
+        window.__sawInitScript = window.__installedEarly === true;
+      </script></body>`);
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("is a real option, and a typo of it is caught", () => {
+    expect(() => validateOptions({ baseUrl: base, initScripts: ["/* noop */"] })).not.toThrow();
+    // The near-miss guard is the half of this that can actually fail: it only
+    // suggests names it knows, so `initScript` resolving to `initScripts`
+    // proves the option is in `KNOWN_OPTION_NAMES`. (The other half — an option
+    // missing from that list — is a compile error from the `UnlistedOptionNames`
+    // guard in `crawler.ts`, which no runtime test can observe.)
+    expect(() => validateOptions({ baseUrl: base, initScript: [] } as never)).toThrow(
+      /unknown option "initScript".*initScripts/s,
+    );
+  });
+
+  it("evaluates before the page's inline script", async () => {
+    let saw: unknown;
+    await chaos({
+      baseUrl: base,
+      maxPages: 1,
+      maxActionsPerPage: 0,
+      headless: true,
+      initScripts: ["window.__installedEarly = true;"],
+      invariants: [
+        {
+          name: "read-order",
+          when: "afterLoad",
+          check: async ({ page }) => {
+            saw = await page.evaluate("window.__sawInitScript");
+            return true;
+          },
+        },
+      ],
+    });
+    expect(saw).toBe(true);
+  }, 60_000);
+
+  it("runs nothing when none are given", async () => {
+    let saw: unknown;
+    await chaos({
+      baseUrl: base,
+      maxPages: 1,
+      maxActionsPerPage: 0,
+      headless: true,
+      invariants: [
+        {
+          name: "read-order",
+          when: "afterLoad",
+          check: async ({ page }) => {
+            saw = await page.evaluate("window.__sawInitScript");
+            return true;
+          },
+        },
+      ],
+    });
+    // The control case: without the option the page sees no flag, so the test
+    // above is measuring the option and not the fixture.
+    expect(saw).toBe(false);
+  }, 60_000);
+});

--- a/packages/chaosbringer/src/load/fault-routes.test.ts
+++ b/packages/chaosbringer/src/load/fault-routes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { compileLoadFaultRules, faultFiringsFrom, faultStatsFrom } from "./fault-routes.js";
+import {
+  compileLoadFaultRules,
+  faultFiringsFrom,
+  faultStatsFrom,
+  installFaultRoutes,
+} from "./fault-routes.js";
 
 describe("compileLoadFaultRules", () => {
   it("returns [] for undefined / empty input", () => {
@@ -101,5 +106,90 @@ describe("compileLoadFaultRules validates the firing policy", () => {
         },
       ]),
     ).toThrow(/empty-table/);
+  });
+});
+
+describe("the load path shares the crawler's fault decision", () => {
+  /** Minimal context/route doubles: enough to drive the installed handler. */
+  function fakeContext() {
+    let handler: ((route: unknown, request: unknown) => Promise<void>) | null = null;
+    const served: string[] = [];
+    const context = {
+      route: async (_pattern: string, h: (route: unknown, request: unknown) => Promise<void>) => {
+        handler = h;
+      },
+    } as never;
+    const send = async (url: string, method = "GET") => {
+      const route = {
+        fulfill: async () => void served.push("fulfilled"),
+        abort: async () => void served.push("aborted"),
+        fallback: async () => void served.push("fallback"),
+      };
+      await handler?.(route, { url: () => url, method: () => method });
+    };
+    return { context, send, served };
+  }
+
+  it("advances a scheduled rule that lost the race, and records it as suppressed", async () => {
+    // Single-pass, `second` was never consulted on the first request, so its
+    // own `decisions[1]` landed on the wrong call and its inject never fired.
+    const compiled = compileLoadFaultRules([
+      {
+        name: "first",
+        urlPattern: /\/api\/x/,
+        fault: { kind: "abort" },
+        schedule: { decisions: ["inject", "pass"] },
+      },
+      {
+        name: "second",
+        urlPattern: /\/api\/x/,
+        fault: { kind: "status", status: 503 },
+        schedule: { decisions: ["inject", "inject"] },
+      },
+    ]);
+    const { context, send, served } = fakeContext();
+    await installFaultRoutes(context, compiled);
+    await send("http://x/api/x");
+    await send("http://x/api/x");
+
+    expect(faultStatsFrom(compiled)).toEqual([
+      { rule: "first", matched: 2, injected: 1 },
+      // Occurrence advanced both times; it lost the first and won the second.
+      { rule: "second", matched: 2, injected: 1, suppressed: 1 },
+    ]);
+    expect(served).toEqual(["aborted", "fulfilled"]);
+  });
+
+  it("falls through when no rule claims the request", async () => {
+    const compiled = compileLoadFaultRules([
+      { name: "only", urlPattern: /\/api\/y/, fault: { kind: "abort" } },
+    ]);
+    const { context, send, served } = fakeContext();
+    await installFaultRoutes(context, compiled);
+    await send("http://x/api/x");
+    expect(served).toEqual(["fallback"]);
+    expect(faultStatsFrom(compiled)).toEqual([{ rule: "only", matched: 0, injected: 0 }]);
+  });
+
+  it("timestamps only the rule that acted", async () => {
+    const compiled = compileLoadFaultRules([
+      {
+        name: "winner",
+        urlPattern: /\/api\/x/,
+        fault: { kind: "abort" },
+        schedule: { decisions: ["inject"] },
+      },
+      {
+        name: "loser",
+        urlPattern: /\/api\/x/,
+        fault: { kind: "abort" },
+        schedule: { decisions: ["inject"] },
+      },
+    ]);
+    const { context, send } = fakeContext();
+    await installFaultRoutes(context, compiled);
+    await send("http://x/api/x");
+    expect(compiled[0]!.firings).toHaveLength(1);
+    expect(compiled[1]!.firings).toHaveLength(0);
   });
 });

--- a/packages/chaosbringer/src/load/fault-routes.ts
+++ b/packages/chaosbringer/src/load/fault-routes.ts
@@ -6,7 +6,8 @@
  * shared abstraction here would over-couple two evolving callers.
  */
 import type { BrowserContext, Route, Request } from "playwright";
-import { decideFault, validateFaultSchedule } from "../schedule.js";
+import { validateFaultSchedule } from "../schedule.js";
+import { pickFaultRule } from "../fault-router.js";
 import type { Fault, FaultRule, FaultInjectionStats, UrlMatcher } from "../types.js";
 
 interface CompiledRule {
@@ -15,6 +16,13 @@ interface CompiledRule {
   methods?: string[];
   matched: number;
   injected: number;
+  /**
+   * Times this rule's schedule said "inject" and an earlier rule had already
+   * claimed the request. Same meaning as on the crawler's network layer, and
+   * present for the same reason: `matched=3 injected=0` is otherwise
+   * indistinguishable from an all-`pass` schedule.
+   */
+  suppressed: number;
   /**
    * Wall-clock timestamps (ms) at which this rule actually injected
    * a fault. Captured so the runner can correlate fault firings with
@@ -65,6 +73,7 @@ export function compileLoadFaultRules(rules: ReadonlyArray<FaultRule | Fault> | 
       methods: r.methods?.map((m) => m.toUpperCase()),
       matched: 0,
       injected: 0,
+      suppressed: 0,
       firings: [],
     });
   }
@@ -116,9 +125,13 @@ async function applyFault(route: Route, fault: Fault): Promise<void> {
  * probability is rolled per match. Stats are mutated on the compiled rule
  * objects — drain via `faultStatsFrom` at run end.
  *
- * Single pass, first claim wins: unlike the network and runtime layers, a
- * later rule is not consulted once one has answered, so occurrence numbering
- * here is per-rule rather than shared.
+ * Two passes over one list, using the crawler's own `pickFaultRule` rather
+ * than a second copy of the decision: a *scheduled* rule consumes its
+ * occurrence whenever its pattern matches, even if an earlier rule already
+ * claimed the request, so two rules watching one URL agree about what
+ * "occurrence 3" means. Rules on the probability path stay lazy. This used to
+ * be single-pass — `return` on the first injection — which made `decisions`
+ * mean something different here than on the crawler's layers, silently.
  */
 export async function installFaultRoutes(
   context: BrowserContext,
@@ -128,21 +141,16 @@ export async function installFaultRoutes(
   await context.route("**/*", async (route: Route, request: Request) => {
     const url = request.url();
     const method = request.method().toUpperCase();
-    for (const c of compiled) {
-      if (!c.pattern.test(url)) continue;
-      if (c.methods && !c.methods.includes(method)) continue;
-      const occurrence = c.matched;
-      c.matched += 1;
-      // Load runs are unseeded by design (workers run concurrently), so the
-      // probability path draws from Math.random; a `schedule` ignores the RNG
-      // entirely and reads its decision table by occurrence.
-      if (decideFault(c.rule, occurrence, { next: Math.random }) === "pass") continue;
-      c.injected += 1;
-      c.firings.push(Date.now());
-      await applyFault(route, c.rule.fault);
+    // Load runs are unseeded by design (workers run concurrently), so the
+    // probability path draws from `Math.random`; a `schedule` ignores the RNG
+    // entirely and reads its decision table by occurrence.
+    const winner = pickFaultRule(compiled, url, method, { next: Math.random });
+    if (!winner) {
+      await route.fallback();
       return;
     }
-    await route.fallback();
+    winner.firings.push(Date.now());
+    await applyFault(route, winner.rule.fault);
   });
 }
 
@@ -153,6 +161,7 @@ export function faultStatsFrom(
     rule: c.rule.name ?? `fault-${i}`,
     matched: c.matched,
     injected: c.injected,
+    ...(c.suppressed > 0 ? { suppressed: c.suppressed } : {}),
   }));
 }
 

--- a/packages/chaosbringer/src/model/async-watch.test.ts
+++ b/packages/chaosbringer/src/model/async-watch.test.ts
@@ -1,0 +1,124 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { type Browser, chromium } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildAsyncWatchScript, drainScheduledWork, readPendingAsync } from "./runner.js";
+
+/**
+ * The timer watch is what lets a run say "no rejection escaped" rather than
+ * "none had escaped yet". Two things about it are only true in a browser, and
+ * both were wrong at some point:
+ *
+ *   - it has to be installed *before* the page's own scripts, or every timer
+ *     scheduled during load is invisible — and an action-less plan has no
+ *     other timers;
+ *   - a read with no instrumentation in place has to be distinguishable from a
+ *     read of an idle page, because the first is not a measurement.
+ *
+ * The unit tests for `nextDrainWaitMs` cover the arithmetic on a
+ * `PendingAsync`; nothing but a real page covers where that value comes from.
+ */
+describe("the async watch, in a page", () => {
+  let browser: Browser;
+  let server: http.Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+      // Both timers are scheduled during load, which is the case an `afterLoad`
+      // install could never see.
+      res.end(`<!doctype html><title>t</title><body><script>
+        setTimeout(() => { window.__ranLate = true; }, 400);
+        setTimeout(() => { window.__ranSoon = true; }, 40);
+      </script></body>`);
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    browser = await chromium.launch();
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("reports an uninstrumented page as unmeasured, not as idle", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(base + "/");
+      const pending = await readPendingAsync(page);
+      // The counters read the same as an idle page. `measured` is the only
+      // thing that separates them, and everything the drain claims rests on it.
+      expect(pending.timers).toBe(0);
+      expect(pending.measured).toBe(false);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("sees timers the page scheduled while loading", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.addInitScript({ content: buildAsyncWatchScript() });
+      await page.goto(base + "/");
+      const pending = await readPendingAsync(page);
+      expect(pending.measured).toBe(true);
+      // The 400ms one is certainly still pending; the 40ms one may already have
+      // run, so assert the floor rather than an exact count that races the load.
+      expect(pending.timers).toBeGreaterThanOrEqual(1);
+      expect(pending.dueInMs?.length).toBe(pending.timers);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("drains them, and the page's own callbacks actually ran", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.addInitScript({ content: buildAsyncWatchScript() });
+      await page.goto(base + "/");
+      const after = await drainScheduledWork(page, 3000);
+      expect(after.measured).toBe(true);
+      expect(after.timers).toBe(0);
+      // Waiting for a timer to become *due* is not the same as waiting for it
+      // to run — the drain's `+25ms` is what makes the difference, and a
+      // pending count of zero would be satisfied either way.
+      expect(await page.evaluate("window.__ranLate === true")).toBe(true);
+      expect(await page.evaluate("window.__ranSoon === true")).toBe(true);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("survives a repeated install and still behaves like setTimeout", async () => {
+    const page = await browser.newPage();
+    try {
+      // Playwright re-runs init scripts on every navigation, so the script
+      // guards against installing twice. That guard is deliberately *not*
+      // asserted here: what it prevents is a wrapper wrapping a wrapper, and
+      // from inside the page that is indistinguishable from a single install —
+      // the reader only ever sees the outermost state bag, and the counts come
+      // out the same either way. Asserting it would mean writing a test that
+      // passes whether or not the guard is there, which is worse than not
+      // having one. What is checked is the part that *is* observable: a page
+      // that got the script twice still gets working timers.
+      await page.addInitScript({ content: buildAsyncWatchScript() });
+      await page.addInitScript({ content: buildAsyncWatchScript() });
+      await page.goto(base + "/");
+      expect((await readPendingAsync(page)).measured).toBe(true);
+      // The patched `setTimeout` still has to behave like `setTimeout`,
+      // including `clearTimeout` removing the entry rather than leaking it.
+      const cleared = await page.evaluate(`(() => {
+        const id = setTimeout(() => { window.__shouldNotRun = true; }, 50);
+        clearTimeout(id);
+        return true;
+      })()`);
+      expect(cleared).toBe(true);
+      await drainScheduledWork(page, 2000);
+      expect(await page.evaluate("window.__shouldNotRun === true")).toBe(false);
+    } finally {
+      await page.close();
+    }
+  });
+});

--- a/packages/chaosbringer/src/model/model.test.ts
+++ b/packages/chaosbringer/src/model/model.test.ts
@@ -17,6 +17,7 @@ import {
   observationNameFor,
   resolvePlanTiming,
   validateCallCountRules,
+  type PendingAsync,
   type PlanOracleInput,
   type PlanRunResult,
 } from "./runner.js";
@@ -845,6 +846,7 @@ describe("nextDrainWaitMs", () => {
     const decoysThenTheInterestingOne = {
       timers: 5,
       intervals: 0,
+      measured: true,
       earliestDueInMs: 150,
       latestDueInMs: 900,
       dueInMs: [150, 300, 450, 600, 900],
@@ -856,6 +858,7 @@ describe("nextDrainWaitMs", () => {
     const withASessionTimer = {
       timers: 6,
       intervals: 0,
+      measured: true,
       earliestDueInMs: 150,
       latestDueInMs: 300000,
       dueInMs: [150, 300, 450, 600, 900, 300000],
@@ -869,7 +872,7 @@ describe("nextDrainWaitMs", () => {
     // stop — the timer is reported in `observed.pendingAsync`, not slept on.
     expect(
       nextDrainWaitMs(
-        { timers: 1, intervals: 0, earliestDueInMs: 295328, latestDueInMs: 295328, dueInMs: [295328] },
+        { timers: 1, intervals: 0, measured: true, earliestDueInMs: 295328, latestDueInMs: 295328, dueInMs: [295328] },
         3000,
       ),
     ).toBeNull();
@@ -877,24 +880,24 @@ describe("nextDrainWaitMs", () => {
     // earliest, which is the safe direction: it under-drains rather than
     // over-sleeping.
     expect(
-      nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: 295328 }, 3000),
+      nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: 295328 }, 3000),
     ).toBeNull();
     // Exactly on the boundary is still worth waiting for; one ms over is not.
-    expect(nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: 2975 }, 3000)).toBe(3000);
-    expect(nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: 2976 }, 3000)).toBeNull();
+    expect(nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: 2975 }, 3000)).toBe(3000);
+    expect(nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: 2976 }, 3000)).toBeNull();
   });
 
   it("stops when nothing is pending or the cap is spent", () => {
-    expect(nextDrainWaitMs({ timers: 0, intervals: 0 }, 3000)).toBeNull();
-    expect(nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: 10 }, 0)).toBeNull();
-    expect(nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: 10 }, -5)).toBeNull();
+    expect(nextDrainWaitMs({ timers: 0, intervals: 0, measured: true }, 3000)).toBeNull();
+    expect(nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: 10 }, 0)).toBeNull();
+    expect(nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: 10 }, -5)).toBeNull();
   });
 
   it("never waits less than the callback needs to actually run", () => {
     // A timer already due reads as 0 or negative; the +25 is what makes the
     // difference between "became due" and "ran".
-    expect(nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: 0 }, 3000)).toBe(25);
-    expect(nextDrainWaitMs({ timers: 1, intervals: 0, earliestDueInMs: -40 }, 3000)).toBe(25);
+    expect(nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: 0 }, 3000)).toBe(25);
+    expect(nextDrainWaitMs({ timers: 1, intervals: 0, measured: true, earliestDueInMs: -40 }, 3000)).toBe(25);
   });
 });
 
@@ -1248,6 +1251,78 @@ describe("evaluatePlanOracle", () => {
   });
   const fields = (input: PlanOracleInput): string[] =>
     evaluatePlanOracle(input).map((m) => m.field).sort();
+
+  describe("a drain that was asked for and did not happen", () => {
+    // `unhandledRejection: false` is a claim about a window. The drain is what
+    // makes the window long enough to cover a `void retry()` on a backoff, so
+    // "the instrumentation was not there" and "the page had nothing pending"
+    // have to be different observations — they used to be the same
+    // `{ timers: 0, intervals: 0 }`.
+    const plan = { name: "clean", schedule: [], expect: { unhandledRejection: false } };
+    const observedWith = (pendingAsync: PendingAsync) => ({
+      unhandledRejection: false,
+      lateUnhandledRejection: false,
+      fired: {},
+      matched: {},
+      pendingAsync,
+    });
+
+    it("reports `undecided` when the instrumentation was not readable", () => {
+      expect(
+        fields(
+          base({
+            plan,
+            asyncDrainCapMs: 3000,
+            observed: observedWith({ timers: 0, intervals: 0, measured: false }),
+          }),
+        ),
+      ).toEqual(["undecided"]);
+    });
+
+    it("says nothing when the page really was idle", () => {
+      // Same counters, opposite meaning. This is the pair the old shape could
+      // not express.
+      expect(
+        fields(
+          base({
+            plan,
+            asyncDrainCapMs: 3000,
+            observed: observedWith({ timers: 0, intervals: 0, measured: true }),
+          }),
+        ),
+      ).toEqual([]);
+    });
+
+    it("respects an explicit opt-out", () => {
+      // `asyncDrainCapMs: 0` disables the instrumentation on purpose, so an
+      // unmeasured read is the documented consequence of the caller's choice,
+      // not a harness that broke. Reporting it would make the opt-out unusable.
+      expect(
+        fields(
+          base({
+            plan,
+            asyncDrainCapMs: 0,
+            observed: observedWith({ timers: 0, intervals: 0, measured: false }),
+          }),
+        ),
+      ).toEqual([]);
+    });
+
+    it("does not fire for a plan that expects a rejection to escape", () => {
+      // The drain only matters to the negative claim: an escape the model
+      // predicted either happened or did not, and waiting longer cannot turn
+      // "it escaped" into a weaker statement.
+      expect(
+        fields(
+          base({
+            plan: { name: "escapes", schedule: [], expect: { unhandledRejection: true } },
+            asyncDrainCapMs: 3000,
+            observed: observedWith({ timers: 0, intervals: 0, measured: false }),
+          }),
+        ),
+      ).toEqual(["unhandledRejection"]);
+    });
+  });
 
   describe("`expect.ui` without a uiProbe", () => {
     // The bridge decides whether a uiProbe exists; the plan decides whether it

--- a/packages/chaosbringer/src/model/model.test.ts
+++ b/packages/chaosbringer/src/model/model.test.ts
@@ -1249,6 +1249,57 @@ describe("evaluatePlanOracle", () => {
   const fields = (input: PlanOracleInput): string[] =>
     evaluatePlanOracle(input).map((m) => m.field).sort();
 
+  describe("`expect.ui` without a uiProbe", () => {
+    // The bridge decides whether a uiProbe exists; the plan decides whether it
+    // states `expect.ui`. When those disagree the run used to skip the label
+    // comparison and report nothing, so the plan's loudest expectation passed
+    // by never being read. These tests pin the opposite.
+    const plan = {
+      name: "no-probe",
+      schedule: [],
+      expect: { ui: "error" },
+    };
+
+    it("reports `undecided` instead of passing silently", () => {
+      expect(fields(base({ plan, hasUiProbe: false }))).toEqual(["undecided"]);
+    });
+
+    it("names the missing probe and the unread label in the detail", () => {
+      const m = evaluatePlanOracle(base({ plan, hasUiProbe: false }));
+      expect(m).toHaveLength(1);
+      expect(m[0]!.expected).toBe("error");
+      expect(m[0]!.actual).toBeUndefined();
+      expect(m[0]!.detail).toContain("uiProbe");
+      expect(m[0]!.detail).toContain('ui="error"');
+    });
+
+    it("stays quiet when the plan states no ui expectation", () => {
+      // A probe-less bridge is a legitimate configuration — it is only the
+      // *combination* with `expect.ui` that decides nothing.
+      expect(
+        fields(base({ plan: { name: "n", schedule: [], expect: {} }, hasUiProbe: false })),
+      ).toEqual([]);
+    });
+
+    it("judges the label normally once a probe exists", () => {
+      expect(
+        fields(
+          base({
+            plan,
+            hasUiProbe: true,
+            observed: {
+              unhandledRejection: false,
+              lateUnhandledRejection: false,
+              fired: {},
+              matched: {},
+              ui: "error",
+            },
+          }),
+        ),
+      ).toEqual([]);
+    });
+  });
+
   describe("an all-`pass` plan has to be observed, not merely not-failed", () => {
     const plan = {
       name: "happy",

--- a/packages/chaosbringer/src/model/runner.ts
+++ b/packages/chaosbringer/src/model/runner.ts
@@ -232,11 +232,19 @@ export interface RunPlanOptions {
    * cap and returned with that timer still pending: +3s per plan of pure
    * sleep for any page with a stray `setTimeout`.)
    *
-   * Blind spot worth knowing: the instrumentation is installed from the
-   * `afterLoad` hook, so timers scheduled *during page load* are invisible to
-   * it. For a plan with no `action` — operations issued by page load itself —
-   * the drain is therefore inert, and `unhandledRejection: false` on such a
-   * plan carries none of the guarantee described above.
+   * The instrumentation goes in as a pre-load init script, so timers scheduled
+   * *during page load* are counted too. It used to be installed from the
+   * `afterLoad` hook, which left a plan with no `action` — operations issued by
+   * page load itself — with nothing instrumented at all: a page that let a
+   * rejection escape from a 900ms load-time backoff was reported as
+   * `unhandledRejection: false`, alongside `pendingAsync: { timers: 0 }`
+   * asserting there had been nothing to wait for.
+   *
+   * The cost of watching from load is that load-time timers a framework
+   * schedules for its own reasons are now waited on as well. That is bounded
+   * by this cap and by what the drain can actually finish, and it buys the one
+   * thing the shorter window could not: `unhandledRejection: false` on an
+   * action-less plan now means something.
    */
   asyncDrainCapMs?: number;
   /**
@@ -1060,73 +1068,88 @@ export interface PendingAsync {
    * budget, which neither extreme can answer.
    */
   dueInMs?: readonly number[];
+  /**
+   * Whether the instrumentation was actually in place when this was read.
+   *
+   * `{ timers: 0, intervals: 0 }` used to be returned both for "the page has
+   * nothing scheduled" and for "the wrapper was never installed, so I have no
+   * idea" — two facts a reader cannot tell apart, one of which is a
+   * measurement and the other an absence of one. Everything the drain and the
+   * `unhandledRejection` verdict claim rests on that difference.
+   */
+  measured: boolean;
 }
 
 /**
  * Instrument `setTimeout` / `setInterval` so the run can tell "no rejection
  * escaped" from "nothing had run yet".
  *
- * Installed from the invariant hook, before the action fires — which is
- * exactly when the interesting timers get scheduled, since they are the app's
- * reaction to the outcomes the plan injected. `fetch` is deliberately left
- * alone: the fault layers already own it, and wrapping it again would insert
- * a microtask into the very promise chains under test.
+ * Installed as a pre-load init script, not from the invariant hook. The hook
+ * runs `afterLoad`, so every timer the page scheduled *while loading* was
+ * invisible to it — and a plan with no `action`, whose operations are issued
+ * by page load itself, therefore had nothing instrumented at all. A page that
+ * let a rejection escape from a 900ms load-time backoff was reported as
+ * `unhandledRejection: false` with `pendingAsync: { timers: 0 }`: not merely
+ * a missed finding, but a positive claim that there was nothing to wait for.
+ *
+ * `fetch` is deliberately left alone: the fault layers already own it, and
+ * wrapping it again would insert a microtask into the very promise chains
+ * under test.
+ *
+ * Returned as a string rather than applied to a `Page`, because being early
+ * enough is the whole point — see `CrawlerOptions.initScripts`.
  */
-async function installAsyncWatch(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const w = window as unknown as {
-      __cbModelAsync?: { timers: Map<unknown, number>; intervals: number };
-    };
-    if (w.__cbModelAsync) return;
-    const state = { timers: new Map<unknown, number>(), intervals: 0 };
-    w.__cbModelAsync = state;
-    try {
-      const origSetTimeout = window.setTimeout;
-      const origClearTimeout = window.clearTimeout;
-      const origSetInterval = window.setInterval;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).setTimeout = function (handler: unknown, timeout?: number, ...args: unknown[]) {
-        if (typeof handler !== "function") {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (origSetTimeout as any).call(window, handler, timeout, ...args);
-        }
-        let id: unknown;
-        function wrapped(this: unknown) {
-          state.timers.delete(id);
-          // eslint-disable-next-line prefer-rest-params
-          return (handler as (...a: unknown[]) => unknown).apply(this, arguments as unknown as unknown[]);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        id = (origSetTimeout as any).call(window, wrapped, timeout, ...args);
-        state.timers.set(id, Date.now() + (Number(timeout) || 0));
-        return id;
-      };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).clearTimeout = function (id: unknown) {
+export function buildAsyncWatchScript(): string {
+  // An explicit string, not `fn.toString()`. Serializing a live function reads
+  // as tidier and is the one form that can break without saying so: a minifier,
+  // a coverage instrumenter or a transpiler rewriting the body leaves an init
+  // script that installs nothing, and an observer that installed nothing
+  // reports zero — see `PendingAsync.measured` for what that costs. The rest of
+  // this codebase builds init scripts as text for the same reason.
+  return `(() => {
+  if (typeof window === "undefined") return;
+  if (window.__cbModelAsync) return;
+  const state = { timers: new Map(), intervals: 0 };
+  window.__cbModelAsync = state;
+  try {
+    const origSetTimeout = window.setTimeout;
+    const origClearTimeout = window.clearTimeout;
+    const origSetInterval = window.setInterval;
+    window.setTimeout = function (handler, timeout, ...args) {
+      if (typeof handler !== "function") {
+        return origSetTimeout.call(window, handler, timeout, ...args);
+      }
+      let id;
+      function wrapped() {
         state.timers.delete(id);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (origClearTimeout as any).call(window, id);
-      };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).setInterval = function (...args: unknown[]) {
-        state.intervals += 1;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (origSetInterval as any).apply(window, args);
-      };
-    } catch {
-      // Never let instrumentation break the page under test.
-    }
-  });
+        return handler.apply(this, arguments);
+      }
+      id = origSetTimeout.call(window, wrapped, timeout, ...args);
+      state.timers.set(id, Date.now() + (Number(timeout) || 0));
+      return id;
+    };
+    window.clearTimeout = function (id) {
+      state.timers.delete(id);
+      return origClearTimeout.call(window, id);
+    };
+    window.setInterval = function (...args) {
+      state.intervals += 1;
+      return origSetInterval.apply(window, args);
+    };
+  } catch {
+    // Never let instrumentation break the page under test.
+  }
+})();`;
 }
 
-async function readPendingAsync(page: Page): Promise<PendingAsync> {
+export async function readPendingAsync(page: Page): Promise<PendingAsync> {
   try {
     return await page.evaluate(() => {
       const w = window as unknown as {
         __cbModelAsync?: { timers: Map<unknown, number>; intervals: number };
       };
       const state = w.__cbModelAsync;
-      if (!state) return { timers: 0, intervals: 0 };
+      if (!state) return { timers: 0, intervals: 0, measured: false };
       const now = Date.now();
       const due: number[] = [];
       state.timers.forEach((at) => {
@@ -1140,11 +1163,14 @@ async function readPendingAsync(page: Page): Promise<PendingAsync> {
             earliestDueInMs: due[0],
             latestDueInMs: due[due.length - 1],
             dueInMs: due,
+            measured: true,
           }
-        : { timers: 0, intervals: state.intervals };
+        : { timers: 0, intervals: state.intervals, measured: true };
     });
   } catch {
-    return { timers: 0, intervals: 0 };
+    // An `evaluate` that threw is a page we could not read, not a page with
+    // nothing scheduled.
+    return { timers: 0, intervals: 0, measured: false };
   }
 }
 
@@ -1269,6 +1295,12 @@ export interface PlanOracleInput {
   hasUiProbe: boolean;
   /** Whether the bridge supplied a `stateProbe`. */
   hasStateProbe: boolean;
+  /**
+   * The drain budget the run asked for, so the oracle can tell an opt-out
+   * (`0`, a deliberate choice) from instrumentation that was asked for and
+   * did not arrive.
+   */
+  asyncDrainCapMs?: number;
   /** Opt-in span comparison; see `RunPlanOptions.checkAmplification`. */
   checkAmplification?: boolean;
   /** Reported in the details, so a failure names the window it was judged in. */
@@ -1311,6 +1343,7 @@ export function evaluatePlanOracle(input: PlanOracleInput): PlanMismatch[] {
     settleMs,
     quiescenceMs,
   } = input;
+
   const uiInvariantFailures = input.uiInvariantFailures ?? [];
   const mismatches: PlanMismatch[] = [];
 
@@ -1651,6 +1684,35 @@ export function evaluatePlanOracle(input: PlanOracleInput): PlanMismatch[] {
             : `a rejection escaped every handler, which the model's contract forbids`,
       });
     }
+    // 4b. `unhandledRejection: false` is a claim about a window, and the drain
+    //     is what makes the window long enough to hold the app's own follow-up
+    //     work. If the run asked for a drain and the instrumentation was not
+    //     there to read, the claim rests on whatever happened to finish before
+    //     the probe — which is the difference between "nothing escaped" and "I
+    //     stopped watching first". `asyncDrainCapMs: 0` is excluded: that is a
+    //     caller deliberately choosing the shorter window, not a harness that
+    //     failed to install.
+    const drain = observed.pendingAsync;
+    if (
+      plan.expect.unhandledRejection === false &&
+      (input.asyncDrainCapMs ?? 0) > 0 &&
+      drain !== undefined &&
+      !drain.measured
+    ) {
+      mismatches.push({
+        plan: plan.name,
+        field: "undecided",
+        expected: false,
+        actual: observed.unhandledRejection,
+        detail:
+          `the plan states no rejection escapes, and the run asked to wait out the app's own ` +
+          `timers (asyncDrainCapMs=${input.asyncDrainCapMs}) — but the timer instrumentation ` +
+          `was not readable when the drain went to look, so nothing waited for a \`void retry()\` ` +
+          `on a backoff. "No rejection escaped" here means "none escaped before the probe", ` +
+          `which is a different and much weaker statement. Check that the init script installed ` +
+          `(a page with a CSP that blocks it, or a navigation that replaced the window).`,
+      });
+    }
   }
   return mismatches;
 }
@@ -1709,7 +1771,6 @@ export async function runPlan(plan: FaultPlan, opts: RunPlanOptions): Promise<Pl
     when: "afterLoad",
     check: async ({ page }) => {
       try {
-        if (asyncDrainCapMs > 0) await installAsyncWatch(page);
         if (opts.action) await opts.action(page);
         // The observation clock starts here, not at the top of the action: the
         // action *issues* the request, so the injected delay's own clock and
@@ -1736,7 +1797,10 @@ export async function runPlan(plan: FaultPlan, opts: RunPlanOptions): Promise<Pl
         // retry the app scheduled on the error path is observed instead of
         // outliving the run.
         const rejectionsAtProbe = await peekEscapedRejections(page);
-        let pending: PendingAsync = { timers: 0, intervals: 0 };
+        // `measured: false` until something reads the page: if the drain is
+        // disabled, or the read below throws, what gets reported has to say so
+        // rather than look like an idle page.
+        let pending: PendingAsync = { timers: 0, intervals: 0, measured: false };
         if (asyncDrainCapMs > 0) pending = await drainScheduledWork(page, asyncDrainCapMs);
         if (quiescenceMs > 0) await page.waitForTimeout(quiescenceMs);
         if (asyncDrainCapMs > 0) pending = await readPendingAsync(page);
@@ -1772,6 +1836,10 @@ export async function runPlan(plan: FaultPlan, opts: RunPlanOptions): Promise<Pl
     timeout: opts.timeout ?? timing.pageTimeoutMs ?? 15000,
     ...(runtimeFaults.length > 0 ? { runtimeFaults } : {}),
     ...(faultInjection.length > 0 ? { faultInjection } : {}),
+    // Before the page's own scripts, so a timer scheduled during load is
+    // visible too. `asyncDrainCapMs: 0` opts out of the instrumentation as
+    // well as the wait, which is what the option documents.
+    ...(asyncDrainCapMs > 0 ? { initScripts: [buildAsyncWatchScript()] } : {}),
     ...(opts.coverageFingerprints ? { coverageFeedback: { enabled: true } } : {}),
     invariants: [oracleHook],
   });
@@ -1801,6 +1869,7 @@ export async function runPlan(plan: FaultPlan, opts: RunPlanOptions): Promise<Pl
     uiInvariantFailuresLate,
     hasUiProbe: opts.uiProbe !== undefined,
     hasStateProbe: opts.stateProbe !== undefined,
+    asyncDrainCapMs,
     ...(opts.checkAmplification !== undefined ? { checkAmplification: opts.checkAmplification } : {}),
     settleMs,
     quiescenceMs,

--- a/packages/chaosbringer/src/model/runner.ts
+++ b/packages/chaosbringer/src/model/runner.ts
@@ -970,6 +970,10 @@ function checkBudgetAndNavigation(
     ...(opts.budgetMs !== undefined ? { settleMs, quiescenceMs } : {}),
     ...(opts.timeout !== undefined ? { pageTimeoutMs: opts.timeout, slowMs } : {}),
   };
+  // The caller declared neither a budget nor a navigation timeout, so there is
+  // genuinely nothing to validate — distinct from handing `checkTiming` an
+  // empty proposal, which it now reports as `ok: false` because "you asked me
+  // to check nothing" is not a verdict.
   if (Object.keys(proposed).length === 0) return;
   const check = checkTiming(profile, request, proposed);
   if (check.ok) return;

--- a/packages/chaosbringer/src/model/runner.ts
+++ b/packages/chaosbringer/src/model/runner.ts
@@ -1261,7 +1261,11 @@ export interface PlanOracleInput {
    * only fails here is `uiInvariant@late`.
    */
   uiInvariantFailuresLate?: ReadonlyArray<{ key: string; message: string }>;
-  /** Whether the bridge supplied a `uiProbe` — without one `expect.ui` is skipped. */
+  /**
+   * Whether the bridge supplied a `uiProbe`. Without one a plan's `expect.ui`
+   * cannot be judged, which is reported as an `undecided` mismatch rather than
+   * skipped — see section 2a.
+   */
   hasUiProbe: boolean;
   /** Whether the bridge supplied a `stateProbe`. */
   hasStateProbe: boolean;
@@ -1478,6 +1482,31 @@ export function evaluatePlanOracle(input: PlanOracleInput): PlanMismatch[] {
   //    the convergence in the detail. A label that started *right* and moved
   //    is the `Promise.race` bug: the user is told the report failed and then
   //    shown the report, from a request the app believes it abandoned.
+  //
+  // 2a. …but first: was there a probe at all? A plan stating `expect.ui`
+  //     against a bridge with no `uiProbe` used to assert nothing about the UI,
+  //     silently — the comparison below was skipped because there was nothing
+  //     to compare, and a plan's most commonly stated expectation evaporated.
+  //     Section 3 already holds the opposite rule for `expect.state` ("an
+  //     unchecked expectation is worse than none") and the `expect.calls` path
+  //     reports `undecided` when no layer counted; `ui` was the one with a free
+  //     pass. Reported as `undecided` rather than `ui` so a consumer switching
+  //     on the field can tell "no label was ever read" from "the app showed the
+  //     wrong label". (Section 3 predates `undecided` and reports under `state`
+  //     with `actual: undefined`; left as it is rather than changed underneath
+  //     its callers.)
+  if (plan.expect.ui !== undefined && !hasUiProbe) {
+    mismatches.push({
+      plan: plan.name,
+      field: "undecided",
+      expected: plan.expect.ui,
+      actual: undefined,
+      detail:
+        `plan expects ui="${plan.expect.ui}" but the bridge has no uiProbe, so no label was ` +
+        `ever read — nothing here decides anything about the UI. Add a uiProbe, or drop ` +
+        `expect.ui from the plan; an unmeasured assertion is not a satisfied one.`,
+    });
+  }
   if (plan.expect.ui !== undefined && hasUiProbe && !undecidedProbe) {
     if (observed.ui !== plan.expect.ui) {
       const converged =

--- a/packages/chaosbringer/src/rejections.test.ts
+++ b/packages/chaosbringer/src/rejections.test.ts
@@ -115,6 +115,77 @@ describe("watchUnhandledRejections", () => {
     }
   }, 60_000);
 
+  it("catches escapes when installed after the page already loaded", async () => {
+    // The whole point of the previous test read the other way round. Installing
+    // only as an init script meant this case listened to nothing and `drain()`
+    // answered `[]` — the same answer a clean page gives, so the caller who got
+    // the order wrong was told their app was fine. Getting the order wrong is
+    // the normal way to use a helper whose name does not mention navigation.
+    const page = await browser.newPage();
+    try {
+      await page.goto(base + "/");
+      const watcher = await watchUnhandledRejections(page);
+      await page.evaluate('window.escapeOne("late-install")');
+      expect((await drainOnce(page, watcher)).map((r) => r.message)).toEqual(["late-install"]);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
+  it("still claims the rejection when installed late, so it is not double-counted", async () => {
+    // `preventDefault` is the load-bearing line: without it Chromium reports
+    // the same rejection again through `pageerror`, and a harness listening to
+    // both counts one escape as two and calls one of them a thrown exception.
+    // The late install runs the same code, so it has to keep that property —
+    // this is what a second copy of the listener would have quietly lost.
+    const page = await browser.newPage();
+    const pageErrors: string[] = [];
+    page.on("pageerror", (e) => pageErrors.push(e.message));
+    try {
+      await page.goto(base + "/");
+      const watcher = await watchUnhandledRejections(page);
+      await page.evaluate('window.escapeOne("claimed")');
+      expect((await drainOnce(page, watcher)).map((r) => r.message)).toEqual(["claimed"]);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
+  it("counts one escape once no matter how many times it was installed", async () => {
+    // Installing twice on a live document is the case the idempotence guard is
+    // for, and it is easy to reach: the crawler installs on page setup, and a
+    // caller who also wants a watcher of their own installs again. Both
+    // listeners push into the same `window.__chaosRejections`, so without the
+    // guard one escaped rejection is reported as two — a fabricated finding,
+    // which is worse than a missed one.
+    const page = await browser.newPage();
+    try {
+      await page.goto(base + "/");
+      await watchUnhandledRejections(page);
+      const watcher = await watchUnhandledRejections(page);
+      await page.evaluate('window.escapeOne("once")');
+      expect((await drainOnce(page, watcher)).map((r) => r.message)).toEqual(["once"]);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
+  it("re-arms across navigation after a late install", async () => {
+    // The guard must not fire on a fresh document, or the first navigation
+    // after a late install would leave nothing listening.
+    const page = await browser.newPage();
+    try {
+      await page.goto(base + "/");
+      const watcher = await watchUnhandledRejections(page);
+      await page.goto(base + "/?again");
+      await page.evaluate('window.escapeOne("after-nav")');
+      expect((await drainOnce(page, watcher)).map((r) => r.message)).toEqual(["after-nav"]);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
   it("reports nothing, rather than throwing, once the page is gone", async () => {
     const page = await browser.newPage();
     const watcher = await watchUnhandledRejections(page);

--- a/packages/chaosbringer/src/rejections.ts
+++ b/packages/chaosbringer/src/rejections.ts
@@ -27,36 +27,61 @@ export interface RejectionWatcher {
    * you want when you probe once at a deadline and again after a quiescence
    * window.
    *
-   * Returns `[]` rather than throwing when the page has navigated away or
-   * closed: a dead page has no rejections to report, and turning that into an
-   * error would fail runs for the wrong reason.
+   * Returns `[]` rather than throwing when the page has closed under you. That
+   * is a genuine loss, not a clean result: escapes already in the bag go with
+   * it, and there is no longer anywhere to read them from. It is not raised as
+   * an error because a page closing is usually reported by whatever closed it,
+   * and failing the run here would name the wrong cause.
    */
   drain(): Promise<EscapedRejection[]>;
 }
 
 /**
- * Start capturing unhandled rejections on `page`.
+ * The listener, as one function used two ways: as an init script for every
+ * future navigation, and evaluated once against the document that is already
+ * open. Both installs run the same code, because the alternative — a second
+ * copy for the already-loaded case — is how one of them ends up without the
+ * `preventDefault`.
+ */
+function installRejectionCapture(): void {
+  const w = window as unknown as { __chaosRejections?: EscapedRejection[] };
+  if (w.__chaosRejections !== undefined) return; // idempotent per frame
+  w.__chaosRejections = [];
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason as { message?: string; stack?: string } | undefined;
+    w.__chaosRejections?.push({
+      message: reason?.message || String(event.reason),
+      ...(reason?.stack !== undefined ? { stack: reason.stack } : {}),
+    });
+    // Claim it, so it does not also arrive as `pageerror` and get counted
+    // twice — once as a rejection and once as a thrown exception.
+    event.preventDefault();
+  });
+}
+
+/**
+ * Start capturing unhandled rejections on `page`. Survives navigation, so one
+ * call covers a whole test, and it does not matter whether the page has loaded
+ * yet.
  *
- * Installed as an init script, so **call this before you navigate** — on an
- * already-loaded page nothing is listening and `drain()` reports an honest but
- * useless empty list. It survives navigation, so one call covers a whole test.
+ * That last part used to be a trap: the listener went in only as an init
+ * script, so calling this *after* navigating left nothing listening and
+ * `drain()` returned `[]` — measured on a page that escapes a rejection on
+ * demand, an empty result while the escape happened. The docstring called that
+ * "an honest but useless empty list", which it is not: `[]` is the same answer
+ * a clean page gives, so a caller who got the order wrong was told their app
+ * was fine. Documenting a trap is not the same as not having one, so the
+ * listener is now also evaluated against the current document.
  */
 export async function watchUnhandledRejections(page: Page): Promise<RejectionWatcher> {
-  await page.addInitScript(() => {
-    const w = window as unknown as { __chaosRejections?: EscapedRejection[] };
-    if (w.__chaosRejections !== undefined) return; // idempotent per frame
-    w.__chaosRejections = [];
-    window.addEventListener("unhandledrejection", (event) => {
-      const reason = event.reason as { message?: string; stack?: string } | undefined;
-      w.__chaosRejections?.push({
-        message: reason?.message || String(event.reason),
-        ...(reason?.stack !== undefined ? { stack: reason.stack } : {}),
-      });
-      // Claim it, so it does not also arrive as `pageerror` and get counted
-      // twice — once as a rejection and once as a thrown exception.
-      event.preventDefault();
-    });
-  });
+  await page.addInitScript(installRejectionCapture);
+  try {
+    await page.evaluate(installRejectionCapture);
+  } catch {
+    // No document to install into yet (or it went away). The init script
+    // covers every navigation from here, which is the common case and the one
+    // the crawler uses.
+  }
   return { drain: () => drainRejections(page) };
 }
 
@@ -70,7 +95,10 @@ export async function drainRejections(page: Page): Promise<EscapedRejection[]> {
       return bag;
     });
   } catch {
-    // Page navigated away or closed — nothing to report, and not an error.
+    // The page is gone. Anything still in the bag is lost with it — this is a
+    // read that could not happen, not a page with nothing to report. Callers
+    // who need to tell those apart have to observe the page closing; there is
+    // nothing left here to ask.
     return [];
   }
 }

--- a/packages/chaosbringer/src/timing.test.ts
+++ b/packages/chaosbringer/src/timing.test.ts
@@ -306,9 +306,15 @@ describe("checkTiming", () => {
   });
 
   it("skips constraints whose inputs were not proposed", () => {
-    const check = checkTiming(MEASURED, { deadlineMs: 5000 }, {});
-    expect(check.rows).toEqual([]);
+    // The skipping is the point: naming one field checks that field and stays
+    // quiet about the rest. This used to be written with an *empty* proposal
+    // and `ok: true`, which asserted something else — that checking nothing
+    // counts as passing. That half is now covered, with the opposite
+    // expectation, under "checkTiming reports whether it checked anything".
+    const check = checkTiming(MEASURED, { deadlineMs: 5000 }, { quiescenceMs: 5097 });
+    expect(check.checked).toBe(1);
     expect(check.ok).toBe(true);
+    expect(check.rows.map((r) => r.constraint)).toEqual(["rejections_drained_after_last_timer"]);
   });
 });
 
@@ -392,5 +398,48 @@ describe("solveTiming and a declared retry ladder", () => {
     if (solved.status !== "sat") return;
     const { tightTailMs: tight, marginMs: margin, delayFloorMs: floor } = solved.profile;
     expect(solved.slowMs + floor).toBeGreaterThanOrEqual(solved.settleMs + tight + margin);
+  });
+});
+
+describe("checkTiming reports whether it checked anything", () => {
+  const profile = { delayFloorMs: 10, delayTailMs: 60, tightTailMs: 5, fixedPerPlanMs: 700 };
+  const request = { deadlineMs: 700 };
+
+  it("does not call an empty proposal `ok`", () => {
+    // It used to: zero rows, `ok: true`. "I checked nothing" reading as
+    // "everything is fine" is the defect this codebase keeps producing, and
+    // finding it in the validator is the least excusable place for it. One
+    // call site had already worked around it locally, which is the tell.
+    const empty = checkTiming(profile, request, {});
+    expect(empty.checked).toBe(0);
+    expect(empty.ok).toBe(false);
+    expect(empty.violations).toEqual([]);
+  });
+
+  it("treats explicitly-undefined fields as absent, not as zero", () => {
+    const undef = checkTiming(profile, request, { settleMs: undefined, slowMs: undefined });
+    expect(undef.checked).toBe(0);
+    expect(undef.ok).toBe(false);
+  });
+
+  it("counts what it evaluated, and passes a sound proposal", () => {
+    const solved = solveTiming(profile, request);
+    expect(solved.status).toBe("sat");
+    if (solved.status !== "sat") return;
+    const check = checkTiming(profile, request, {
+      settleMs: solved.settleMs,
+      slowMs: solved.slowMs,
+    });
+    expect(check.checked).toBeGreaterThan(0);
+    expect(check.ok).toBe(true);
+    expect(check.violations).toEqual([]);
+  });
+
+  it("still fails a proposal that violates something", () => {
+    // The guard above must not be satisfiable by calling everything ok.
+    const check = checkTiming(profile, request, { settleMs: 1 });
+    expect(check.checked).toBeGreaterThan(0);
+    expect(check.ok).toBe(false);
+    expect(check.violations.length).toBeGreaterThan(0);
   });
 });

--- a/packages/chaosbringer/src/timing.ts
+++ b/packages/chaosbringer/src/timing.ts
@@ -583,13 +583,35 @@ export interface TimingSlack {
 }
 
 export interface TimingCheck {
+  /**
+   * True when something was checked **and** all of it held.
+   *
+   * The second half matters: an empty `ProposedTiming` used to return
+   * `ok: true` with zero rows, so "I checked nothing" read as "everything is
+   * fine" — in the validator, which is the one place that shape is least
+   * excusable. One call site had worked around it with its own
+   * `Object.keys(proposed).length === 0` guard, which is how you can tell the
+   * knowledge was in the wrong place.
+   */
   ok: boolean;
+  /**
+   * How many constraints were actually evaluated. Zero means the proposal
+   * named no fields this function knows how to check — a programming error at
+   * the call site, not a verdict about the timing.
+   */
+  checked: number;
   rows: TimingSlack[];
   violations: TimingSlack[];
   profile: ResolvedProfile;
 }
 
-/** A config to validate — anything omitted is skipped rather than assumed. */
+/**
+ * A config to validate — anything omitted is skipped rather than assumed.
+ *
+ * Omitting *everything* is not "nothing to complain about": see
+ * `TimingCheck.ok`. If your proposal is built conditionally and may come out
+ * empty, decide what that means at your call site before calling.
+ */
 export interface ProposedTiming {
   settleMs?: number;
   quiescenceMs?: number;
@@ -713,7 +735,16 @@ export function checkTiming(
   }
 
   const violations = rows.filter((r) => r.slackMs < 0);
-  return { ok: violations.length === 0, rows, violations, profile: p };
+  // `rows.length` is the count of constraints evaluated: one row per thing this
+  // function had something to say about. Zero means the proposal named nothing
+  // checkable, which is a call-site mistake and not a passing verdict.
+  return {
+    ok: rows.length > 0 && violations.length === 0,
+    checked: rows.length,
+    rows,
+    violations,
+    profile: p,
+  };
 }
 
 /** Render a check as a one-screen report. */

--- a/packages/chaosbringer/src/types.ts
+++ b/packages/chaosbringer/src/types.ts
@@ -133,6 +133,24 @@ export interface CrawlerOptions {
    * action sequence.
    */
   coverageFeedback?: CoverageFeedbackOptions;
+  /**
+   * Raw JavaScript to evaluate on every page before any of the page's own
+   * scripts run, installed at the context level so pages opened via
+   * `window.open` inherit it too.
+   *
+   * The fault layers use `addInitScript` for exactly this reason: to patch an
+   * API the app is about to call, you have to be there before it calls it. A
+   * script installed from an `afterLoad` invariant instead is already too
+   * late for anything the page did while loading, and the gap does not
+   * announce itself — an observer that missed the load reports zero
+   * observations, which reads as "nothing happened" rather than "I wasn't
+   * watching yet".
+   *
+   * Each string is installed verbatim, so wrap in an IIFE and guard against
+   * double-install (`if (window.__myFlag) return;`) — Playwright re-runs init
+   * scripts on every navigation, including same-page iframes.
+   */
+  initScripts?: readonly string[];
   /** HAR record/replay configuration for deterministic network state. */
   har?: HarConfig;
   /**

--- a/packages/chaosbringer/src/validate.test.ts
+++ b/packages/chaosbringer/src/validate.test.ts
@@ -90,6 +90,38 @@ describe("validateOptions", () => {
     ).toThrow(/bad.*urlPattern/);
   });
 
+  it("names an unnamed fault rule by index and by pattern", () => {
+    // The two halves of this library labelled the same unnamed rule
+    // differently: validation said "rule #1", `getFaultStats` reports
+    // `pattern.toString()`. The index locates it in your config array and the
+    // pattern locates it in the report, so an error carrying only one leaves
+    // the reader to guess which row it is about.
+    let message = "";
+    try {
+      validateOptions(
+        base({
+          faultInjection: [
+            { urlPattern: "/api/ok", fault: { kind: "abort" } },
+            { urlPattern: "/api/cart", probability: 4, fault: { kind: "abort" } },
+          ],
+        }),
+      );
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("rule #1");
+    expect(message).toContain("/api/cart");
+    // …and a rule that has a name still leads with the name, which is the
+    // handle the stats table uses for it too.
+    expect(() =>
+      validateOptions(
+        base({
+          faultInjection: [{ name: "cart-500", urlPattern: "/api/cart", probability: 4, fault: { kind: "abort" } }],
+        }),
+      ),
+    ).toThrow(/rule "cart-500"/);
+  });
+
   it("rejects an invalid excludePatterns regex", () => {
     expect(() => validateOptions(base({ excludePatterns: ["("] }))).toThrow(
       /excludePatterns/

--- a/packages/playwright-faults/src/compiled-guard.test.ts
+++ b/packages/playwright-faults/src/compiled-guard.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { compileIframeFaults, mergeIframeStats } from "./iframe-faults.js";
+import { compileLifecycleFaults, lifecycleStatsFrom } from "./lifecycle-faults.js";
+import { compileRuntimeFaults, mergeRuntimeStats } from "./runtime-faults.js";
+
+/**
+ * The stats readers take *compiled* faults. Handed the originals — an easy slip,
+ * since both are "the faults" from the caller's side — each produced garbage
+ * rather than an error, and the runtime one was the worst: a row labelled with
+ * the raw fault's own `name` and counters of `NaN`, which reads as "the fault
+ * never fired" in the one assertion the whole harness rests on.
+ */
+describe("the stats readers refuse raw faults", () => {
+  it("runtime: names the compile step instead of returning NaN counters", () => {
+    const raw = [{ name: "f1", urlPattern: /x/, action: { kind: "reject-fetch" } }] as const;
+    expect(() => mergeRuntimeStats(raw as never, { "0": { matched: 3, fired: 1 } })).toThrow(
+      /compileRuntimeFaults/,
+    );
+  });
+
+  it("lifecycle: names it instead of returning an empty object", () => {
+    const raw = [{ when: "afterLoad", action: { kind: "clear-storage", scopes: ["localStorage"] } }];
+    expect(() => lifecycleStatsFrom(raw as never)).toThrow(/compileLifecycleFaults/);
+  });
+
+  it("iframe: names it instead of a `reading 'selector'` TypeError", () => {
+    const raw = [{ name: "i1", selector: "iframe", action: { kind: "never-load" } }];
+    expect(() => mergeIframeStats(raw as never, { "0": { matched: 2, fired: 1 } })).toThrow(
+      /compileIframeFaults/,
+    );
+  });
+
+  it("says which index, and that the counters would have lied", () => {
+    const raw = [
+      { name: "ok", urlPattern: /a/, action: { kind: "reject-fetch" } },
+      { name: "also-raw", urlPattern: /b/, action: { kind: "flaky-fetch" } },
+    ];
+    // The first element is raw too, so index 0 is what it names — the point is
+    // that the message carries an index at all.
+    expect(() => mergeRuntimeStats(raw as never, {})).toThrow(/index 0/);
+    expect(() => mergeRuntimeStats(raw as never, {})).toThrow(/never fired/);
+  });
+
+  it("still accepts the compiled shape, so the guard is not just a wall", () => {
+    const runtime = compileRuntimeFaults([
+      { name: "f1", urlPattern: /x/, action: { kind: "reject-fetch" } },
+    ]);
+    expect(mergeRuntimeStats(runtime, { "0": { matched: 3, fired: 1 } })).toEqual([
+      { rule: "f1", matched: 3, fired: 1 },
+    ]);
+
+    const lifecycle = compileLifecycleFaults([
+      { when: "afterLoad", action: { kind: "clear-storage", scopes: ["localStorage"] } },
+    ]);
+    expect(lifecycleStatsFrom(lifecycle)).toEqual([
+      { name: "clear-storage:localStorage", matched: 0, fired: 0, errored: 0 },
+    ]);
+
+    const iframe = compileIframeFaults([
+      { name: "i1", selector: "iframe", action: { kind: "never-load" } },
+    ]);
+    expect(mergeIframeStats(iframe, { "0": { matched: 2, fired: 1 } })).toEqual([
+      { rule: "i1", selector: "iframe", action: "never-load", matched: 2, fired: 1 },
+    ]);
+  });
+
+  it("accepts an empty list — nothing configured is not an error", () => {
+    expect(mergeRuntimeStats([], {})).toEqual([]);
+    expect(lifecycleStatsFrom([])).toEqual([]);
+    expect(mergeIframeStats([], {})).toEqual([]);
+  });
+});

--- a/packages/playwright-faults/src/compiled-guard.ts
+++ b/packages/playwright-faults/src/compiled-guard.ts
@@ -1,0 +1,57 @@
+/**
+ * Refuse raw faults where a *compiled* fault is expected.
+ *
+ * `compileXFaults()` wraps each fault as `{ fault, name, matched, fired, … }`,
+ * and the stats readers take that shape. Handed the originals instead — an
+ * easy mistake, since both are "the faults" from the caller's point of view —
+ * they produced garbage rather than an error, each in its own way:
+ *
+ * - `mergeRuntimeStats(rawFaults, …)` returned
+ *   `{ rule: "f1", matched: NaN, fired: NaN }`. The label came from the raw
+ *   fault's own `name`, so the row looks real, and `NaN > 0` is false: the
+ *   "did the fault fire?" check reports "it didn't" rather than "you called
+ *   this wrong".
+ * - `lifecycleStatsFrom(rawFaults)` returned `[{}]` — every field undefined.
+ * - `mergeIframeStats(rawFaults, …)` threw
+ *   `Cannot read properties of undefined (reading 'selector')`, which is at
+ *   least loud but names nothing a caller can act on.
+ *
+ * One guard for the three, because the alternative is three near-identical
+ * checks and eventually two of them.
+ */
+
+/** Fields every `Compiled*Fault` carries and no raw fault does. */
+interface CompiledLike {
+  fault: unknown;
+  name: unknown;
+  matched: unknown;
+}
+
+function isCompiled(value: unknown): value is CompiledLike {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return "fault" in v && "name" in v && typeof v.matched === "number";
+}
+
+/**
+ * @param fn - the function being called, for the message.
+ * @param compileFn - the name of the compile step the caller skipped.
+ */
+export function assertCompiledFaults(
+  fn: string,
+  compileFn: string,
+  faults: readonly unknown[],
+): void {
+  for (const [i, f] of faults.entries()) {
+    if (isCompiled(f)) continue;
+    const hasAction = f !== null && typeof f === "object" && "action" in f;
+    throw new Error(
+      `chaosbringer: ${fn} expects the output of ${compileFn}, but index ${i} is ` +
+        (hasAction
+          ? `a raw fault — pass \`${compileFn}(faults)\`, not \`faults\`. ` +
+            `Without the compiled wrapper the counters read as NaN or undefined, which is ` +
+            `indistinguishable from "the fault never fired".`
+          : `not a compiled fault (no \`fault\`/\`name\`/\`matched\`).`),
+    );
+  }
+}

--- a/packages/playwright-faults/src/iframe-faults.ts
+++ b/packages/playwright-faults/src/iframe-faults.ts
@@ -36,6 +36,8 @@ export interface CompiledIframeFault {
   name: string;
   matched: number;
   fired: number;
+  /** Decided "inject" while an earlier fault was already claiming the iframe. */
+  suppressed: number;
 }
 
 /** Auto-derive a stats label when the user didn't set `fault.name`. */
@@ -63,6 +65,7 @@ export function compileIframeFaults(
       name: iframeFaultName(fault),
       matched: 0,
       fired: 0,
+      suppressed: 0,
     };
   });
 }
@@ -111,19 +114,22 @@ export function buildIframeFaultsScript(
 
   const faults = ${JSON.stringify(serialized)};
   const stats = window.__chaosbringerIframeFaultStats;
-  for (const f of faults) stats[String(f.id)] = { matched: 0, fired: 0 };
+  for (const f of faults) stats[String(f.id)] = { matched: 0, fired: 0, suppressed: 0 };
 
   ${buildDecisionHelperSource()}
 
   // Occurrence = how many matching iframes this fault has seen in this frame.
+  // Deciding and firing are separate counts, as on the network and runtime
+  // layers: a scheduled fault whose decision is "inject" still advances its
+  // occurrence, but only one fault can act on a given iframe.
   const roll = (f) => {
     const slot = stats[String(f.id)];
     const occurrence = slot.matched;
     slot.matched++;
-    const fired = __decide(f, occurrence);
-    if (fired) slot.fired++;
-    return fired;
+    return __decide(f, occurrence);
   };
+  const fire = (f) => { stats[String(f.id)].fired++; };
+  const suppress = (f) => { stats[String(f.id)].suppressed++; };
 
   const HIFE = HTMLIFrameElement.prototype;
   const srcDescriptor = Object.getOwnPropertyDescriptor(HIFE, "src");
@@ -135,6 +141,12 @@ export function buildIframeFaultsScript(
 
   // Returns true if a fault claimed responsibility for this src assignment.
   function handleSrc(iframe, value) {
+    // Two passes, like the network and runtime layers. This was single-pass —
+    // the first fault to claim the iframe returned, so a *scheduled* fault
+    // behind it never advanced its occurrence and therefore never fired. That
+    // made \`decisions\` mean something different here than on the other layers,
+    // silently, while the docs promised one shape understood by all four.
+    let chosen = null;
     for (const f of faults) {
       let matched;
       try {
@@ -143,7 +155,24 @@ export function buildIframeFaultsScript(
         matched = false;
       }
       if (!matched) continue;
-      if (!roll(f)) continue;
+      if (f.schedule) {
+        // A scheduled fault always consumes its occurrence when its selector
+        // matches, so two faults watching one iframe agree about what
+        // "occurrence 1" means.
+        if (roll(f)) {
+          if (chosen) suppress(f);
+          else chosen = f;
+        }
+        continue;
+      }
+      // Probability stays lazy: never consulted once a winner exists, so
+      // existing seeds draw exactly as many numbers as before.
+      if (chosen) continue;
+      if (roll(f)) chosen = f;
+    }
+    if (chosen) {
+      const f = chosen;
+      fire(f);
       const action = f.action;
       if (action.kind === "load-delay") {
         const ms = Number(action.ms);
@@ -197,7 +226,7 @@ export function buildIframeFaultsScript(
  */
 export function mergeIframeStats(
   compiled: CompiledIframeFault[],
-  pageStats: Record<string, { matched: number; fired: number }>,
+  pageStats: Record<string, { matched: number; fired: number; suppressed?: number }>,
 ): IframeFaultStats[] {
   assertCompiledFaults("mergeIframeStats", "compileIframeFaults", compiled);
   for (let i = 0; i < compiled.length; i++) {
@@ -206,6 +235,7 @@ export function mergeIframeStats(
     if (ps) {
       c.matched += ps.matched;
       c.fired += ps.fired;
+      c.suppressed += ps.suppressed ?? 0;
     }
   }
   return compiled.map((c) => ({
@@ -214,5 +244,6 @@ export function mergeIframeStats(
     action: actionKind(c.fault.action),
     matched: c.matched,
     fired: c.fired,
+    ...(c.suppressed > 0 ? { suppressed: c.suppressed } : {}),
   }));
 }

--- a/packages/playwright-faults/src/iframe-faults.ts
+++ b/packages/playwright-faults/src/iframe-faults.ts
@@ -28,6 +28,7 @@ import {
   validateFaultSchedule,
 } from "./schedule.js";
 import type { IframeAction, IframeFault, IframeFaultStats } from "./types.js";
+import { assertCompiledFaults } from "./compiled-guard.js";
 
 /** Compiled form: stats counters initialised, name pre-derived. */
 export interface CompiledIframeFault {
@@ -198,6 +199,7 @@ export function mergeIframeStats(
   compiled: CompiledIframeFault[],
   pageStats: Record<string, { matched: number; fired: number }>,
 ): IframeFaultStats[] {
+  assertCompiledFaults("mergeIframeStats", "compileIframeFaults", compiled);
   for (let i = 0; i < compiled.length; i++) {
     const c = compiled[i]!;
     const ps = pageStats[String(i)];

--- a/packages/playwright-faults/src/iframe-script.test.ts
+++ b/packages/playwright-faults/src/iframe-script.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { buildIframeFaultsScript } from "./iframe-faults.js";
+import type { IframeFault } from "./types.js";
+
+/**
+ * The iframe layer was the odd one out. Its in-page loop was single-pass — the
+ * first fault to claim an iframe returned — so a *scheduled* fault sitting
+ * behind a claiming one never advanced its occurrence and therefore never
+ * fired. `decisions: ["pass", "inject"]` on the second rule meant something
+ * different here than on the network and runtime layers, silently, while
+ * `schedule.ts` promised "the same shape is understood by all four layers".
+ *
+ * The script is a self-contained IIFE over `window` and `HTMLIFrameElement`, so
+ * `new Function` with stubs runs the real thing.
+ */
+interface FakeIframe {
+  matches(selector: string): boolean;
+  src: string;
+  remove(): void;
+}
+
+function install(faults: IframeFault[], seed = 1) {
+  const assigned: string[] = [];
+  const realSrcSetter = function (this: FakeIframe, v: string) {
+    assigned.push(v);
+  };
+  // Minimal HTMLIFrameElement.prototype with a configurable `src` accessor and
+  // a `setAttribute`, which is all the patch needs.
+  const proto = {
+    setAttribute(this: FakeIframe, name: string, value: string) {
+      if (name === "src") this.src = value;
+    },
+  };
+  Object.defineProperty(proto, "src", {
+    configurable: true,
+    enumerable: true,
+    get(this: FakeIframe) {
+      return "";
+    },
+    set: realSrcSetter,
+  });
+  const HTMLIFrameElement = function () {} as unknown as { prototype: object };
+  HTMLIFrameElement.prototype = proto;
+
+  const win: Record<string, unknown> = {};
+  const script = buildIframeFaultsScript(faults, seed);
+  new Function("window", "HTMLIFrameElement", "document", script)(win, HTMLIFrameElement, {});
+
+  const make = (selector: string): FakeIframe =>
+    Object.create(proto, {
+      matches: { value: (s: string) => s === selector },
+      remove: { value: () => {} },
+    }) as FakeIframe;
+
+  const stats = () =>
+    win.__chaosbringerIframeFaultStats as Record<
+      string,
+      { matched: number; fired: number; suppressed: number }
+    >;
+  return { make, assigned, stats };
+}
+
+const neverLoad = (over: Partial<IframeFault>): IframeFault => ({
+  selector: "iframe",
+  action: { kind: "never-load" },
+  ...over,
+});
+
+describe("the generated iframe script", () => {
+  it("advances a scheduled fault behind a claiming one, so occurrence 1 means what it says", () => {
+    // `first` claims occurrence 0; `second` must still count it, so its own
+    // `decisions[1]` lands on the *second* iframe. Single-pass, `second` never
+    // saw the first assignment and its inject never fired.
+    const { make, stats } = install([
+      neverLoad({ name: "first", schedule: { decisions: ["inject", "pass"] } }),
+      neverLoad({ name: "second", schedule: { decisions: ["pass", "inject"] } }),
+    ]);
+    make("iframe").src = "https://a.example/";
+    make("iframe").src = "https://b.example/";
+
+    expect(stats()["0"]).toEqual({ matched: 2, fired: 1, suppressed: 0 });
+    expect(stats()["1"]).toEqual({ matched: 2, fired: 1, suppressed: 0 });
+  });
+
+  it("records the decision it could not act on rather than dropping it", () => {
+    const { make, stats } = install([
+      neverLoad({ name: "winner", schedule: { decisions: ["inject"] } }),
+      neverLoad({ name: "loser", schedule: { decisions: ["inject"] } }),
+    ]);
+    make("iframe").src = "https://a.example/";
+    expect(stats()["0"]).toEqual({ matched: 1, fired: 1, suppressed: 0 });
+    // Occurrence advanced, decision was "inject", nothing acted.
+    expect(stats()["1"]).toEqual({ matched: 1, fired: 0, suppressed: 1 });
+  });
+
+  it("does not count an iframe whose selector does not match", () => {
+    const { make, stats } = install([
+      neverLoad({ name: "ads-only", selector: ".ad", schedule: { decisions: ["inject"] } }),
+    ]);
+    make("iframe").src = "https://a.example/";
+    expect(stats()["0"]).toEqual({ matched: 0, fired: 0, suppressed: 0 });
+  });
+
+  it("still claims the assignment when a fault fires, and passes it through when none does", () => {
+    // The guard against "made everything advance and broke the actual effect".
+    const firing = install([neverLoad({ name: "f", schedule: { decisions: ["inject"] } })]);
+    firing.make("iframe").src = "https://a.example/";
+    expect(firing.assigned).toEqual(["about:blank"]);
+
+    const passing = install([neverLoad({ name: "f", schedule: { decisions: ["pass"] } })]);
+    passing.make("iframe").src = "https://a.example/";
+    expect(passing.assigned).toEqual(["https://a.example/"]);
+  });
+
+  it("keeps probability lazy, so adding a rule behind a firing one does not shift the seed", () => {
+    // The probability path must NOT be consulted once a winner exists — that is
+    // what keeps existing seeded configs drawing the same numbers.
+    const { make, stats } = install([
+      neverLoad({ name: "always", probability: 1 }),
+      neverLoad({ name: "behind", probability: 0.5 }),
+    ]);
+    make("iframe").src = "https://a.example/";
+    expect(stats()["0"]).toEqual({ matched: 1, fired: 1, suppressed: 0 });
+    expect(stats()["1"]).toEqual({ matched: 0, fired: 0, suppressed: 0 });
+  });
+});

--- a/packages/playwright-faults/src/lifecycle-faults.ts
+++ b/packages/playwright-faults/src/lifecycle-faults.ts
@@ -22,6 +22,7 @@ import type {
   LifecycleStage,
   UrlMatcher,
 } from "./types.js";
+import { assertCompiledFaults } from "./compiled-guard.js";
 import { compileUrlMatcher } from "./url-matcher.js";
 
 /** Compiled form: regex pre-compiled, name pre-derived. */
@@ -119,6 +120,7 @@ export function lifecycleFaultsAtStage(
 export function lifecycleStatsFrom(
   compiled: readonly CompiledLifecycleFault[],
 ): LifecycleFaultStats[] {
+  assertCompiledFaults("lifecycleStatsFrom", "compileLifecycleFaults", compiled);
   return compiled.map((c) => ({
     name: c.name,
     matched: c.matched,

--- a/packages/playwright-faults/src/runtime-faults.ts
+++ b/packages/playwright-faults/src/runtime-faults.ts
@@ -28,6 +28,7 @@ import {
   validateFaultSchedule,
 } from "./schedule.js";
 import type { Rng, RuntimeFault, RuntimeFaultStats, UrlMatcher } from "./types.js";
+import { assertCompiledFaults } from "./compiled-guard.js";
 import { compileUrlMatcher, stripStatefulFlags } from "./url-matcher.js";
 
 /** Compiled form: regex pre-compiled, name pre-derived. */
@@ -402,6 +403,7 @@ export function mergeRuntimeStats(
   // right — that script could not distinguish the case.
   pageStats: Record<string, { matched: number; fired: number; suppressed?: number }>,
 ): RuntimeFaultStats[] {
+  assertCompiledFaults("mergeRuntimeStats", "compileRuntimeFaults", compiled);
   for (let i = 0; i < compiled.length; i++) {
     const c = compiled[i]!;
     // Index-keyed (current shape).

--- a/packages/playwright-faults/src/schedule.ts
+++ b/packages/playwright-faults/src/schedule.ts
@@ -23,12 +23,13 @@
  * generated from `buildDecisionHelperSource()` here rather than hand-written
  * twice.
  *
- * What the layers do *not* all share is who gets to advance an occurrence.
- * The network, runtime-`fetch` and lifecycle layers consult every matching
- * rule, so two faults on one URL agree about what "occurrence 1" means. The
- * iframe layer and the load path are single-pass — the first fault to claim
- * the event returns — so a scheduled fault behind a claiming one never
- * advances, and its occurrences count only the events it was asked about.
+ * Occurrence numbering is shared on every layer: each consults every matching
+ * rule, so two faults watching one URL (or one iframe) agree about what
+ * "occurrence 1" means, and a scheduled fault behind a claiming one still
+ * advances. It was not always so — the iframe layer and the load path were
+ * single-pass, returning on the first claim, which made `decisions` mean
+ * something different there than everywhere else, silently. A fault that
+ * decided "inject" and lost the race is reported as `suppressed`.
  */
 
 import type { FaultDecision, FaultSchedule, Rng } from "./types.js";

--- a/packages/playwright-faults/src/types.ts
+++ b/packages/playwright-faults/src/types.ts
@@ -421,4 +421,10 @@ export interface IframeFaultStats {
   matched: number;
   /** Iframes the fault actually fired on (after the probability roll). */
   fired: number;
+  /**
+   * Iframes where this fault decided "inject" and another fault claimed the
+   * assignment first. Present only when non-zero — see
+   * `FaultInjectionStats.suppressed` for why the decision is consumed anyway.
+   */
+  suppressed?: number;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   examples/cloudflare-worker:
     dependencies:
@@ -83,7 +87,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/playwright-test:
     devDependencies:
@@ -122,7 +126,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/chaosbringer:
     dependencies:
@@ -168,7 +172,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/playwright-faults:
     devDependencies:
@@ -180,7 +184,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/playwright-v8-coverage:
     devDependencies:
@@ -192,7 +196,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/server-faults:
     devDependencies:
@@ -201,7 +205,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   playground:
     dependencies:
@@ -1910,6 +1914,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2420,13 +2429,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3299,13 +3308,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3320,7 +3329,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0):
+  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3332,12 +3341,13 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3355,8 +3365,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -3437,6 +3447,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/scripts/check-skill-docs.mjs
+++ b/scripts/check-skill-docs.mjs
@@ -35,6 +35,12 @@ const mod = await import(pkgEntry.href).catch((err) => {
   process.exit(2);
 });
 const exported = new Set(Object.keys(mod));
+// The runtime's own list of legal option names, imported rather than restated:
+// a second copy here would drift, and the copy the checker used would be the
+// one nobody fixed.
+const { KNOWN_OPTION_NAMES } = await import(
+  new URL("../packages/chaosbringer/src/crawler.ts", import.meta.url).href
+);
 const faultHelpers = new Set(Object.keys(mod.faults ?? {}));
 
 const files = ["SKILL.md", ...readdirSync(join(skillDir, "references")).map((f) => `references/${f}`)];
@@ -110,6 +116,46 @@ for (const rel of files) {
     for (const flag of line.match(/--[a-z][a-z0-9-]*/g) ?? []) {
       if (!cliFlags.has(flag)) {
         problems.push(`${rel}: \`${line.trim()}\` uses ${flag}, which the CLI does not accept`);
+      }
+    }
+  }
+}
+
+// Crawler option names. `maxActions` is not an option: JavaScript accepts it,
+// ignores it, and the run then fails as "my fault never fired" — the hardest
+// thing in this library to debug. A wrong option *in the docs* propagates that
+// to every reader, so the names the docs hand out are checked against the same
+// list the runtime near-miss guard uses.
+const optionNames = new Set(KNOWN_OPTION_NAMES);
+// Keys `chaos()` layers on top of CrawlerOptions, plus the bridge options of
+// `runPlan`, which appear in the same object-literal shape.
+const alsoValid = new Set([
+  "setup", "teardown", "rules", "action", "uiProbe", "stateProbe", "uiInvariants",
+  "settleMs", "quiescenceMs", "asyncDrainCapMs", "checkAmplification", "plansDir",
+  "allowOrderSensitive", "timingProfile", "appDeadlineMs", "coverageFingerprints",
+]);
+for (const rel of files) {
+  const text = readFileSync(join(skillDir, rel), "utf8");
+  const blocks = [...text.matchAll(/```(\w*)\n([\s\S]*?)```/g)]
+    .filter(([, lang]) => lang === "ts" || lang === "js");
+  for (const [, , body] of blocks) {
+    // `new ChaosCrawler({`, `chaos({`, `runPlan(plan, {` — the option literal
+    // runs to the matching close, which a regex cannot find, so take the keys
+    // at the literal's own indentation depth and stop at the first dedent.
+    for (const m of body.matchAll(/(?:new ChaosCrawler|chaos|runPlan)\s*\([^{]*\{\n([\s\S]*?)\n(?=\S|\}\))/g)) {
+      const lines = m[1].split("\n");
+      const indent = (lines[0].match(/^\s*/) ?? [""])[0];
+      for (const line of lines) {
+        if (!line.startsWith(indent) || line.slice(indent.length).startsWith(" ")) continue;
+        const key = line.slice(indent.length).match(/^([A-Za-z_$][A-Za-z0-9_$]*)\s*:/);
+        if (!key) continue;
+        checkedIdentifiers++;
+        if (!optionNames.has(key[1]) && !alsoValid.has(key[1])) {
+          problems.push(
+            `${rel}: documents option "${key[1]}", which is not a CrawlerOptions key — ` +
+              `a misspelled option is accepted and ignored, and fails as "my fault never fired"`,
+          );
+        }
       }
     }
   }

--- a/scripts/check-skill-docs.mjs
+++ b/scripts/check-skill-docs.mjs
@@ -161,6 +161,69 @@ for (const rel of files) {
   }
 }
 
+// The same flag check against the workflows that actually invoke the CLI.
+//
+// Motivated by `.github/workflows/chaos-flake.yml` passing
+// `--max-actions-per-page 5` to `chaosbringer flake`, whose parser declared
+// only `--max-actions`: strict `parseArgs` killed the step on its first line,
+// a `|| true` swallowed it, and the next step failed on the `flake.json` that
+// was never written — a weekly scheduled job that had never once detected a
+// flake.
+//
+// Worth being exact about what this catches, because it does NOT catch that
+// one: `--max-actions-per-page` is a real flag of the *root* crawl command,
+// and the flag union here is deliberately loose across every `*cli.ts` (see
+// above), so a flag that is valid for one subcommand and passed to another
+// reads as valid. Making it per-subcommand means teaching this script which
+// parser owns which verb, which is a second copy of a mapping that lives in
+// `cli.ts` — and a drifting second copy is the defect this file exists to
+// prevent. That bug was fixed at the source instead, by having `flake` accept
+// both spellings as the root command already did.
+//
+// What this does catch is a flag that appears in no parser at all — a typo, a
+// rename, an invented option — in a scheduled workflow nobody watches.
+// Verified against a planted `--bogus-flag`.
+const workflowDir = new URL("../.github/workflows/", import.meta.url).pathname;
+let workflowFiles = [];
+try {
+  workflowFiles = readdirSync(workflowDir).filter((f) => /\.ya?ml$/.test(f));
+} catch {
+  workflowFiles = [];
+}
+if (workflowFiles.length === 0) {
+  // A check that silently finds nothing to check is the thing this whole file
+  // is about, so say it rather than reporting a pass.
+  problems.push(`no workflow files found under .github/workflows — this check ran on nothing`);
+}
+for (const rel of workflowFiles) {
+  const text = readFileSync(join(workflowDir, rel), "utf8");
+  // Join backslash continuations first: a multi-line `run:` block puts the
+  // command on one line and every flag on its own, so a line-at-a-time scan
+  // never sees a flag next to the command it belongs to.
+  const joined = text.replace(/\\\s*\n\s*/g, " ");
+  for (const raw of joined.split("\n")) {
+    // Drop YAML comments before matching. A `# … the --changed file list …`
+    // comment is prose, and a checker that flags prose gets loosened until it
+    // stops flagging anything.
+    const line = raw.replace(/(^|\s)#.*$/, "$1");
+    // Only a real invocation: `chaosbringer` as the executable, after `npx` or
+    // `exec` or at the start of the command. Not `pnpm -F chaosbringer
+    // flaker:status --markdown`, where `chaosbringer` names the workspace
+    // package and the flags belong to a different binary entirely.
+    if (!/(?:\bnpx\s+|\bexec\s+|^\s*|&&\s+|\|\s+)chaosbringer\s+[a-z]/.test(line)) continue;
+    if (/-F\s+chaosbringer|--filter\s+chaosbringer/.test(line)) continue;
+    for (const flag of line.match(/--[a-z][a-z0-9-]*/g) ?? []) {
+      if (!cliFlags.has(flag)) {
+        problems.push(
+          `.github/workflows/${rel}: passes ${flag} to the chaosbringer CLI, which does not ` +
+            `accept it — \`parseArgs\` is strict, so the step dies on its first line`,
+        );
+      }
+    }
+    checkedIdentifiers++;
+  }
+}
+
 // And the session surface the docs promise.
 const SESSION_METHODS = ["stats", "runtimeStats", "firings", "heldRequests", "release", "dispose"];
 const apiText = readFileSync(join(skillDir, "references/api.md"), "utf8");

--- a/scripts/check-skill-docs.mjs
+++ b/scripts/check-skill-docs.mjs
@@ -20,6 +20,7 @@
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 const skillDir =
   process.argv[2] ?? new URL("../.claude/skills/chaosbringer", import.meta.url).pathname;
@@ -195,32 +196,65 @@ if (workflowFiles.length === 0) {
   // is about, so say it rather than reporting a pass.
   problems.push(`no workflow files found under .github/workflows — this check ran on nothing`);
 }
+// The `run:` scripts come off a parsed tree, not out of a regex over the raw
+// text. The first version of this scan read the YAML with regexes and would
+// have happily reported a pass on a file GitHub cannot load — which is what
+// `check-workflow-shell.mjs` did, one commit after being written to catch
+// exactly that. Once is a bug; leaving the second copy is the "one rule in two
+// places" shape this file exists to prevent.
+function runScripts(node, out) {
+  if (Array.isArray(node)) {
+    for (const v of node) runScripts(v, out);
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "run" && typeof value === "string") out.push(value);
+    else runScripts(value, out);
+  }
+}
 for (const rel of workflowFiles) {
   const text = readFileSync(join(workflowDir, rel), "utf8");
-  // Join backslash continuations first: a multi-line `run:` block puts the
-  // command on one line and every flag on its own, so a line-at-a-time scan
-  // never sees a flag next to the command it belongs to.
-  const joined = text.replace(/\\\s*\n\s*/g, " ");
-  for (const raw of joined.split("\n")) {
-    // Drop YAML comments before matching. A `# … the --changed file list …`
-    // comment is prose, and a checker that flags prose gets loosened until it
-    // stops flagging anything.
-    const line = raw.replace(/(^|\s)#.*$/, "$1");
-    // Only a real invocation: `chaosbringer` as the executable, after `npx` or
-    // `exec` or at the start of the command. Not `pnpm -F chaosbringer
-    // flaker:status --markdown`, where `chaosbringer` names the workspace
-    // package and the flags belong to a different binary entirely.
-    if (!/(?:\bnpx\s+|\bexec\s+|^\s*|&&\s+|\|\s+)chaosbringer\s+[a-z]/.test(line)) continue;
-    if (/-F\s+chaosbringer|--filter\s+chaosbringer/.test(line)) continue;
-    for (const flag of line.match(/--[a-z][a-z0-9-]*/g) ?? []) {
-      if (!cliFlags.has(flag)) {
-        problems.push(
-          `.github/workflows/${rel}: passes ${flag} to the chaosbringer CLI, which does not ` +
-            `accept it — \`parseArgs\` is strict, so the step dies on its first line`,
-        );
+  let doc;
+  try {
+    doc = parseYaml(text);
+  } catch {
+    // `check:workflow-shell` reports the parse error with its position; here it
+    // only matters that a broken file is not scanned and called clean.
+    problems.push(
+      `.github/workflows/${rel}: does not parse as YAML, so its flags were not checked ` +
+        `(and GitHub will not run it) — see \`pnpm check:workflow-shell\``,
+    );
+    continue;
+  }
+  const scripts = [];
+  runScripts(doc, scripts);
+  for (const script of scripts) {
+    // Join backslash continuations: a multi-line command puts the executable on
+    // one line and every flag on its own, so a line-at-a-time scan never sees a
+    // flag next to the command it belongs to.
+    const joined = script.replace(/\\\s*\n\s*/g, " ");
+    for (const raw of joined.split("\n")) {
+      // Drop shell comments before matching. A `# … the --changed file list …`
+      // comment is prose, and a checker that flags prose gets loosened until it
+      // stops flagging anything.
+      const line = raw.replace(/(^|\s)#.*$/, "$1");
+      // Only a real invocation: `chaosbringer` as the executable, after `npx` or
+      // `exec` or at the start of the command. Not `pnpm -F chaosbringer
+      // flaker:status --markdown`, where `chaosbringer` names the workspace
+      // package and the flags belong to a different binary entirely.
+      if (!/(?:\bnpx\s+|\bexec\s+|^\s*|&&\s+|\|\s+)chaosbringer\s+[a-z]/.test(line)) continue;
+      if (/-F\s+chaosbringer|--filter\s+chaosbringer/.test(line)) continue;
+      for (const flag of line.match(/--[a-z][a-z0-9-]*/g) ?? []) {
+        if (!cliFlags.has(flag)) {
+          problems.push(
+            `.github/workflows/${rel}: passes ${flag} to the chaosbringer CLI, which does not ` +
+              `accept it — \`parseArgs\` is strict, so the step dies on its first line`,
+          );
+        }
       }
+      checkedIdentifiers++;
     }
-    checkedIdentifiers++;
   }
 }
 

--- a/scripts/check-workflow-shell.mjs
+++ b/scripts/check-workflow-shell.mjs
@@ -1,15 +1,26 @@
 #!/usr/bin/env node
 /**
- * `bash -n` over every `run:` block in `.github/workflows`.
+ * Every workflow must parse as YAML, and every `run:` block in it must parse as
+ * shell.
  *
- * `flaker-confirm.yml` shipped its only real step as a bash syntax error — the
- * command was written with `\$(seq …)` and `\\` line continuations, escaped for
- * a quoting layer that a YAML block scalar does not have. It is dispatch-only,
- * so nothing ever ran it, and a flakiness-confirmation tool that cannot run
- * looks exactly like one nobody has needed yet.
+ * Two bugs, one shape. `flaker-confirm.yml` shipped its only real step as a
+ * bash syntax error — `\$(seq …)` and `\\` continuations, escaped for a quoting
+ * layer a YAML block scalar does not have. It is dispatch-only, so nothing ever
+ * ran it, and a flakiness-confirmation tool that cannot run looks exactly like
+ * one nobody has needed yet.
  *
- * Nothing checked workflow shell, which is the same gap as the CLI flags in
- * `check-skill-docs`: the code is verified and the thing that invokes it is not.
+ * Then the first version of this script had the same problem one level up. It
+ * read workflows with regexes, so when a step name in `ci.yml` was written as
+ * `name: Check workflow run: blocks parse as shell` — an unquoted scalar
+ * containing `: `, which YAML reads as a nested mapping and rejects — GitHub
+ * silently stopped running the whole file (`build-and-test`, `adversarial` and
+ * every `example-tests` job vanished from the PR) while this script cheerfully
+ * reported "checked 64 run: blocks". A checker that passes a file the runner
+ * cannot load is worse than no checker.
+ *
+ * So the YAML is parsed, not pattern-matched: a parse failure is the first
+ * thing reported, and the `run:` blocks are read off the parsed tree rather
+ * than guessed at from indentation.
  *
  * Usage: `pnpm check:workflow-shell` (from the repo root).
  */
@@ -17,6 +28,7 @@ import { readFileSync, readdirSync, writeFileSync, mkdtempSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { parse } from "yaml";
 
 const dir = new URL("../.github/workflows/", import.meta.url).pathname;
 const files = readdirSync(dir).filter((f) => /\.ya?ml$/.test(f));
@@ -29,59 +41,63 @@ if (files.length === 0) {
 const scratch = mkdtempSync(join(tmpdir(), "wf-shell-"));
 const problems = [];
 let blocks = 0;
+let parsed = 0;
 
-for (const file of files) {
-  const lines = readFileSync(join(dir, file), "utf8").split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    // `run: |` or `run: >` starts a block scalar; `run: cmd` is one line.
-    const m = lines[i].match(/^(\s*)(?:- )?run:\s*(\|[-+]?|>[-+]?)?\s*(.*)$/);
-    if (!m) continue;
-    const [, indent, scalar, inline] = m;
-    let body;
-    let startLine = i + 1;
-    if (scalar) {
-      const out = [];
-      // The block ends at the first line that is neither blank nor indented
-      // deeper than the `run:` key itself.
-      for (let j = i + 1; j < lines.length; j++) {
-        const line = lines[j];
-        if (line.trim() === "") { out.push(""); continue; }
-        const lead = line.match(/^\s*/)[0].length;
-        if (lead <= indent.length) break;
-        out.push(line);
-        i = j;
-      }
-      // Strip the common indent so heredocs and continuations line up.
-      const deepest = Math.min(
-        ...out.filter((l) => l.trim() !== "").map((l) => l.match(/^\s*/)[0].length),
-      );
-      body = out.map((l) => l.slice(deepest)).join("\n");
+/** Every `run:` string anywhere in the tree, with a path for the message. */
+function collectRuns(node, path, out) {
+  if (Array.isArray(node)) {
+    node.forEach((v, i) => collectRuns(v, `${path}[${i}]`, out));
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "run" && typeof value === "string") {
+      out.push({ path: `${path}.run`, script: value, name: node.name });
     } else {
-      if (inline.trim() === "") continue;
-      body = inline;
-    }
-    // GitHub expressions are substituted before the shell ever sees them, and
-    // `${{` is not valid bash. Replace each with a plain word so what is left
-    // is the shell the runner would actually execute. A quoted expression
-    // becomes a quoted word, so quoting is preserved.
-    const shell = body.replace(/\$\{\{[^}]*\}\}/g, "GHEXPR");
-    blocks++;
-    const path = join(scratch, `${file.replace(/\W/g, "_")}-${startLine}.sh`);
-    writeFileSync(path, shell);
-    try {
-      execFileSync("bash", ["-n", path], { stdio: ["ignore", "ignore", "pipe"] });
-    } catch (err) {
-      const msg = String(err.stderr ?? err.message)
-        .replaceAll(path, `${file}:${startLine}`)
-        .trim();
-      problems.push(`${file}: \`run:\` block at line ${startLine} is not valid shell\n    ${msg}`);
+      collectRuns(value, `${path}.${key}`, out);
     }
   }
 }
 
-console.log(`checked ${blocks} run: blocks across ${files.length} workflow files`);
+for (const file of files) {
+  const text = readFileSync(join(dir, file), "utf8");
+  let doc;
+  try {
+    doc = parse(text);
+  } catch (err) {
+    // Reported and skipped: there is no tree to walk, and "0 shell problems"
+    // in a file GitHub refuses to load is the reassuring lie this exists to
+    // prevent.
+    problems.push(
+      `${file}: does not parse as YAML, so GitHub will not run it at all\n    ${String(err.message).split("\n")[0]}`,
+    );
+    continue;
+  }
+  parsed++;
+  const runs = [];
+  collectRuns(doc, "", runs);
+  for (const { path, script, name } of runs) {
+    // GitHub expands `${{ … }}` before the shell sees it, and `${{` is not
+    // valid bash. A quoted expression becomes a quoted word, so quoting is
+    // preserved by the substitution.
+    const shell = script.replace(/\$\{\{[^}]*\}\}/g, "GHEXPR");
+    blocks++;
+    const tmp = join(scratch, `${file.replace(/\W/g, "_")}-${blocks}.sh`);
+    writeFileSync(tmp, shell);
+    try {
+      execFileSync("bash", ["-n", tmp], { stdio: ["ignore", "ignore", "pipe"] });
+    } catch (err) {
+      const msg = String(err.stderr ?? err.message).replaceAll(tmp, file).trim();
+      problems.push(
+        `${file}: \`run:\` at ${path}${name ? ` ("${name}")` : ""} is not valid shell\n    ${msg}`,
+      );
+    }
+  }
+}
+
+console.log(`parsed ${parsed}/${files.length} workflow files, checked ${blocks} run: blocks`);
 if (problems.length > 0) {
   for (const p of problems) console.log("  FAIL " + p);
   process.exit(1);
 }
-console.log("every workflow run: block parses as shell");
+console.log("every workflow parses as YAML and every run: block parses as shell");

--- a/scripts/check-workflow-shell.mjs
+++ b/scripts/check-workflow-shell.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * `bash -n` over every `run:` block in `.github/workflows`.
+ *
+ * `flaker-confirm.yml` shipped its only real step as a bash syntax error — the
+ * command was written with `\$(seq …)` and `\\` line continuations, escaped for
+ * a quoting layer that a YAML block scalar does not have. It is dispatch-only,
+ * so nothing ever ran it, and a flakiness-confirmation tool that cannot run
+ * looks exactly like one nobody has needed yet.
+ *
+ * Nothing checked workflow shell, which is the same gap as the CLI flags in
+ * `check-skill-docs`: the code is verified and the thing that invokes it is not.
+ *
+ * Usage: `pnpm check:workflow-shell` (from the repo root).
+ */
+import { readFileSync, readdirSync, writeFileSync, mkdtempSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const dir = new URL("../.github/workflows/", import.meta.url).pathname;
+const files = readdirSync(dir).filter((f) => /\.ya?ml$/.test(f));
+if (files.length === 0) {
+  // A checker that finds nothing to check is the defect it is here to prevent.
+  console.error("no workflow files under .github/workflows — this check ran on nothing");
+  process.exit(2);
+}
+
+const scratch = mkdtempSync(join(tmpdir(), "wf-shell-"));
+const problems = [];
+let blocks = 0;
+
+for (const file of files) {
+  const lines = readFileSync(join(dir, file), "utf8").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    // `run: |` or `run: >` starts a block scalar; `run: cmd` is one line.
+    const m = lines[i].match(/^(\s*)(?:- )?run:\s*(\|[-+]?|>[-+]?)?\s*(.*)$/);
+    if (!m) continue;
+    const [, indent, scalar, inline] = m;
+    let body;
+    let startLine = i + 1;
+    if (scalar) {
+      const out = [];
+      // The block ends at the first line that is neither blank nor indented
+      // deeper than the `run:` key itself.
+      for (let j = i + 1; j < lines.length; j++) {
+        const line = lines[j];
+        if (line.trim() === "") { out.push(""); continue; }
+        const lead = line.match(/^\s*/)[0].length;
+        if (lead <= indent.length) break;
+        out.push(line);
+        i = j;
+      }
+      // Strip the common indent so heredocs and continuations line up.
+      const deepest = Math.min(
+        ...out.filter((l) => l.trim() !== "").map((l) => l.match(/^\s*/)[0].length),
+      );
+      body = out.map((l) => l.slice(deepest)).join("\n");
+    } else {
+      if (inline.trim() === "") continue;
+      body = inline;
+    }
+    // GitHub expressions are substituted before the shell ever sees them, and
+    // `${{` is not valid bash. Replace each with a plain word so what is left
+    // is the shell the runner would actually execute. A quoted expression
+    // becomes a quoted word, so quoting is preserved.
+    const shell = body.replace(/\$\{\{[^}]*\}\}/g, "GHEXPR");
+    blocks++;
+    const path = join(scratch, `${file.replace(/\W/g, "_")}-${startLine}.sh`);
+    writeFileSync(path, shell);
+    try {
+      execFileSync("bash", ["-n", path], { stdio: ["ignore", "ignore", "pipe"] });
+    } catch (err) {
+      const msg = String(err.stderr ?? err.message)
+        .replaceAll(path, `${file}:${startLine}`)
+        .trim();
+      problems.push(`${file}: \`run:\` block at line ${startLine} is not valid shell\n    ${msg}`);
+    }
+  }
+}
+
+console.log(`checked ${blocks} run: blocks across ${files.length} workflow files`);
+if (problems.length > 0) {
+  for (const p of problems) console.log("  FAIL " + p);
+  process.exit(1);
+}
+console.log("every workflow run: block parses as shell");


### PR DESCRIPTION
Follow-up to #135, now merged. Same defect class that PR was about — **a check that reports nothing rather than reporting that it could not check** — plus its sibling, **one rule encoded in more than one place, where the copy the tests exercise is the one that got fixed**.

Fourteen commits. Each fix is mutation-checked: reverting it fails at least one new test, and where a guard could be satisfied by refusing everything, that direction is checked too.

> ## ⚠️ Read before merging: this changes behaviour for existing callers
>
> `chaosbringer` is published, and merging this triggers release-please +
> `publish.yml`. **Every commit here is `fix:`, so it cuts `0.9.1` — a patch**
> — and anyone on `^0.9.0` picks it up automatically. Several changes are not
> patch-safe:
>
> | change | how it breaks a caller |
> |---|---|
> | `FlakeAnalysis.decidable` added as a **required** field | compile error for anyone constructing the type (public export) |
> | `PendingAsync.measured` added as **required** | same, reachable through the public `PlanRunResult` |
> | `applyFaults` / `applyFaultRules` now **throw** on an uncompilable `urlPattern` | a call that previously succeeded (having silently installed nothing) now raises |
> | `checkTiming({})` → `ok: false` | was `true` |
> | `runPlan` reports `undecided` for `expect.ui` with no `uiProbe` | `modelRunPassed` requires zero mismatches, so a previously green model run goes red |
> | `flake` CLI exits `1` when the run count cannot decide | was `0`; someone's CI gate flips |
>
> The behavioural ones are defensible as fixes — the old pass was wrong, which
> is the entire point of the PR. The **required type fields and the new throw
> are unambiguously breaking** regardless of that argument.
>
> I have deliberately *not* marked a commit `BREAKING CHANGE:`, because
> `bump-minor-pre-major` is unset in `release-please-config.json`, which means
> a breaking change on a `0.x` package cuts **`1.0.0`** — declaring 1.0 is a
> maintainer's call about project maturity, not a side effect of bug fixes.
> The two ways to signal this honestly are:
>
> 1. set `bump-minor-pre-major: true` and add the footer → `0.10.0`
> 2. add the footer as-is → `1.0.0`
>
> Both are policy decisions, so they are left here rather than taken. Merging
> unchanged ships the above as `0.9.1`.

## Library

| what | measured before |
|---|---|
| Three stats readers accepted raw (uncompiled) faults | `matched: NaN` with a real-looking label, `[{}]`, and a `TypeError` — and `NaN > 0` is false, so "did the fault fire?" answered *no* instead of *you called this wrong* |
| `faultFirings` emitted `undefined` counters | `matched undefinedx and never fired — the firing policy said no`, asserting a policy never consulted |
| Occurrence numbering differed per layer | a scheduled iframe/load fault behind another never advanced its occurrence, so `decisions` meant something different on two of four layers |
| `checkTiming({})` returned `ok: true` | a constraint set with no inputs proposed reported a pass; one call site had a local workaround, which was the tell |
| `expect.ui` with no `uiProbe` was skipped | the most commonly stated expectation in a plan passed by never being read. `expect.state` and `expect.calls` already reported the opposite; the field's doc comment described the gap as intended |
| The timer watch was installed `afterLoad` | a page escaping a rejection from a 900ms load-time backoff reported `unhandledRejection: false` **and** `pendingAsync: { timers: 0 }` — a positive claim from code never installed |
| `watchUnhandledRejections` installed after `goto` heard nothing | `drain()` returned `[]`, the same answer a clean page gives |
| `freshTestEmail` collided | 67 of 4000 trials of 50 calls (1.68%); 20000 calls lost 215 addresses. These are the addresses auth-attack probes sign up with, so a collision reads a *duplicate* signup response as a *fresh* one |
| One run of the flake detector reported zero flakes | `flakyClusters` empty by construction, and `runFlakeCli` turns that into `exit 0` as a CI gate. `flakyPages` already guarded this; the headline did not |
| An uncompilable `urlPattern` was dropped silently | `applyFaultRules` with `"/api/(cart"`: no error, page saw 200, `stats()` `[]`, `firings()` `{}` — the rule not even listed as having matched nothing |

Two behaviours are now nameable rather than inferred: `PendingAsync.measured` separates a measurement from the absence of one, and `FlakeAnalysis.decidable` separates "nothing flaked" from "nothing was measured". `checkTiming` gained `checked`, and `Firing` gained `counted`. `CrawlerOptions.initScripts` is new — running JS before the page's own scripts is what makes the timer watch possible at all.

**Known inconsistency, deliberately left:** those four flags — `measured`, `decidable`, `checked`, `counted` — are four spellings of "was this actually measured", which is the very pattern this PR fixes elsewhere, committed by me in the API I designed. They are not identical (`checked` is a count, the others booleans), and all four are now public, so unifying them is itself a breaking rename. Flagged for a future major rather than churned now.

## CI configuration

The same class, one directory over: the code was tested and the thing that invokes it was not.

- `chaos-flake.yml` passed `--max-actions-per-page` to `chaosbringer flake`, whose parser declared only `--max-actions`. Strict `parseArgs` killed the step on its first line, `|| true` swallowed it, and the next step failed on the `flake.json` never written. A weekly job that had never once detected a flake. Not a typo — the root command accepts both spellings, so `flake` does now too.
- `flaker-confirm.yml`'s only real step was a bash syntax error (`\$(seq …)`, escaped for a quoting layer a YAML block scalar does not have). Dispatch-only, so nothing ever ran it.
- That `|| true` swallowed every exit code identically. It now allows 1 (flakes found) and fails on anything above.
- `chaos-flake-issues.ts` closes every open flake issue absent from the report — so an undecidable report would close them all. It refuses now.

Two new gates, both mutation-verified:

- **`pnpm check:workflow-shell`** — every workflow must parse as YAML and every `run:` block as shell (11 files, 64 blocks). Catches the bug that motivated it.
- **Workflow CLI flags** in `check-skill-docs`, and **crawler option names** in documented code blocks, checked against `KNOWN_OPTION_NAMES` imported from `crawler.ts` rather than restated. The flag check does **not** catch the `--max-actions-per-page` bug — that flag is real for another subcommand, and the union is deliberately loose; making it per-subcommand would mean a second copy of a mapping that lives in `cli.ts`. The comment says so.

## Three regressions I introduced and fixed

Recorded because they are the same defect, authored by me:

- A CI step named `Check workflow run: blocks parse as shell` — an unquoted scalar containing `: `. GitHub could not load `ci.yml`, so `build-and-test`, `adversarial` and every `example-tests` job stopped appearing; 8 checks became 3. Found by noticing the absence, not by any gate. Worse: `check-workflow-shell.mjs`, added the same commit to catch exactly this, read workflows with regexes and reported "checked 64 run: blocks" on a file the runner refuses to load. It parses the YAML now, reports a parse failure first, and prints `parsed 10/11` so a skip is visible instead of folded into a pass.
- The flag scan in `check-skill-docs` had the identical flaw, and I fixed only the copy that had already embarrassed me.
- `chaos-flake-issues.ts` declared its own `FlakeAnalysis`, and when `decidable` was added to the real one I hand-copied it into the duplicate. Now imported, with the one legitimate difference (`decidable` may be absent from a `flake.json` on disk) stated as `ParsedAnalysis` rather than inherited.

## Verification

| | |
|---|---|
| `packages/chaosbringer` | 1116 passed |
| `packages/playwright-faults` | 148 passed |
| `tsc`, `pnpm check:skill-docs`, `pnpm check:workflow-shell` | clean |

Both gates confirmed executing in CI's own `build-and-test` log, not merely inferred from a green tick:

```
checked 28 identifiers across 5 files
every documented import, fault helper and session method exists
parsed 11/11 workflow files, checked 64 run: blocks
every workflow parses as YAML and every run: block parses as shell
```

Three tests of my own were rewritten or deleted for failing to discriminate: one subsumed by a preceding assertion, one promising to check a guard it could not observe, and one whose 50-call sample caught a real defect only 1.68% of the time.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019v8DCcmgnuym26eP1QryiG

---
_Generated by [Claude Code](https://claude.ai/code/session_019v8DCcmgnuym26eP1QryiG)_